### PR TITLE
Fix handling of dangling comments in empty blocks

### DIFF
--- a/src/plugin/src/printer/comments.js
+++ b/src/plugin/src/printer/comments.js
@@ -173,8 +173,22 @@ const GAME_MAKER_TYPE_NORMALIZATIONS = new Map(
     })
 );
 
+function isCommentNode(node) {
+    return (
+        node &&
+        typeof node === "object" &&
+        (node.type === "CommentBlock" || node.type === "CommentLine")
+    );
+}
+
 function printComment(commentPath, options) {
     const comment = commentPath.getValue();
+    if (!isCommentNode(comment)) {
+        if (comment && typeof comment === "object") {
+            comment.printed = true;
+        }
+        return "";
+    }
     if (comment?._structPropertyTrailing) {
         if (comment._structPropertyHandled) {
             return "";
@@ -335,17 +349,23 @@ function collectDanglingComments(path, filter) {
     const entries = [];
     path.each((commentPath) => {
         const comment = commentPath.getValue();
+        if (!isCommentNode(comment)) {
+            return;
+        }
         if (
             comment &&
             !comment.leading &&
             !comment.trailing &&
             (!filter || filter(comment))
         ) {
-            entries.push({ commentPath, comment });
+            entries.push({
+                commentIndex: commentPath.getName(),
+                comment
+            });
         }
     }, "comments");
 
-    return { entries, totalCount: node.comments.length };
+    return { entries, totalCount: entries.length };
 }
 
 function printDanglingComments(path, options, sameIndent, filter) {
@@ -354,11 +374,17 @@ function printDanglingComments(path, options, sameIndent, filter) {
         return "";
     }
 
-    return entries.map(({ commentPath, comment }) => (
-        comment.attachToBrace
-            ? [" ", printComment(commentPath, options)]
-            : [printComment(commentPath, options)]
-    ));
+    return entries.map(({ commentIndex, comment }) => {
+        const printedComment = path.call(
+            (commentPath) => printComment(commentPath, options),
+            "comments",
+            commentIndex
+        );
+
+        return comment.attachToBrace
+            ? [" ", printedComment]
+            : [printedComment];
+    });
 }
 
 // print dangling comments and preserve the whitespace around the comments.
@@ -373,11 +399,16 @@ function printDanglingCommentsAsGroup(path, options, sameIndent, filter) {
     let i = 0;
     const finalIndex = totalCount - 1;
 
-    for (const { commentPath, comment } of entries) {
+    for (const { commentIndex, comment } of entries) {
         if (i === 0) {
             parts.push(whitespaceToDoc(comment.leadingWS));
         }
-        parts.push([printComment(commentPath, options)]);
+        const printedComment = path.call(
+            (commentPath) => printComment(commentPath, options),
+            "comments",
+            commentIndex
+        );
+        parts.push([printedComment]);
         if (i !== finalIndex) {
             let wsDoc = whitespaceToDoc(comment.trailingWS);
             // enforce at least one space between comments
@@ -513,5 +544,6 @@ export {
     printComment,
     formatLineComment,
     getLineCommentBannerMinimum,
-    normalizeDocCommentTypeAnnotations
+    normalizeDocCommentTypeAnnotations,
+    isCommentNode
 };

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -40,7 +40,8 @@ import {
     printDanglingCommentsAsGroup,
     formatLineComment,
     getLineCommentBannerMinimum,
-    normalizeDocCommentTypeAnnotations
+    normalizeDocCommentTypeAnnotations,
+    isCommentNode
 } from "./comments.js";
 import { getNodeStartIndex, getNodeEndIndex } from "../../../shared/ast-locations.js";
 
@@ -2219,7 +2220,10 @@ function printEmptyParens(path, options, print) {
 // prints an empty block with dangling comments
 function printEmptyBlock(path, options, print) {
     const node = path.getValue();
-    if (node?.comments?.length > 0) {
+    const comments = Array.isArray(node?.comments) ? node.comments : [];
+    const hasPrintableComments = comments.some(isCommentNode);
+
+    if (hasPrintableComments) {
         // an empty block with comments
         return [
             "{",


### PR DESCRIPTION
## Summary
- ensure printer utilities only operate on real comment nodes via a shared `isCommentNode` guard
- use stable comment indices when emitting dangling comment groups so mutated paths do not reach `printComment`
- only treat empty blocks as decorated when they contain printable comments to avoid bad braces handling

## Testing
- npm run test:plugin *(fails on pre-existing fixture mismatches, but test16 now completes without comment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e58bf4ba48832f81b0e901a42568e9