### PR TITLE
Normalize doc metadata parameter names

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1150,12 +1150,14 @@ function getParameterDocInfo(paramNode, functionNode, options) {
     }
 
     if (paramNode.type === "Identifier") {
-        const name = getIdentifierText(paramNode);
+        const rawName = getIdentifierText(paramNode);
+        const name = normalizeDocMetadataName(rawName);
         return name ? { name, optional: false } : null;
     }
 
     if (paramNode.type === "DefaultParameter") {
-        const name = getIdentifierText(paramNode.left);
+        const rawName = getIdentifierText(paramNode.left);
+        const name = normalizeDocMetadataName(rawName);
         if (!name) {
             return null;
         }
@@ -1174,7 +1176,8 @@ function getParameterDocInfo(paramNode, functionNode, options) {
         return null;
     }
 
-    const fallbackName = getIdentifierText(paramNode);
+    const rawFallbackName = getIdentifierText(paramNode);
+    const fallbackName = normalizeDocMetadataName(rawFallbackName);
     return fallbackName ? { name: fallbackName, optional: false } : null;
 }
 
@@ -1557,6 +1560,15 @@ function getIdentifierText(identifier) {
     }
 
     return null;
+}
+
+function normalizeDocMetadataName(name) {
+    if (typeof name !== "string") {
+        return name;
+    }
+
+    const normalized = name.replace(/^_+/, "").replace(/_+$/, "");
+    return normalized.length > 0 ? normalized : name;
 }
 
 function docHasTrailingComment(doc) {


### PR DESCRIPTION
## Summary
- add a doc metadata helper that trims leading and trailing underscores from parameter names
- apply the normalization when collecting identifier and default-parameter names for generated docs

## Testing
- npm run test:plugin *(fails: existing fixture mismatches for synthetic doc generation)*

------
https://chatgpt.com/codex/tasks/task_e_68e481883408832fb684dad040631f76