### PR TITLE
Avoid aligning short assignment groups

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -908,7 +908,7 @@ function applyAssignmentAlignment(statements) {
     let currentGroup = [];
 
     const flushGroup = () => {
-        if (currentGroup.length <= 1) {
+        if (currentGroup.length <= 2) {
             currentGroup.forEach((node) => {
                 node._alignAssignmentPadding = 0;
             });


### PR DESCRIPTION
## Summary
- stop the printer from padding assignment operators when there are only one or two simple assignments in a group so short structs keep compact spacing

## Testing
- npm run test:plugin *(fails: existing fixture regressions unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5950d64f4832fa531f6adfa9a29dd