### PR TITLE
Add maxParamsPerLine option and improve call wrapping

### DIFF
--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -61,7 +61,16 @@ export const options = {
         default: 5,
         range: { start: 1, end: Infinity },
         description:
-            "Minimum number of consecutive '/' characters that must prefix a line comment before it is preserved verbatim."
+            "Minimum number of consecutive '/' characters that must prefix a line comment before it is preserved verbatim.",
+    },
+    maxParamsPerLine: {
+        since: "0.0.0",
+        type: "int",
+        category: "gml",
+        default: 0,
+        range: { start: 0, end: Infinity },
+        description:
+            "Maximum number of arguments allowed on a single line before a function call is forced to wrap. Set to 0 to disable.",
     }
 };
 
@@ -73,6 +82,7 @@ export const defaultOptions = {
     optimizeArrayLengthLoops: true,
     condenseStructAssignments: true,
     arrayLengthHoistFunctionSuffixes: "",
-    lineCommentBannerMinimumSlashes: 5
+    lineCommentBannerMinimumSlashes: 5,
+    maxParamsPerLine: 0
 };
 


### PR DESCRIPTION
## Summary
- add a `maxParamsPerLine` option to configure call argument wrapping limits
- respect the option while printing calls, including better handling of callback-heavy invocations
- tweak member access and list printing so multi-line calls keep the callee on one line and chunk arguments by the configured limit

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e5dbd59670832f99c706a1c1152dc7