### PR TITLE
Handle synthetic doc merges and constructor semicolons

### DIFF
--- a/src/plugin/src/printer/comments.js
+++ b/src/plugin/src/printer/comments.js
@@ -234,9 +234,22 @@ function formatLineComment(comment, bannerMinimumSlashes = DEFAULT_LINE_COMMENT_
         }
     }
 
-    const slashesMatch = original.match(/^\s*(\/\/+)(.*)$/);
-    if (slashesMatch && slashesMatch[1].length >= bannerMinimumSlashes) {
-        return applyInlinePadding(comment, original.trim());
+    const valueSlashMatch = trimmedValue.match(/^\/+/);
+    const valueSlashCount = valueSlashMatch ? valueSlashMatch[0].length : 0;
+    const computedFromValue = valueSlashCount > 0 ? 2 + valueSlashCount : leadingSlashCount;
+    const totalSlashCount = Math.max(leadingSlashCount, computedFromValue);
+    const docCandidate = trimmedValue.replace(/^\/+/, "").trimStart();
+    const looksLikeDocComment = docCandidate.startsWith("@");
+    const meetsBannerDetectionThreshold =
+        totalSlashCount >= DEFAULT_LINE_COMMENT_BANNER_MIN_SLASHES;
+
+    if (!looksLikeDocComment && meetsBannerDetectionThreshold) {
+        const targetSlashCount = Math.max(totalSlashCount, bannerMinimumSlashes);
+        const remainder = trimmedValue.slice(valueSlashCount);
+        const needsSpace = remainder.length > 0 && !/^\s/.test(remainder);
+        const normalizedRemainder = needsSpace ? ` ${remainder}` : remainder;
+        const bannerText = `${"/".repeat(targetSlashCount)}${normalizedRemainder}`;
+        return applyInlinePadding(comment, bannerText);
     }
 
     if (


### PR DESCRIPTION
## Summary
- refine banner comment detection so synthetic doc comments preserve inline markers without reformatting doc blocks
- update synthetic doc generation checks to merge only when new metadata is needed
- suppress semicolons for constructors comprised solely of default-parameter self assignments to match fixture expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e590e81cc8832fbf1382b140776143