### PR TITLE
Ensure mocha installs with workspace setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ nvm use # optional but recommended; aligns with the .nvmrc version
 npm install
 ```
 
-The workspace definition installs the root tooling plus the parser and plugin package dependencies in a single `npm install` run. Use `npm install --workspace src/plugin` or `npm install --workspace src/parser` when you only need to refresh a single package.
+The workspace definition installs the root tooling plus the parser and plugin package dependencies in a single `npm install` run. This includes the shared [Mocha](https://mochajs.org/) binary so the parser and plugin test suites work out of the box. Use `npm install --workspace src/plugin` or `npm install --workspace src/parser` when you only need to refresh a single package.
 
 ### Test the plugin and parser
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "devDependencies": {
         "@eslint/js": "^9.37.0",
         "eslint": "^9.37.0",
-        "globals": "^16.4.0"
+        "globals": "^16.4.0",
+        "mocha": "^11.7.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@eslint/js": "^9.37.0",
     "eslint": "^9.37.0",
-    "globals": "^16.4.0"
+    "globals": "^16.4.0",
+    "mocha": "^11.7.4"
   }
 }


### PR DESCRIPTION
## Summary
- add mocha to the root workspace devDependencies so npm install provides the shared test runner
- document that the standard workspace install now includes the Mocha binary for parser and plugin tests

## Testing
- npm list mocha

------
https://chatgpt.com/codex/tasks/task_e_68e58c94f8a4832fa38a555212465680