### PR TITLE
Add option to control array length loop hoisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ The plugin exposes standard Prettier options. Keep overrides scoped to `.gml` fi
 
 Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configuration.html) for the complete option list.
 
+#### Plugin-specific options
+
+- `optimizeArrayLengthLoops` (default: `true`)
+
+  Hoists calls to `array_length(...)` out of matching `for` loop conditions and stores the result in a cached variable
+  (`var <array>_len = array_length(<array>);`). Disable the option to keep the original loop structure when this optimization
+  is undesirable for your project.
+
 ## Troubleshooting
 
 - Confirm Node and npm meet the version requirements. Prettier 3 needs at least Node 16.13.

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -60,9 +60,21 @@ export const printers = {
     }
 };
 
+export const options = {
+    optimizeArrayLengthLoops: {
+        since: "0.0.0",
+        type: "boolean",
+        category: "gml",
+        default: true,
+        description: "Hoist array_length calls out of for-loop conditions by caching the result in a temporary variable."
+    }
+};
+
 export const defaultOptions = {
     tabWidth: 4,
     semi: true,
     trailingComma: "none",
-    printWidth: 120
+    printWidth: 120,
+    optimizeArrayLengthLoops: true
 };
+

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -140,7 +140,11 @@ export function print(path, options, print) {
             ]);
         }
         case "ForStatement": {
-            const hoistInfo = getArrayLengthHoistInfo(path.getValue());
+            const shouldHoistArrayLength =
+                options?.optimizeArrayLengthLoops ?? true;
+            const hoistInfo = shouldHoistArrayLength
+                ? getArrayLengthHoistInfo(path.getValue())
+                : null;
             if (hoistInfo) {
                 const { arrayLengthCallDoc, iteratorDoc, cachedLengthName } = buildArrayLengthDocs(
                     path,

--- a/src/plugin/tests/test-plugin.js
+++ b/src/plugin/tests/test-plugin.js
@@ -33,6 +33,7 @@ async function testFiles() {
 
         const baseName = inputFile.slice(0, -4); // remove '.gml' extension
         const outputFile = baseName.replace(".input", ".output") + fileExt;
+        const optionsFile = baseName.replace(".input", ".options") + ".json";
 
         const inputCode = await fs.promises.readFile(path.join(testsDirectory, inputFile), fileEncoding);
         if (typeof inputCode !== "string") {
@@ -48,9 +49,17 @@ async function testFiles() {
 
         let formatted = "";
         try {
+            let customOptions = {};
+            const optionsPath = path.join(testsDirectory, optionsFile);
+            if (fs.existsSync(optionsPath)) {
+                const optionsContents = await fs.promises.readFile(optionsPath, fileEncoding);
+                customOptions = JSON.parse(optionsContents);
+            }
+
             formatted = await prettier.format(inputCode, {
                 plugins: [path.join(currentDirectory, "../src/gml.js")],
-                parser: "gml-parse"
+                parser: "gml-parse",
+                ...customOptions
             });
         } catch (e) {
             console.error(`  [ERROR] Unexpected error while formatting code`, e);

--- a/src/plugin/tests/test22.input.gml
+++ b/src/plugin/tests/test22.input.gml
@@ -1,0 +1,4 @@
+var arr=[1,2,3];
+for(var i=0;i<array_length(arr);i++){
+show_debug_message(arr[i]);
+}

--- a/src/plugin/tests/test22.options.json
+++ b/src/plugin/tests/test22.options.json
@@ -1,0 +1,3 @@
+{
+    "optimizeArrayLengthLoops": false
+}

--- a/src/plugin/tests/test22.output.gml
+++ b/src/plugin/tests/test22.output.gml
@@ -1,0 +1,4 @@
+var arr = [1, 2, 3];
+for (var i = 0; i < array_length(arr); i++) {
+    show_debug_message(arr[i]);
+}


### PR DESCRIPTION
## Summary
- expose a new `optimizeArrayLengthLoops` option with documentation and default behaviour
- gate the for-loop array_length hoisting logic on the option and allow tests to specify custom settings
- add a regression fixture that confirms array_length hoisting is skipped when the option is disabled

## Testing
- npm run test:plugin *(fails: existing fixture mismatches around documentation comment casing)*

------
https://chatgpt.com/codex/tasks/task_e_68e45d19736c832fbf57e2d56e1e0e1c