### PR TITLE
Ensure plugin tests install dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm run test:parser && npm run test:plugin",
     "test:parser": "node set-config-values.mjs && cd $npm_package_config_root_path/$npm_package_config_parser_path && npm run test",
     "prettier": "node set-config-values.mjs && cd $npm_package_config_root_path/$npm_package_config_plugin_path && npm run prettier:plugin --path=$npm_config_path",
-    "test:plugin": "node set-config-values.mjs && cd $npm_package_config_root_path/$npm_package_config_plugin_path && npm run test",
+    "test:plugin": "node set-config-values.mjs && npm ci --prefix $npm_package_config_root_path/$npm_package_config_plugin_path && cd $npm_package_config_root_path/$npm_package_config_plugin_path && npm run test",
     "antlr": "node set-config-values.mjs && cd $npm_package_config_root_path/$npm_package_config_parser_path && npm run antlr",
     "example:plugin": "node set-config-values.mjs && cd $npm_package_config_root_path/$npm_package_config_plugin_path && npm run example"
   },


### PR DESCRIPTION
## Summary
- update the root test:plugin script to install the plugin package before running its test suite

## Testing
- npm run test:plugin *(fails: parser dependency 'antlr4' missing during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e57a8a85b8832f95bc9da5ff26bcf5