### PR TITLE
Ensure do-until statements emit semicolons

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -221,7 +221,8 @@ export function print(path, options, print) {
                 printInBlock(path, options, print, "body"),
                 " until (",
                 buildClauseGroup(printWithoutExtraParens(path, print, "test")),
-                ") "
+                ")",
+                ";"
             ]);
         }
         case "WhileStatement": {


### PR DESCRIPTION
## Summary
- append a trailing semicolon when printing `do ... until` statements so the output matches the fixture expectations

## Testing
- `npm run test:plugin` *(fails: existing fixture mismatches unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e53befce88832fa5568518741eeb1c