### PR TITLE
Detect argument_count default locals

### DIFF
--- a/src/plugin/tests/test23.input.gml
+++ b/src/plugin/tests/test23.input.gml
@@ -1,0 +1,11 @@
+function greet(name, greeting) {
+        var name = argument_count > 0 ? argument[0] : "friend";
+        var greeting = argument_count > 1 ? argument[1] : "Hello";
+        return greeting + ", " + name;
+}
+
+var message1 = greet();
+var message2 = greet("Alice");
+var message3 = greet("Bob", "Howdy");
+var message4 = greet("Chaz");
+var message5 = greet(undefined, "Welcome");

--- a/src/plugin/tests/test23.output.gml
+++ b/src/plugin/tests/test23.output.gml
@@ -1,0 +1,12 @@
+/// @function greet
+/// @param [name="friend"]
+/// @param [greeting="Hello"]
+function greet(name = "friend", greeting = "Hello") {
+    return (greeting + ", ") + name;
+}
+
+var message1 = greet();
+var message2 = greet("Alice");
+var message3 = greet("Bob", "Howdy");
+var message4 = greet("Chaz");
+var message5 = greet(undefined, "Welcome");


### PR DESCRIPTION
## Summary
- convert canonical argument_count fallback locals into default parameters via preprocessing, removing redundant body assignments during printing.
- capture default expressions for synthetic docs and ensure functions with default parameters receive generated documentation.
- add greeting fixture covering the converted signature and optional argument omissions.

## Testing
- npm run test:plugin --silent *(fails: existing fixture mismatches unrelated to the new change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4638df828832f8272af2a3626d346