### PR TITLE
Add option to control single-line if statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
   Merges consecutive property assignments on the same struct into a single struct literal when it is safe to do so. Disable
   the option to keep individual assignment statements instead of collapsing them into `{property: value}` expressions.
 
+- `allowSingleLineIfStatements` (default: `true`)
+
+  Keeps short `if` statements such as `if (condition) { return; }` on a single line. Set the option to `false` if you prefer
+  the formatter to always expand the consequent across multiple lines.
+
 - `arrayLengthHoistFunctionSuffixes` (default: empty string)
 
   Override the suffix that the cached loop variable receives for specific size-retrieval functions, or disable hoisting for a

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -54,6 +54,14 @@ export const options = {
         description:
             "Comma-separated overrides for cached loop size variable suffixes (e.g. 'array_length=len,ds_queue_size=count'). Use '-' as the suffix to disable a function."
     },
+    allowSingleLineIfStatements: {
+        since: "0.0.0",
+        type: "boolean",
+        category: "gml",
+        default: true,
+        description:
+            "Collapse single-statement 'if' bodies to a single line (for example, 'if (condition) { return; }'). Disable to always expand the consequent across multiple lines.",
+    },
     lineCommentBannerMinimumSlashes: {
         since: "0.0.0",
         type: "int",
@@ -73,6 +81,7 @@ export const defaultOptions = {
     optimizeArrayLengthLoops: true,
     condenseStructAssignments: true,
     arrayLengthHoistFunctionSuffixes: "",
+    allowSingleLineIfStatements: true,
     lineCommentBannerMinimumSlashes: 5
 };
 

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -2593,8 +2593,9 @@ function printSingleClauseStatement(path, options, print, keyword, clauseKey, bo
     const clauseDoc = wrapInClauseParens(path, print, clauseKey);
     const node = path.getValue();
     const bodyNode = node?.[bodyKey];
+    const allowSingleLineIfStatements = options?.allowSingleLineIfStatements ?? true;
 
-    if (bodyNode && bodyNode.type === "ReturnStatement") {
+    if (allowSingleLineIfStatements && bodyNode && bodyNode.type === "ReturnStatement") {
         return group([
             keyword,
             " ",

--- a/src/plugin/tests/test33.input.gml
+++ b/src/plugin/tests/test33.input.gml
@@ -1,0 +1,1 @@
+if (should_exit()) return;

--- a/src/plugin/tests/test33.options.json
+++ b/src/plugin/tests/test33.options.json
@@ -1,0 +1,3 @@
+{
+    "allowSingleLineIfStatements": false
+}

--- a/src/plugin/tests/test33.output.gml
+++ b/src/plugin/tests/test33.output.gml
@@ -1,0 +1,3 @@
+if (should_exit()) {
+    return;
+}


### PR DESCRIPTION
## Summary
- add a new `allowSingleLineIfStatements` configuration flag and document it
- respect the flag in the printer so `if` statements with single return bodies stay multi-line when disabled
- cover the new option with a plugin fixture exercising the expanded formatting

## Testing
- npm run test:plugin *(fails: formats test31, formats test32)*

------
https://chatgpt.com/codex/tasks/task_e_68e5dcf46ad0832fabcbafb51a62092d