### PR TITLE
Strip parameter signatures from @function doc lines

### DIFF
--- a/src/plugin/src/printer/comments.js
+++ b/src/plugin/src/printer/comments.js
@@ -288,7 +288,23 @@ function applyJsDocReplacements(text) {
         formattedText = formattedText.replace(regex, `$1${newWord}`);
     }
 
+    formattedText = stripTrailingFunctionParameters(formattedText);
+
     return normalizeDocCommentTypeAnnotations(formattedText);
+}
+
+const FUNCTION_SIGNATURE_PATTERN = /(^|\n)(\s*\/\/\/\s*@function\b[^\r\n]*?)(\s*\([^\)]*\))(\s*(?=\r?\n|$))/gi;
+
+function stripTrailingFunctionParameters(text) {
+    if (typeof text !== "string" || !/@function\b/i.test(text)) {
+        return text;
+    }
+
+    return text.replace(
+        FUNCTION_SIGNATURE_PATTERN,
+        (match, linePrefix, functionPrefix) =>
+            `${linePrefix}${functionPrefix.replace(/\s+$/, "")}`
+    );
 }
 
 function normalizeDocCommentTypeAnnotations(text) {


### PR DESCRIPTION
## Summary
- normalize doc comment formatting by removing trailing parameter lists from `@function` lines after alias replacement
- add a helper that trims the parentheses while preserving indentation so other doc tags stay unchanged

## Testing
- npm run test:plugin *(fails: existing fixture mismatches unrelated to @function normalization)*

------
https://chatgpt.com/codex/tasks/task_e_68e58bf257c0832f96b2e10c8aa8c956