### PR TITLE
Add option to control struct assignment condensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
   (`var <array>_len = array_length(<array>);`). Disable the option to keep the original loop structure when this optimization
   is undesirable for your project.
 
+- `condenseStructAssignments` (default: `true`)
+
+  Merges consecutive property assignments on the same struct into a single struct literal when it is safe to do so. Disable
+  the option to keep individual assignment statements instead of collapsing them into `{property: value}` expressions.
+
 - `arrayLengthHoistFunctionSuffixes` (default: empty string)
 
   Override the suffix that the cached loop variable receives for specific size-retrieval functions, or disable hoisting for a

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -17,12 +17,15 @@ export const languages = [
 
 export const parsers = {
     "gml-parse": {
-        parse: text => {
+        parse: (text, _parsers, options) => {
             const ast = GMLParser.parse(text, {
                 getLocations: true,
                 simplifyLocations: false
             });
-            return consolidateStructAssignments(ast);
+            if (options?.condenseStructAssignments ?? true) {
+                return consolidateStructAssignments(ast);
+            }
+            return ast;
         },
         astFormat: "gml-ast",
         locStart: (node) => {
@@ -58,6 +61,14 @@ export const options = {
         default: true,
         description: "Hoist array_length calls out of for-loop conditions by caching the result in a temporary variable."
     },
+    condenseStructAssignments: {
+        since: "0.0.0",
+        type: "boolean",
+        category: "gml",
+        default: true,
+        description:
+            "Condense consecutive struct property assignments into a single struct literal when possible."
+    },
     arrayLengthHoistFunctionSuffixes: {
         since: "0.0.0",
         type: "string",
@@ -83,6 +94,7 @@ export const defaultOptions = {
     trailingComma: "none",
     printWidth: 120,
     optimizeArrayLengthLoops: true,
+    condenseStructAssignments: true,
     arrayLengthHoistFunctionSuffixes: "",
     lineCommentBannerMinimumSlashes: 5
 };

--- a/src/plugin/tests/test30.input.gml
+++ b/src/plugin/tests/test30.input.gml
@@ -1,0 +1,7 @@
+function build_struct(value) {
+var foo = {};
+foo.alpha = 1;
+foo[$ "beta"] = value;
+foo.gamma = call();
+return foo;
+}

--- a/src/plugin/tests/test30.options.json
+++ b/src/plugin/tests/test30.options.json
@@ -1,0 +1,3 @@
+{
+    "condenseStructAssignments": false
+}

--- a/src/plugin/tests/test30.output.gml
+++ b/src/plugin/tests/test30.output.gml
@@ -1,0 +1,9 @@
+/// @function build_struct
+/// @param value
+function build_struct(value) {
+    var foo = {};
+    foo.alpha = 1;
+    foo[$ "beta"] = value;
+    foo.gamma = call();
+    return foo;
+}


### PR DESCRIPTION
## Summary
- add a `condenseStructAssignments` option so struct collapsing can be toggled per project
- document the new option in the README alongside existing plugin-specific settings
- cover the disabled behaviour with a new fixture exercising the option

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e5cb73e574832fb5b10df69bb1fb33