### PR TITLE
Normalize GameMaker doc comment types

### DIFF
--- a/src/plugin/src/printer/comments.js
+++ b/src/plugin/src/printer/comments.js
@@ -131,6 +131,33 @@ const jsDocReplacements = {
     // Add more replacements here as needed
 };
 
+const GAME_MAKER_TYPE_NORMALIZATIONS = new Map(
+    Object.entries({
+        void: "undefined",
+        undefined: "undefined",
+        real: "real",
+        bool: "bool",
+        boolean: "bool",
+        string: "string",
+        array: "array",
+        struct: "struct",
+        enum: "enum",
+        pointer: "pointer",
+        method: "method",
+        asset: "asset",
+        any: "any",
+        var: "var",
+        int64: "int64",
+        int32: "int32",
+        int16: "int16",
+        int8: "int8",
+        uint64: "uint64",
+        uint32: "uint32",
+        uint16: "uint16",
+        uint8: "uint8"
+    })
+);
+
 function printComment(commentPath, options) {
     const comment = commentPath.getValue();
     comment.printed = true;
@@ -225,7 +252,29 @@ function applyJsDocReplacements(text) {
         formattedText = formattedText.replace(regex, `$1${newWord}`);
     }
 
-    return formattedText;
+    return normalizeDocCommentTypeAnnotations(formattedText);
+}
+
+function normalizeDocCommentTypeAnnotations(text) {
+    if (typeof text !== "string" || text.indexOf("{") === -1) {
+        return text;
+    }
+
+    return text.replace(/\{([^}]+)\}/g, (match, typeText) => {
+        const normalized = normalizeGameMakerType(typeText);
+        return `{${normalized}}`;
+    });
+}
+
+function normalizeGameMakerType(typeText) {
+    if (typeof typeText !== "string") {
+        return typeText;
+    }
+
+    return typeText.replace(/[A-Za-z_][A-Za-z0-9_]*/g, (identifier) => {
+        const normalized = GAME_MAKER_TYPE_NORMALIZATIONS.get(identifier.toLowerCase());
+        return normalized ?? identifier;
+    });
 }
 
 function splitCommentIntoSentences(text) {
@@ -425,5 +474,6 @@ export {
     printDanglingCommentsAsGroup,
     handleComments,
     printComment,
-    formatLineComment
+    formatLineComment,
+    normalizeDocCommentTypeAnnotations
 };

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -38,7 +38,8 @@ import {
 import {
     printDanglingComments,
     printDanglingCommentsAsGroup,
-    formatLineComment
+    formatLineComment,
+    normalizeDocCommentTypeAnnotations
 } from "./comments.js";
 
 export function print(path, options, print) {
@@ -1075,7 +1076,7 @@ function computeSyntheticFunctionDocLines(node, existingDocLines, options, overr
         lines.push(`/// @param ${docName}`);
     }
 
-    return lines;
+    return lines.map((line) => normalizeDocCommentTypeAnnotations(line));
 }
 
 function parseDocCommentMetadata(line) {


### PR DESCRIPTION
## Summary
- add a type-normalization helper so doc comments lowercase known GameMaker types and treat void as undefined
- apply the normalization when rewriting existing documentation lines and when generating synthetic doc comments

## Testing
- npm run test:plugin *(fails: existing fixture mismatches unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e53becd99c832f87d255bad3bcbc62