### PR TITLE
Handle synthetic docs for top-level functions without comments

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1534,13 +1534,31 @@ function shouldGenerateSyntheticDocForFunction(path) {
         return false;
     }
 
-    const hasDocComments = Array.isArray(node.docComments) && node.docComments.length > 0;
-    if (!hasDocComments) {
+    if (!hasExistingDocComment(node)) {
         return true;
     }
 
     return Array.isArray(node.params) && node.params.some((param) => {
         return param?.type === "DefaultParameter";
+    });
+}
+
+function hasExistingDocComment(node) {
+    if (!node) {
+        return false;
+    }
+
+    if (!Array.isArray(node.docComments) || node.docComments.length === 0) {
+        return false;
+    }
+
+    return node.docComments.some((comment) => {
+        const formatted = formatLineComment(comment);
+        if (typeof formatted !== "string") {
+            return false;
+        }
+
+        return formatted.trim().startsWith("///");
     });
 }
 


### PR DESCRIPTION
## Summary
- add a helper to detect existing doc comments before generating synthetic documentation
- ensure program-level functions without doc comments still receive synthesized metadata while keeping constructor behavior intact

## Testing
- npm run test:plugin *(fails: existing fixture expectations differ from formatter output in multiple legacy cases)*

------
https://chatgpt.com/codex/tasks/task_e_68e53beabda0832fa4b720266b8e09ff