### PR TITLE
Add AGENTS instructions for parser fixtures

### DIFF
--- a/src/parser/AGENTS.md
+++ b/src/parser/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+- The existing test input and output fixtures in this package (the GameMaker Language parser) are considered golden files and **must not be modified**. They capture the desired formatting for GML and must be preserved byte-for-byte.
+- You may add new tests or adjust the way tests are executed, but do not change or replace the current input/output text fixtures.


### PR DESCRIPTION
## Summary
- add an AGENTS.md file to gamemaker-language-parser clarifying that existing test input/output fixtures are golden files that must not change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3223f4804832fb9c3d4ce03fa4171