### PR TITLE
Fix doc banner spacing in doc-like comments

### DIFF
--- a/src/plugin/src/printer/comments.js
+++ b/src/plugin/src/printer/comments.js
@@ -239,7 +239,14 @@ function formatLineComment(comment, bannerMinimumSlashes = DEFAULT_LINE_COMMENT_
         if (remainder.startsWith("/")) {
             // comments like "// comment" should stay as regular comments
         } else {
-            let formatted = remainder.length > 0 ? `/// ${remainder}` : "///";
+            const remainderHasWordCharacters = /\w/.test(remainder);
+            const separator = remainder.length === 0
+                ? ""
+                : remainderHasWordCharacters
+                    ? " "
+                    : "";
+
+            let formatted = `///${separator}${remainder}`;
             formatted = applyJsDocReplacements(formatted);
             return applyInlinePadding(comment, formatted);
         }


### PR DESCRIPTION
## Summary
- avoid adding an extra space when rewriting doc-style line comments whose content is punctuation-only banners
- continue inserting the normal space for doc lines that contain identifiers or other word characters

## Testing
- npm run test:plugin *(fails: existing fixture mismatches unrelated to this change; test18 now passes)*

------
https://chatgpt.com/codex/tasks/task_e_68e58bf5bdfc832fa1e86239c9eccba5