### PR TITLE
Add formatting fixture for do-until control flow

### DIFF
--- a/src/plugin/tests/test21.input.gml
+++ b/src/plugin/tests/test21.input.gml
@@ -1,0 +1,36 @@
+#define  SQUARE(_value)    ((_value)*(_value))
+
+var total=0;
+var limit   =   argument0;
+var arr=argument1;
+var value=0;
+var tracker={data:arr,lastIndex:-1};
+
+do{
+value+=1;
+if(value>limit)  {
+throw   "Exceeded";
+}
+}until(value>=limit);
+
+for(var i=0;i<array_length(arr);i++){
+var current=arr[i];
+if(current<0){continue}
+if(current>limit){
+throw "Too big";
+}
+tracker.lastIndex=i;
+total+=current;
+}
+
+#define INCREMENT(_v) ((_v)+1)
+
+do{
+value = INCREMENT(value);
+if(value==SQUARE(limit)){
+value = limit*limit;
+throw "Square limit";
+}
+}until  (value>limit*limit)
+
+return total;

--- a/src/plugin/tests/test21.output.gml
+++ b/src/plugin/tests/test21.output.gml
@@ -1,0 +1,36 @@
+#define  SQUARE(_value)    ((_value)*(_value))
+var total = 0;
+var limit = argument0;
+var arr = argument1;
+var value = 0;
+var tracker = {data: arr, lastIndex: -1};
+
+do {
+    value += 1;
+    if (value > limit) {
+        throw "Exceeded";
+    }
+} until (value >= limit)
+
+for (var i = 0; i < array_length(arr); i++) {
+    var current = arr[i];
+    if (current < 0) {
+        continue;
+    }
+    if (current > limit) {
+        throw "Too big";
+    }
+    tracker.lastIndex = i;
+    total += current;
+}
+
+#define INCREMENT(_v) ((_v)+1)
+do {
+    value = INCREMENT(value);
+    if (value == SQUARE(limit)) {
+        value = limit * limit;
+        throw "Square limit";
+    }
+} until (value > (limit * limit))
+
+return total;


### PR DESCRIPTION
## Summary
- add a test21 input/output fixture that exercises do-until loops, throw statements, continues, and macro defines to expand formatter coverage

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e43bae8670832fa2f018e4cd53173d