### PR TITLE
Preserve globalvar declarations in formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
   Keeps short `if` statements such as `if (condition) { return; }` on a single line. Set the option to `false` if you prefer
   the formatter to always expand the consequent across multiple lines.
 
+- `preserveGlobalVarStatements` (default: `true`)
+
+  Keeps `globalvar` declarations in the formatted output while still prefixing subsequent assignments with `global.`. Set the
+  option to `false` if you prefer to omit the declarations entirely.
+
 - `arrayLengthHoistFunctionSuffixes` (default: empty string)
 
   Override the suffix that the cached loop variable receives for specific size-retrieval functions, or disable hoisting for a

--- a/src/parser/tests/parser.test.js
+++ b/src/parser/tests/parser.test.js
@@ -170,4 +170,23 @@ describe('GameMaker parser fixtures', () => {
       'Member expression start should include the object portion.'
     );
   });
+
+  it("retains 'globalvar' declarations in the AST", () => {
+    const source = 'globalvar foo, bar;\nfoo = 1;\n';
+    const ast = parseFixture(source, { options: { getLocations: true } });
+
+    assert.ok(ast, 'Parser returned no AST when parsing globalvar source.');
+    const [statement] = ast.body;
+
+    assert.ok(statement, 'Expected a globalvar statement to be present.');
+    assert.strictEqual(statement.type, 'GlobalVarStatement', 'Expected a GlobalVarStatement node in the AST.');
+    assert.strictEqual(statement.kind, 'globalvar', "GlobalVarStatement should preserve the 'globalvar' keyword.");
+    assert.ok(Array.isArray(statement.declarations), 'GlobalVarStatement should expose declarations.');
+    assert.strictEqual(statement.declarations.length, 2, 'Expected two global declarations.');
+    assert.deepStrictEqual(
+      statement.declarations.map((declaration) => declaration?.id?.name),
+      ['foo', 'bar'],
+      'Global declarations should retain their names.'
+    );
+  });
 });

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -62,6 +62,13 @@ export const options = {
         description:
             "Collapse single-statement 'if' bodies to a single line (for example, 'if (condition) { return; }'). Disable to always expand the consequent across multiple lines.",
     },
+    preserveGlobalVarStatements: {
+        since: "0.0.0",
+        type: "boolean",
+        category: "gml",
+        default: true,
+        description: "Preserve 'globalvar' declarations instead of eliding them during formatting.",
+    },
     lineCommentBannerMinimumSlashes: {
         since: "0.0.0",
         type: "int",
@@ -102,6 +109,7 @@ export const defaultOptions = {
     lineCommentBannerMinimumSlashes: 5,
     lineCommentBannerAutofillThreshold: 4,
     maxParamsPerLine: 0,
-    allowSingleLineIfStatements: true
+    allowSingleLineIfStatements: true,
+    preserveGlobalVarStatements: true
 };
 

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -345,7 +345,27 @@ export function print(path, options, print) {
                 group(print("right"))
             ]);
         }
-        case "GlobalVarStatement":
+        case "GlobalVarStatement": {
+            if (options?.preserveGlobalVarStatements === false) {
+                return null;
+            }
+
+            let decls = [];
+            if (node.declarations.length > 1) {
+                decls = printDelimitedList(path, print, "declarations", "", "", {
+                    delimiter: ",",
+                    allowTrailingDelimiter: options.trailingComma === "all",
+                    leadingNewline: false,
+                    trailingNewline: false
+                });
+            } else {
+                decls = path.map(print, "declarations");
+            }
+
+            const keyword = typeof node.kind === "string" ? node.kind : "globalvar";
+
+            return concat([keyword, " ", decls]);
+        }
         case "VariableDeclaration": {
             let decls = [];
             if (node.declarations.length > 1) {
@@ -902,6 +922,11 @@ function printStatements(path, options, print, childrenAttribute) {
         const node = childPath.getValue();
         const isTopLevel = childPath.parent?.type === "Program";
         const printed = print();
+
+        if (printed == null) {
+            return [];
+        }
+
         let semi = optionalSemicolon(node.type);
         const startProp = node?.start;
         const endProp = node?.end;

--- a/src/plugin/tests/plugin.test.js
+++ b/src/plugin/tests/plugin.test.js
@@ -178,4 +178,40 @@ describe('Prettier GameMaker plugin fixtures', () => {
       }
     });
   }
+
+  it("preserves 'globalvar' declarations by default", async () => {
+    const source = [
+      'globalvar foo, bar;',
+      'foo = 1;',
+      'bar = 2;',
+      '',
+    ].join('\n');
+
+    const formatted = await formatWithPlugin(source);
+
+    assert.ok(
+      /globalvar foo, bar;/.test(formatted),
+      "Expected formatted output to retain the 'globalvar' declaration."
+    );
+    assert.ok(
+      /global\.foo = 1;/.test(formatted) && /global\.bar = 2;/.test(formatted),
+      "Expected formatter to continue prefixing global assignments."
+    );
+  });
+
+  it("can elide 'globalvar' declarations when disabled", async () => {
+    const source = [
+      'globalvar foo, bar;',
+      'foo = 1;',
+      'bar = 2;',
+      '',
+    ].join('\n');
+
+    const formatted = await formatWithPlugin(source, { preserveGlobalVarStatements: false });
+
+    assert.ok(
+      !/globalvar\s+foo,\s*bar;/.test(formatted),
+      "Expected formatter to omit 'globalvar' declarations when disabled."
+    );
+  });
 });

--- a/src/plugin/tests/test04.options.json
+++ b/src/plugin/tests/test04.options.json
@@ -1,0 +1,3 @@
+{
+    "preserveGlobalVarStatements": false
+}

--- a/src/plugin/tests/test37.input.gml
+++ b/src/plugin/tests/test37.input.gml
@@ -1,0 +1,3 @@
+globalvar foo ,  bar ;
+foo = argument0;
+bar   = argument1;

--- a/src/plugin/tests/test37.output.gml
+++ b/src/plugin/tests/test37.output.gml
@@ -1,0 +1,3 @@
+globalvar foo, bar;
+global.foo = argument0;
+global.bar = argument1;


### PR DESCRIPTION
## Summary
- keep `globalvar` declarations in the AST and expose a `preserveGlobalVarStatements` option that preserves them by default
- update the printer to honor the new option, document it, and add tests covering preserved declarations
- add parser-level coverage to ensure global declarations are retained

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e65901f548832f90c1edd1e450d853