### PR TITLE
Support hoisting DS size lookups

### DIFF
--- a/src/plugin/tests/test23.input.gml
+++ b/src/plugin/tests/test23.input.gml
@@ -1,0 +1,7 @@
+function iterate_structures(list, map, grid) {
+for(var i=0;i<ds_list_size(list);i++){show_debug_message(list[|i]);}
+for(var key=0;key<=ds_map_size(map);key+=1){show_debug_message(ds_map_find_value(map,key));}
+for(var x=0;x<ds_grid_width(grid);x++){
+for(var y=0;y<ds_grid_height(grid);y++){show_debug_message(grid[# x,y]);}}
+for(var unsafe=0;unsafe<ds_list_size(list);other++){show_debug_message(unsafe);}
+}

--- a/src/plugin/tests/test23.output.gml
+++ b/src/plugin/tests/test23.output.gml
@@ -1,0 +1,20 @@
+function iterate_structures(list, map, grid) {
+    var list_size = ds_list_size(list);
+    for (var i = 0; i < list_size; i++) {
+        show_debug_message(list[| i]);
+    }
+    var map_size = ds_map_size(map);
+    for (var key = 0; key <= map_size; key += 1) {
+        show_debug_message(ds_map_find_value(map, key));
+    }
+    var grid_width = ds_grid_width(grid);
+    for (var x = 0; x < grid_width; x++) {
+        var grid_height = ds_grid_height(grid);
+        for (var y = 0; y < grid_height; y++) {
+            show_debug_message(grid[# x, y]);
+        }
+    }
+    for (var unsafe = 0; unsafe < ds_list_size(list); other++) {
+        show_debug_message(unsafe);
+    }
+}


### PR DESCRIPTION
## Summary
- allow loop-length hoisting to recognize ds_* size helpers via a shared suffix map
- derive stable cached variable names for each supported size helper
- add a regression fixture covering safe and unsafe DS traversal loops

## Testing
- npm run test:plugin *(fails on pre-existing fixture mismatches, new ds_* tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68e4637acd58832f8627dfd2ee8f53f8