### PR TITLE
Refine feather metadata diagnostics layout

### DIFF
--- a/resources/feather-metadata.json
+++ b/resources/feather-metadata.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "manualRef": "8539feb61e46005516b03efbe470fae1abfdbdc7",
+    "manualRef": "develop",
     "commitSha": "8539feb61e46005516b03efbe470fae1abfdbdc7",
-    "generatedAt": "2025-10-08T22:26:37.722Z",
+    "generatedAt": "2025-10-09T02:48:21.456Z",
     "source": "YoYoGames/GameMaker-Manual",
     "manualPaths": {
       "diagnostics": "Manual/contents/The_Asset_Editors/Code_Editor_Properties/Feather_Messages.htm",
@@ -15,3625 +15,850 @@
     {
       "id": "GM1000",
       "title": "No enclosing loop from which to break.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The keyword&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/break.htm\">break</a></span> must be used inside the body of a loop statement such as <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/while.htm\">while</a></span>, <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/for.htm\">for</a></span>, <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/repeat.htm\">repeat</a></span>, or <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/with.htm\">with</a></span>.</p>",
-          "text": "The keyword break must be used inside the body of a loop statement such as while, for, repeat, or with."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Usage outside of a loop statement is not possible and results in a Compile Error.</p>",
-          "text": "Usage outside of a loop statement is not possible and results in a Compile Error."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_items&nbsp;=&nbsp;get_items();<br>\n    var&nbsp;i&nbsp;=&nbsp;0;<br>\n    repeat&nbsp;(array_length(_items))<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var&nbsp;_item&nbsp;=&nbsp;_items[i++];<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;(_item&nbsp;==&nbsp;undefined)<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;break;&nbsp;// Good!<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;// ... Some logic here ...<br>\n    }<br>\n    break;&nbsp;// GM1000 - No loop to break from.</p>",
-          "text": "var _items = get_items();\n\n    var i = 0;\n\n    repeat (array_length(_items))\n\n    {\n\n        var _item = _items[i++];\n\n        if (_item == undefined)\n\n            break; // Good!\n\n        // ... Some logic here ...\n\n    }\n\n    break; // GM1000 - No loop to break from."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this error requires identifying where the <span class=\"inline2\">break</span> statement was intended to go and moving it to the correct location. In the above example there was no loop to break from and thus the fix is to simply remove the last <span class=\"inline2\">break</span> statement.</p>",
-          "text": "Correcting this error requires identifying where the break statement was intended to go and moving it to the correct location. In the above example there was no loop to break from and thus the fix is to simply remove the last break statement."
-        }
-      ]
+      "description": "The keyword break must be used inside the body of a loop statement such as while, for, repeat, or with.\n\nUsage outside of a loop statement is not possible and results in a Compile Error.",
+      "badExample": "var _items = get_items();\n\n    var i = 0;\n\n    repeat (array_length(_items))\n\n    {\n\n        var _item = _items[i++];\n\n        if (_item == undefined)\n\n            break; // Good!\n\n        // ... Some logic here ...\n\n    }\n\n    break; // GM1000 - No loop to break from.",
+      "goodExample": null,
+      "correction": "Correcting this error requires identifying where the break statement was intended to go and moving it to the correct location. In the above example there was no loop to break from and thus the fix is to simply remove the last break statement."
     },
     {
       "id": "GM1001",
       "title": "No enclosing loop from which to continue.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The keyword&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/continue.htm\">continue</a></span> must be used inside the body of a loop statement such as <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/while.htm\">while</a></span>, <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/for.htm\">for</a></span>, <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/repeat.htm\">repeat</a></span>, or <span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/with.htm\">with</a></span>.</p>",
-          "text": "The keyword continue must be used inside the body of a loop statement such as while, for, repeat, or with."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Usage outside of a loop statement is not possible and results in a Compile Error.</p>",
-          "text": "Usage outside of a loop statement is not possible and results in a Compile Error."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_items&nbsp;=&nbsp;get_items();<br>\n    var&nbsp;i&nbsp;=&nbsp;0;<br>\n    repeat&nbsp;(array_length(_items))<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var&nbsp;_item&nbsp;=&nbsp;_items[i++];<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;if&nbsp;(_item&nbsp;==&nbsp;undefined)<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;continue;&nbsp;// Good!<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;// ... Some logic here ...<br>\n    }<br>\n    continue;&nbsp;// GM1001 - No loop to continue from.</p>",
-          "text": "var _items = get_items();\n\n    var i = 0;\n\n    repeat (array_length(_items))\n\n    {\n\n        var _item = _items[i++];\n\n        if (_item == undefined)\n\n            continue; // Good!\n\n        // ... Some logic here ...\n\n    }\n\n    continue; // GM1001 - No loop to continue from."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this error requires identifying where the <span class=\"inline2\">continue</span> statement was intended to go and moving it to the correct location. In the above example there was no loop to continue from and thus the fix is to simply remove the last <span class=\"inline2\">continue</span> statement.</p>",
-          "text": "Correcting this error requires identifying where the continue statement was intended to go and moving it to the correct location. In the above example there was no loop to continue from and thus the fix is to simply remove the last continue statement."
-        }
-      ]
+      "description": "The keyword continue must be used inside the body of a loop statement such as while, for, repeat, or with.\n\nUsage outside of a loop statement is not possible and results in a Compile Error.",
+      "badExample": "var _items = get_items();\n\n    var i = 0;\n\n    repeat (array_length(_items))\n\n    {\n\n        var _item = _items[i++];\n\n        if (_item == undefined)\n\n            continue; // Good!\n\n        // ... Some logic here ...\n\n    }\n\n    continue; // GM1001 - No loop to continue from.",
+      "goodExample": null,
+      "correction": "Correcting this error requires identifying where the continue statement was intended to go and moving it to the correct location. In the above example there was no loop to continue from and thus the fix is to simply remove the last continue statement."
     },
     {
       "id": "GM1002",
       "title": "globalvar does not support inline initializers.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>When using <span class=\"inline2\">globalvar</span>'s you must split the declaration and initialization of its value. This is in contrast to local variables which can be declared and initialized in the same statement (e.g. <span class=\"inline2\">var _width = 100;</span>).</p>",
-          "text": "When using globalvar's you must split the declaration and initialization of its value. This is in contrast to local variables which can be declared and initialized in the same statement (e.g. var _width = 100;)."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Attempting to initialize a globalvar inline in this manner is invalid syntax and results in a Compile Error.</p>",
-          "text": "Attempting to initialize a globalvar inline in this manner is invalid syntax and results in a Compile Error."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">globalvar&nbsp;gameManager&nbsp;=&nbsp;new&nbsp;GameManager();&nbsp;// GM1002 - globalvar does not support inline initializers.</p>",
-          "text": "globalvar gameManager = new GameManager(); // GM1002 - globalvar does not support inline initializers."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this error requires splitting the declaration and initialization statements. The above example can be fixed by rewriting it as so:</p>",
-          "text": "Correcting this error requires splitting the declaration and initialization statements. The above example can be fixed by rewriting it as so:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">globalvar&nbsp;gameManager;<br>\n    gameManager&nbsp;=&nbsp;new&nbsp;GameManager();</p>",
-          "text": "globalvar gameManager;\n\n    gameManager = new GameManager();"
-        }
-      ]
+      "description": "When using globalvar's you must split the declaration and initialization of its value. This is in contrast to local variables which can be declared and initialized in the same statement (e.g. var _width = 100;).\n\nAttempting to initialize a globalvar inline in this manner is invalid syntax and results in a Compile Error.",
+      "badExample": "globalvar gameManager = new GameManager(); // GM1002 - globalvar does not support inline initializers.",
+      "goodExample": "globalvar gameManager;\n\n    gameManager = new GameManager();",
+      "correction": "Correcting this error requires splitting the declaration and initialization statements. The above example can be fixed by rewriting it as so:"
     },
     {
       "id": "GM1003",
       "title": "Enum assignment must be integer assignment.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>When declaring the members of an <a href=\"../../GameMaker_Language/GML_Overview/Variables/Constants.htm#enumhead\">enum</a> you can assign specific integer values to the members. You cannot assign any other type of value to these members however. Attempting to do so will result in a Compile Error.</p>",
-          "text": "When declaring the members of an enum you can assign specific integer values to the members. You cannot assign any other type of value to these members however. Attempting to do so will result in a Compile Error."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum&nbsp;FRUIT<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;UNKNOWN =&nbsp;-1,&nbsp;// Good!<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;BANANA,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE =&nbsp;\"apple\"&nbsp;// GM1003 - Enum assignment must be integer assignment.<br>\n    }</p>",
-          "text": "enum FRUIT\n\n    {\n\n        UNKNOWN = -1, // Good!\n\n        BANANA,\n\n        ORANGE,\n\n        APPLE = \"apple\" // GM1003 - Enum assignment must be integer assignment.\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this error requires changing the assigned value to an integer in some way. If your code requires a value type other than&nbsp;<span data-keyref=\"Type_Real\"><a href=\"../../GameMaker_Language/GML_Overview/Data_Types.htm\" target=\"_blank\">Real</a></span> for some reason then you may want to investigate using macros instead.</p>",
-          "text": "Correcting this error requires changing the assigned value to an integer in some way. If your code requires a value type other than Real for some reason then you may want to investigate using macros instead."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Approach 1<br>\n    enum&nbsp;FRUIT<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;UNKNOWN =&nbsp;-1,&nbsp;// Good!<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;BANANA,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE =&nbsp;10&nbsp;// Good!<br>\n    }<br>\n    <br>\n    // Approach 2<br>\n    #macro&nbsp;FRUIT_UNKNOWN&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-1<br>\n    #macro&nbsp;FRUIT_BANANA&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0<br>\n    #macro&nbsp;FRUIT_ORANGE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1<br>\n    #macro&nbsp;FRUIT_APPLE&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"apple\"\n  </p>",
-          "text": "// Approach 1\n\n    enum FRUIT\n\n    {\n\n        UNKNOWN = -1, // Good!\n\n        BANANA,\n\n        ORANGE,\n\n        APPLE = 10 // Good!\n\n    }\n\n\n\n    // Approach 2\n\n    #macro FRUIT_UNKNOWN     -1\n\n    #macro FRUIT_BANANA     0\n\n    #macro FRUIT_ORANGE     1\n\n    #macro FRUIT_APPLE     \"apple\""
-        }
-      ]
+      "description": "When declaring the members of an enum you can assign specific integer values to the members. You cannot assign any other type of value to these members however. Attempting to do so will result in a Compile Error.",
+      "badExample": "enum FRUIT\n\n    {\n\n        UNKNOWN = -1, // Good!\n\n        BANANA,\n\n        ORANGE,\n\n        APPLE = \"apple\" // GM1003 - Enum assignment must be integer assignment.\n\n    }",
+      "goodExample": "// Approach 1\n\n    enum FRUIT\n\n    {\n\n        UNKNOWN = -1, // Good!\n\n        BANANA,\n\n        ORANGE,\n\n        APPLE = 10 // Good!\n\n    }\n\n\n\n    // Approach 2\n\n    #macro FRUIT_UNKNOWN     -1\n\n    #macro FRUIT_BANANA     0\n\n    #macro FRUIT_ORANGE     1\n\n    #macro FRUIT_APPLE     \"apple\"",
+      "correction": "Correcting this error requires changing the assigned value to an integer in some way. If your code requires a value type other than Real for some reason then you may want to investigate using macros instead."
     },
     {
       "id": "GM1004",
       "title": "The enum value 'ENUM MEMBER NAME' has already been previously defined in the enum 'ENUM NAME'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p><a href=\"../../GameMaker_Language/GML_Overview/Variables/Constants.htm#enumhead\">Enum</a> members must be uniquely named, duplicate names will result in a Compile Error.</p>",
-          "text": "Enum members must be uniquely named, duplicate names will result in a Compile Error."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum&nbsp;FRUIT<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,&nbsp;// Good!<br>\n    &nbsp; &nbsp; APPLE,&nbsp;// GM1004 The enum value 'APPLE'&nbsp;has already been previously defined in the enum 'FRUIT'<br>\n    }</p>",
-          "text": "enum FRUIT\n\n    {\n\n        APPLE, // Good!\n\n        APPLE, // GM1004 The enum value 'APPLE' has already been previously defined in the enum 'FRUIT'\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Typically, this error is the result of a typo of oversight. Removing the duplicate declaration will fix the issue.</p>",
-          "text": "Typically, this error is the result of a typo of oversight. Removing the duplicate declaration will fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum&nbsp;FRUIT<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,&nbsp;// Good!<br>\n    }</p>",
-          "text": "enum FRUIT\n\n    {\n\n        APPLE, // Good!\n\n    }"
-        }
-      ]
+      "description": "Enum members must be uniquely named, duplicate names will result in a Compile Error.",
+      "badExample": "enum FRUIT\n\n    {\n\n        APPLE, // Good!\n\n        APPLE, // GM1004 The enum value 'APPLE' has already been previously defined in the enum 'FRUIT'\n\n    }",
+      "goodExample": "enum FRUIT\n\n    {\n\n        APPLE, // Good!\n\n    }",
+      "correction": "Typically, this error is the result of a typo of oversight. Removing the duplicate declaration will fix the issue."
     },
     {
       "id": "GM1005",
       "title": "Argument must be provided.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>A function's parameter is required, yet an argument was not passed. While some parameters are optional (denoted with [square brackets]), most are required. When no argument is passed to these parameters, a compile error occurs.</p>",
-          "text": "A function's parameter is required, yet an argument was not passed. While some parameters are optional (denoted with [square brackets]), most are required. When no argument is passed to these parameters, a compile error occurs."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">draw_set_color();&nbsp;//&nbsp;GM1005&nbsp;-&nbsp;Argument&nbsp;must&nbsp;be&nbsp;provided.</p>",
-          "text": "draw_set_color(); // GM1005 - Argument must be provided."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Typically, this error is the result of an oversight. Providing the missing argument will fix the issue.</p>",
-          "text": "Typically, this error is the result of an oversight. Providing the missing argument will fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">draw_set_color(c_black);&nbsp;//&nbsp;Good!</p>",
-          "text": "draw_set_color(c_black); // Good!"
-        }
-      ]
+      "description": "A function's parameter is required, yet an argument was not passed. While some parameters are optional (denoted with [square brackets]), most are required. When no argument is passed to these parameters, a compile error occurs.",
+      "badExample": "draw_set_color(); // GM1005 - Argument must be provided.",
+      "goodExample": "draw_set_color(c_black); // Good!",
+      "correction": "Typically, this error is the result of an oversight. Providing the missing argument will fix the issue."
     },
     {
       "id": "GM1006",
       "title": "The enum 'ENUM NAME' has already been previously declared.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p><a href=\"../../GameMaker_Language/GML_Overview/Variables/Constants.htm#enumhead\">Enums</a> must be uniquely named, duplicate names will result in a compile error.</p>",
-          "text": "Enums must be uniquely named, duplicate names will result in a compile error."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum&nbsp;FRUIT {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;BLUEBERRY<br>\n    }<br>\n    enum&nbsp;FRUIT // GM1006 - The enum 'FRUIT' has already been previously declared.<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;CHERRY<br>\n    }</p>",
-          "text": "enum FRUIT {\n\n        APPLE,\n\n        ORANGE,\n\n        BLUEBERRY\n\n    }\n\n    enum FRUIT // GM1006 - The enum 'FRUIT' has already been previously declared.\n\n    {\n\n        APPLE,\n\n        ORANGE,\n\n        CHERRY\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Typically, this error is the result of an oversight. Removing the duplicate declaration, merging members of applicable will fix the issue. If the enums are intended to be different but names conflict, consider a different name for the new enum.</p>",
-          "text": "Typically, this error is the result of an oversight. Removing the duplicate declaration, merging members of applicable will fix the issue. If the enums are intended to be different but names conflict, consider a different name for the new enum."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum&nbsp;FRUIT<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;BLUEBERRY,<br>\n    &nbsp; &nbsp; CHERRY<br>\n    }</p>",
-          "text": "enum FRUIT\n\n    {\n\n        APPLE,\n\n        ORANGE,\n\n        BLUEBERRY,\n\n        CHERRY\n\n    }"
-        }
-      ]
+      "description": "Enums must be uniquely named, duplicate names will result in a compile error.",
+      "badExample": "enum FRUIT {\n\n        APPLE,\n\n        ORANGE,\n\n        BLUEBERRY\n\n    }\n\n    enum FRUIT // GM1006 - The enum 'FRUIT' has already been previously declared.\n\n    {\n\n        APPLE,\n\n        ORANGE,\n\n        CHERRY\n\n    }",
+      "goodExample": "enum FRUIT\n\n    {\n\n        APPLE,\n\n        ORANGE,\n\n        BLUEBERRY,\n\n        CHERRY\n\n    }",
+      "correction": "Typically, this error is the result of an oversight. Removing the duplicate declaration, merging members of applicable will fix the issue. If the enums are intended to be different but names conflict, consider a different name for the new enum."
     },
     {
       "id": "GM1007",
       "title": "Left-hand side of an assignment must be a variable.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The assignment operator <span class=\"inline2\">=</span> requires that the left-hand side of the statement be a variable. Constants, and other non-variables&nbsp;cannot be logically assigned to. E.g. <span class=\"inline2\">1 = 2</span> is not a mathematically valid statement.</p>",
-          "text": "The assignment operator = requires that the left-hand side of the statement be a variable. Constants, and other non-variables cannot be logically assigned to. E.g. 1 = 2 is not a mathematically valid statement."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A variable assignment stores the value on the right-hand side of the <span class=\"inline2\">=</span> sign somewhere in the computer's memory and makes it accessible in code through the name that you write on the left. If the variable already exists, the assignment will replace its contents with the new value on the right-hand side. Instances, structs, functions, constants and asset IDs are all non-variables and cannot be assigned to. You can, however, assign a value to one of the variables of an instance, struct or function.</p>",
-          "text": "A variable assignment stores the value on the right-hand side of the = sign somewhere in the computer's memory and makes it accessible in code through the name that you write on the left. If the variable already exists, the assignment will replace its contents with the new value on the right-hand side. Instances, structs, functions, constants and asset IDs are all non-variables and cannot be assigned to. You can, however, assign a value to one of the variables of an instance, struct or function."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>For more info on variable assignment see <a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Variables_And_Variable_Scope.htm\">Variables And Variable Scope</a>.</p>",
-          "text": "For more info on variable assignment see Variables And Variable Scope."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_foo&nbsp;=&nbsp;1234;<br>\n    _foo&nbsp;=&nbsp;4321;&nbsp;// Good!<br>\n    <br>\n    function&nbsp;get_random_item()<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;{<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name:&nbsp;\"Sword\"<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;};<br>\n    }<br>\n    <br>\n    get_random_item()&nbsp;=&nbsp;\"Shield\";&nbsp;// GM1007 - Left-hand side of an assignment must be a variable\n  </p>",
-          "text": "var _foo = 1234;\n\n    _foo = 4321; // Good!\n\n\n\n    function get_random_item()\n\n    {\n\n        return\n\n        {\n\n            name: \"Sword\"\n\n        };\n\n    }\n\n\n\n    get_random_item() = \"Shield\"; // GM1007 - Left-hand side of an assignment must be a variable"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Typically, this error is the result of a typo or oversight. Sometimes it's the result of a misunderstanding of how data flows through a program. If this is the case, take a step back and think about what you're trying to communicate to the CPU.</p>",
-          "text": "Typically, this error is the result of a typo or oversight. Sometimes it's the result of a misunderstanding of how data flows through a program. If this is the case, take a step back and think about what you're trying to communicate to the CPU."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_foo&nbsp;=&nbsp;1234;<br>\n    _foo&nbsp;=&nbsp;4321;&nbsp;// Good!<br>\n    <br>\n    function&nbsp;get_random_item()<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;{<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name:&nbsp;\"Sword\"<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;};<br>\n    }<br>\n    <br>\n    get_random_item() = { name: \"Shield\" }; // Bad! Return values are not variables<br>\n    get_random_item().name&nbsp;=&nbsp;\"Shield\";&nbsp;// Good!<br>\n    vk_space = vk_tab; // Bad! Constants are not variables and cannot change\n  </p>",
-          "text": "var _foo = 1234;\n\n    _foo = 4321; // Good!\n\n\n\n    function get_random_item()\n\n    {\n\n        return\n\n        {\n\n            name: \"Sword\"\n\n        };\n\n    }\n\n\n\n    get_random_item() = { name: \"Shield\" }; // Bad! Return values are not variables\n\n    get_random_item().name = \"Shield\"; // Good!\n\n    vk_space = vk_tab; // Bad! Constants are not variables and cannot change"
-        }
-      ]
+      "description": "The assignment operator = requires that the left-hand side of the statement be a variable. Constants, and other non-variables cannot be logically assigned to. E.g. 1 = 2 is not a mathematically valid statement.\n\nA variable assignment stores the value on the right-hand side of the = sign somewhere in the computer's memory and makes it accessible in code through the name that you write on the left. If the variable already exists, the assignment will replace its contents with the new value on the right-hand side. Instances, structs, functions, constants and asset IDs are all non-variables and cannot be assigned to. You can, however, assign a value to one of the variables of an instance, struct or function.\n\nFor more info on variable assignment see Variables And Variable Scope.",
+      "badExample": "var _foo = 1234;\n\n    _foo = 4321; // Good!\n\n\n\n    function get_random_item()\n\n    {\n\n        return\n\n        {\n\n            name: \"Sword\"\n\n        };\n\n    }\n\n\n\n    get_random_item() = \"Shield\"; // GM1007 - Left-hand side of an assignment must be a variable",
+      "goodExample": "var _foo = 1234;\n\n    _foo = 4321; // Good!\n\n\n\n    function get_random_item()\n\n    {\n\n        return\n\n        {\n\n            name: \"Sword\"\n\n        };\n\n    }\n\n\n\n    get_random_item() = { name: \"Shield\" }; // Bad! Return values are not variables\n\n    get_random_item().name = \"Shield\"; // Good!\n\n    vk_space = vk_tab; // Bad! Constants are not variables and cannot change",
+      "correction": "Typically, this error is the result of a typo or oversight. Sometimes it's the result of a misunderstanding of how data flows through a program. If this is the case, take a step back and think about what you're trying to communicate to the CPU."
     },
     {
       "id": "GM1008",
       "title": "The variable 'BUILT-IN VARIABLE' is readonly and cannot be assigned to.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>Attempting to assign a value to a read-only built-in variable is not allowed. These variables can be read and assigned to other variables or used in expressions, but cannot have their value directly modified.</p>",
-          "text": "Attempting to assign a value to a read-only built-in variable is not allowed. These variables can be read and assigned to other variables or used in expressions, but cannot have their value directly modified."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">working_directory = @\"PlayerData\";&nbsp;// Bad! working_directory is readonly<br>\n    var&nbsp;_file&nbsp;=&nbsp;file_find_first(working_directory&nbsp;+&nbsp;@\"\\Screenshots\\*.png\", fa_archive);<br>\n    // ...</p>",
-          "text": "working_directory = @\"PlayerData\"; // Bad! working_directory is readonly\n\n    var _file = file_find_first(working_directory + @\"\\Screenshots\\*.png\", fa_archive);\n\n    // ..."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p style=\"text-align: left; \">Since read-only variables cannot be directly assigned to the fix will depend on what your intention with setting the variable is. In the above example, we intend to find all the files in a directory <span class=\"inline2\">\"PlayerData\\Screenshots\\\"</span> relative to our <span class=\"inline2\">working_directory</span>. For this we can just use a local variable instead.</p>",
-          "text": "Since read-only variables cannot be directly assigned to the fix will depend on what your intention with setting the variable is. In the above example, we intend to find all the files in a directory \"PlayerData\\Screenshots\\\" relative to our working_directory. For this we can just use a local variable instead."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_playerdata_directory = working_directory + @\"PlayerData\";<br>\n    var&nbsp;_file&nbsp;=&nbsp;file_find_first(_playerdata_directory&nbsp;+&nbsp;@\"\\Screenshots\\*.png\", fa_archive);<br>\n    // ...</p>",
-          "text": "var _playerdata_directory = working_directory + @\"PlayerData\";\n\n    var _file = file_find_first(_playerdata_directory + @\"\\Screenshots\\*.png\", fa_archive);\n\n    // ..."
-        }
-      ]
+      "description": "Attempting to assign a value to a read-only built-in variable is not allowed. These variables can be read and assigned to other variables or used in expressions, but cannot have their value directly modified.",
+      "badExample": "working_directory = @\"PlayerData\"; // Bad! working_directory is readonly\n\n    var _file = file_find_first(working_directory + @\"\\Screenshots\\*.png\", fa_archive);\n\n    // ...",
+      "goodExample": "var _playerdata_directory = working_directory + @\"PlayerData\";\n\n    var _file = file_find_first(_playerdata_directory + @\"\\Screenshots\\*.png\", fa_archive);\n\n    // ...",
+      "correction": "Since read-only variables cannot be directly assigned to the fix will depend on what your intention with setting the variable is. In the above example, we intend to find all the files in a directory \"PlayerData\\Screenshots\\\" relative to our working_directory. For this we can just use a local variable instead."
     },
     {
       "id": "GM1009",
       "title": "Operation OPERATOR between types 'TYPE' and 'TYPE' may result in unexpected behavior or an error during runtime.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This indicates that the specified operation, while valid, may not have the result or behaviour that is expected. You may see this when adding reals to constant or asset types; which is an abuse of these types. Constant values are intended to be used in very specific ways, and asset IDs are not safely modifiable.</p>",
-          "text": "This indicates that the specified operation, while valid, may not have the result or behaviour that is expected. You may see this when adding reals to constant or asset types; which is an abuse of these types. Constant values are intended to be used in very specific ways, and asset IDs are not safely modifiable."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Find all *.doc files that are readonly archives<br>\n    var _attribs = fa_readonly + fa_archive; // Warn!<br>\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);<br>\n    <br>\n    // Go to the next room<br>\n    room_goto(room + 1); //&nbsp;Warn!\n  </p>",
-          "text": "// Find all *.doc files that are readonly archives\n\n    var _attribs = fa_readonly + fa_archive; // Warn!\n\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);\n\n\n\n    // Go to the next room\n\n    room_goto(room + 1); // Warn!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the above example we have 2 problems: Adding constants that are meant to be flags, and adding 1 to the current room ID to find the next room. The tricky bit is that this code might just work! But it's brittle and unrelated changes to the Runner or even your Game Project might break this code! Why?</p>",
-          "text": "In the above example we have 2 problems: Adding constants that are meant to be flags, and adding 1 to the current room ID to find the next room. The tricky bit is that this code might just work! But it's brittle and unrelated changes to the Runner or even your Game Project might break this code! Why?"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p><strong>Bitfield Constants</strong></p>",
-          "text": "Bitfield Constants"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>When it comes to constants used as bit field flags you should use the Bitwise OR operation <span class=\"inline2\">|</span> instead of the Arithmetic Add operation <span class=\"inline2\">+</span>. If we were to consider <span class=\"inline2\">fa_readonly</span>&nbsp;as <span class=\"inline2\">0b0001</span> and <span class=\"inline2\">fa_archive</span> as <span class=\"inline2\">0b0010</span> and we added (<span class=\"inline2\">0b0001 + 0b0010 = 0b0011</span>) these two together we would get the same result as if we or'd the values (<span class=\"inline2\">0b0001 | 0b0010 = 0b0011</span>). However, if for some reason the value of <span class=\"inline2\">fa_readonly</span>&nbsp;changed to be <span class=\"inline2\">0b0011</span> with two set bits instead of one (perhaps it's a mask field, or represents two other values together) then we will suddenly end up with an incorrect value and our code will stop working. (<span class=\"inline2\">0b0011 + 0b0001 = 0b0100</span>, and <span class=\"inline2\">0b0011 | 0b0001 = 0b0011</span>).</p>",
-          "text": "When it comes to constants used as bit field flags you should use the Bitwise OR operation | instead of the Arithmetic Add operation +. If we were to consider fa_readonly as 0b0001 and fa_archive as 0b0010 and we added (0b0001 + 0b0010 = 0b0011) these two together we would get the same result as if we or'd the values (0b0001 | 0b0010 = 0b0011). However, if for some reason the value of fa_readonly changed to be 0b0011 with two set bits instead of one (perhaps it's a mask field, or represents two other values together) then we will suddenly end up with an incorrect value and our code will stop working. (0b0011 + 0b0001 = 0b0100, and 0b0011 | 0b0001 = 0b0011)."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p><strong>Mutating Asset IDs</strong></p>",
-          "text": "Mutating Asset IDs"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Assets such as Rooms, Sprites and Objects are assigned an ordinal index number when your game is compiled. Which means that each asset is given a unique number that increments by 1 from 0. This may lead you to believe that if you wanted to get the next or previous room, for example, you can simply add or subtract 1 from the current room. However, the order that the rooms are in is different from the asset ID, perhaps you created the rooms out of order and then rearranged them, perhaps the method by which the compiler determines the asset IDs changes. In either of these instances your code would break. Instead you should use functions provided by the Runner for these specific tasks.</p>",
-          "text": "Assets such as Rooms, Sprites and Objects are assigned an ordinal index number when your game is compiled. Which means that each asset is given a unique number that increments by 1 from 0. This may lead you to believe that if you wanted to get the next or previous room, for example, you can simply add or subtract 1 from the current room. However, the order that the rooms are in is different from the asset ID, perhaps you created the rooms out of order and then rearranged them, perhaps the method by which the compiler determines the asset IDs changes. In either of these instances your code would break. Instead you should use functions provided by the Runner for these specific tasks."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Find all *.doc files that are readonly archives<br>\n    var _attribs = fa_readonly | fa_archive; // Good!<br>\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);<br>\n    <br>\n    // Go to the next room<br>\n    room_goto_next(); //&nbsp;Good!\n  </p>",
-          "text": "// Find all *.doc files that are readonly archives\n\n    var _attribs = fa_readonly | fa_archive; // Good!\n\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);\n\n\n\n    // Go to the next room\n\n    room_goto_next(); // Good!"
-        }
-      ]
+      "description": "This indicates that the specified operation, while valid, may not have the result or behaviour that is expected. You may see this when adding reals to constant or asset types; which is an abuse of these types. Constant values are intended to be used in very specific ways, and asset IDs are not safely modifiable.",
+      "badExample": "// Find all *.doc files that are readonly archives\n\n    var _attribs = fa_readonly + fa_archive; // Warn!\n\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);\n\n\n\n    // Go to the next room\n\n    room_goto(room + 1); // Warn!",
+      "goodExample": "// Find all *.doc files that are readonly archives\n\n    var _attribs = fa_readonly | fa_archive; // Good!\n\n    var _filename = file_find_first(\"/User Content/*.doc\", _attribs);\n\n\n\n    // Go to the next room\n\n    room_goto_next(); // Good!",
+      "correction": "In the above example we have 2 problems: Adding constants that are meant to be flags, and adding 1 to the current room ID to find the next room. The tricky bit is that this code might just work! But it's brittle and unrelated changes to the Runner or even your Game Project might break this code! Why?\n\nBitfield Constants\n\nWhen it comes to constants used as bit field flags you should use the Bitwise OR operation | instead of the Arithmetic Add operation +. If we were to consider fa_readonly as 0b0001 and fa_archive as 0b0010 and we added (0b0001 + 0b0010 = 0b0011) these two together we would get the same result as if we or'd the values (0b0001 | 0b0010 = 0b0011). However, if for some reason the value of fa_readonly changed to be 0b0011 with two set bits instead of one (perhaps it's a mask field, or represents two other values together) then we will suddenly end up with an incorrect value and our code will stop working. (0b0011 + 0b0001 = 0b0100, and 0b0011 | 0b0001 = 0b0011).\n\nMutating Asset IDs\n\nAssets such as Rooms, Sprites and Objects are assigned an ordinal index number when your game is compiled. Which means that each asset is given a unique number that increments by 1 from 0. This may lead you to believe that if you wanted to get the next or previous room, for example, you can simply add or subtract 1 from the current room. However, the order that the rooms are in is different from the asset ID, perhaps you created the rooms out of order and then rearranged them, perhaps the method by which the compiler determines the asset IDs changes. In either of these instances your code would break. Instead you should use functions provided by the Runner for these specific tasks."
     },
     {
       "id": "GM1010",
       "title": "Cannot perform OPERATOR operation between types 'TYPE' and 'TYPE'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This indicates that the specified operation is invalid in such a way that no result can be produced and instead result in either a runtime or compile time error. You may see this error between some type and <span class=\"inline2\">undefined</span>&nbsp;or unset. If Feather is unable to determine the type of a variable (or the variable is genuinely unset) then this error will appear.</p>",
-          "text": "This indicates that the specified operation is invalid in such a way that no result can be produced and instead result in either a runtime or compile time error. You may see this error between some type and undefined or unset. If Feather is unable to determine the type of a variable (or the variable is genuinely unset) then this error will appear."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _item1 = { price: 10 };<br>\n    var _item2 = { price: 20 };<br>\n    var _diff = _item2 - _item1; // Error!<br>\n    var _a, _b = 1234;<br>\n    var _c = _a + _b; //&nbsp;Error!</p>",
-          "text": "var _item1 = { price: 10 };\n\n    var _item2 = { price: 20 };\n\n    var _diff = _item2 - _item1; // Error!\n\n    var _a, _b = 1234;\n\n    var _c = _a + _b; // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This will require rewriting your code such that the intention is conveyed in valid operations. In the above example we intended to get the difference in price between 2 items. We can instead subtract the <span class=\"inline2\">price</span> variables, which are of type <span data-keyref=\"Type_Real\"><a href=\"../../GameMaker_Language/GML_Overview/Data_Types.htm\" target=\"_blank\">Real</a></span>, instead of the structs themselves.</p>",
-          "text": "This will require rewriting your code such that the intention is conveyed in valid operations. In the above example we intended to get the difference in price between 2 items. We can instead subtract the price variables, which are of type Real, instead of the structs themselves."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _item1 = { price: 10 };<br>\n    var _item2 = { price: 20 };<br>\n    var _diff = _item2.price - _item1.price; // Good!<br>\n    var _a = 4321, _b = 1234;<br>\n    var _c = _a + _b; // Good!</p>",
-          "text": "var _item1 = { price: 10 };\n\n    var _item2 = { price: 20 };\n\n    var _diff = _item2.price - _item1.price; // Good!\n\n    var _a = 4321, _b = 1234;\n\n    var _c = _a + _b; // Good!"
-        }
-      ]
+      "description": "This indicates that the specified operation is invalid in such a way that no result can be produced and instead result in either a runtime or compile time error. You may see this error between some type and undefined or unset. If Feather is unable to determine the type of a variable (or the variable is genuinely unset) then this error will appear.",
+      "badExample": "var _item1 = { price: 10 };\n\n    var _item2 = { price: 20 };\n\n    var _diff = _item2 - _item1; // Error!\n\n    var _a, _b = 1234;\n\n    var _c = _a + _b; // Error!",
+      "goodExample": "var _item1 = { price: 10 };\n\n    var _item2 = { price: 20 };\n\n    var _diff = _item2.price - _item1.price; // Good!\n\n    var _a = 4321, _b = 1234;\n\n    var _c = _a + _b; // Good!",
+      "correction": "This will require rewriting your code such that the intention is conveyed in valid operations. In the above example we intended to get the difference in price between 2 items. We can instead subtract the price variables, which are of type Real, instead of the structs themselves."
     },
     {
       "id": "GM1011",
       "title": "Implicit cast of type 'TYPE' to 'Bool' may result in unexpected behavior or an error during runtime.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>A common shorthand for if statement conditionals is to exclude the <span class=\"inline2\">== false</span> or <span class=\"inline2\">== true</span> from a boolean logic comparison. In GML doing so implicitly casts the conditional to a Boolean and compares it to <span class=\"inline2\">true</span>. Some types cannot be converted to Boolean and will result in a runtime error. The type <span class=\"inline2\">Unset</span>&nbsp;is special and indicates that you've declared a variable but never assigned a value to it, no operation is valid on <span class=\"inline2\">Unset</span>.</p>",
-          "text": "A common shorthand for if statement conditionals is to exclude the == false or == true from a boolean logic comparison. In GML doing so implicitly casts the conditional to a Boolean and compares it to true. Some types cannot be converted to Boolean and will result in a runtime error. The type Unset is special and indicates that you've declared a variable but never assigned a value to it, no operation is valid on Unset."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See: <a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/If_Else_and_Conditional_Operators.htm\">if / else and Conditional Operators</a></p>",
-          "text": "See: if / else and Conditional Operators"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = true;<br>\n    var _b = 1234;<br>\n    var _c = [];<br>\n    var _d;<br>\n    if (_a) { } // Good!<br>\n    if (_b) { } // Good!<br>\n    if (_c) { } // Error!<br>\n    if (_d) { } // Error!</p>",
-          "text": "var _a = true;\n\n    var _b = 1234;\n\n    var _c = [];\n\n    var _d;\n\n    if (_a) { } // Good!\n\n    if (_b) { } // Good!\n\n    if (_c) { } // Error!\n\n    if (_d) { } // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The solution is typically to be explicit about your comparisons.</p>",
-          "text": "The solution is typically to be explicit about your comparisons."
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>String, Array, Function, Struct, Id, Asset, Constant – <span class=\"inline2\">!= undefined</span></li>\n    <li>Bool – <span class=\"inline2\">== true</span>, or implicit cast still valid</li>\n    <li>Real – <span class=\"inline2\">&gt; 0</span>, or implicit cast still valid (though discouraged)</li>\n    <li>Unset – Assign a value to it!</li>\n  </ul>",
-          "text": "String, Array, Function, Struct, Id, Asset, Constant – != undefined\n    Bool – == true, or implicit cast still valid\n    Real – > 0, or implicit cast still valid (though discouraged)\n    Unset – Assign a value to it!"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = true;<br>\n    var _b = 1234;<br>\n    var _c = [];<br>\n    var _d;<br>\n    if (_a == true) { } // Good!<br>\n    if (_a) { } // Good!<br>\n    if (_b &gt; 0) { } // Good!<br>\n    if (_b) { } // Good!<br>\n    if (_c != undefined) { } // Good!<br>\n    _d = true; // Assign a value to change from Unset<br>\n    if (_d) { } // Good!</p>",
-          "text": "var _a = true;\n\n    var _b = 1234;\n\n    var _c = [];\n\n    var _d;\n\n    if (_a == true) { } // Good!\n\n    if (_a) { } // Good!\n\n    if (_b > 0) { } // Good!\n\n    if (_b) { } // Good!\n\n    if (_c != undefined) { } // Good!\n\n    _d = true; // Assign a value to change from Unset\n\n    if (_d) { } // Good!"
-        }
-      ]
+      "description": "A common shorthand for if statement conditionals is to exclude the == false or == true from a boolean logic comparison. In GML doing so implicitly casts the conditional to a Boolean and compares it to true. Some types cannot be converted to Boolean and will result in a runtime error. The type Unset is special and indicates that you've declared a variable but never assigned a value to it, no operation is valid on Unset.\n\nSee: if / else and Conditional Operators",
+      "badExample": "var _a = true;\n\n    var _b = 1234;\n\n    var _c = [];\n\n    var _d;\n\n    if (_a) { } // Good!\n\n    if (_b) { } // Good!\n\n    if (_c) { } // Error!\n\n    if (_d) { } // Error!",
+      "goodExample": "var _a = true;\n\n    var _b = 1234;\n\n    var _c = [];\n\n    var _d;\n\n    if (_a == true) { } // Good!\n\n    if (_a) { } // Good!\n\n    if (_b > 0) { } // Good!\n\n    if (_b) { } // Good!\n\n    if (_c != undefined) { } // Good!\n\n    _d = true; // Assign a value to change from Unset\n\n    if (_d) { } // Good!",
+      "correction": "The solution is typically to be explicit about your comparisons.\n\nString, Array, Function, Struct, Id, Asset, Constant – != undefined\nBool – == true, or implicit cast still valid\nReal – > 0, or implicit cast still valid (though discouraged)\nUnset – Assign a value to it!"
     },
     {
       "id": "GM1012",
       "title": "Malformed variable addressing expression.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The dot operator is used to access a variable that exists in another scope. These dot operators can be chained together or exist alone, in either occurrence this is known in GML as a \"variable addressing expression\", as it is an expression that gives a variable's address. Usually the left-hand side of this expression is a variable or constant containing an Object Asset, Instance ID, or Struct. Other types cannot be on the left-hand side because they do not contain variables.</p>",
-          "text": "The dot operator is used to access a variable that exists in another scope. These dot operators can be chained together or exist alone, in either occurrence this is known in GML as a \"variable addressing expression\", as it is an expression that gives a variable's address. Usually the left-hand side of this expression is a variable or constant containing an Object Asset, Instance ID, or Struct. Other types cannot be on the left-hand side because they do not contain variables."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = { name: \"GameMaker\" };<br>\n    var _b = _a.name; // Good!<br>\n    var _c = obj_manager.name; // Good!<br>\n    var&nbsp;_d = \"name\".length; // Error!</p>",
-          "text": "var _a = { name: \"GameMaker\" };\n\n    var _b = _a.name; // Good!\n\n    var _c = obj_manager.name; // Good!\n\n    var _d = \"name\".length; // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this error depends on what is on the left-hand side of the expression. You likely intended to reference a variable from an Object Asset, Instance, or Struct but either typo'd the name or your variable contains a different type than was expected.</p>",
-          "text": "Correcting this error depends on what is on the left-hand side of the expression. You likely intended to reference a variable from an Object Asset, Instance, or Struct but either typo'd the name or your variable contains a different type than was expected."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_d = string_length(\"name\"); // Good!</p>",
-          "text": "var _d = string_length(\"name\"); // Good!"
-        }
-      ]
+      "description": "The dot operator is used to access a variable that exists in another scope. These dot operators can be chained together or exist alone, in either occurrence this is known in GML as a \"variable addressing expression\", as it is an expression that gives a variable's address. Usually the left-hand side of this expression is a variable or constant containing an Object Asset, Instance ID, or Struct. Other types cannot be on the left-hand side because they do not contain variables.",
+      "badExample": "var _a = { name: \"GameMaker\" };\n\n    var _b = _a.name; // Good!\n\n    var _c = obj_manager.name; // Good!\n\n    var _d = \"name\".length; // Error!",
+      "goodExample": "var _d = string_length(\"name\"); // Good!",
+      "correction": "Correcting this error depends on what is on the left-hand side of the expression. You likely intended to reference a variable from an Object Asset, Instance, or Struct but either typo'd the name or your variable contains a different type than was expected."
     },
     {
       "id": "GM1013",
       "title": "Reference to variable 'IDENTIFIER' which has not been previously declared in 'IDENTIFIER'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This error indicates that the specified variable cannot be found in the referenced scope.</p>",
-          "text": "This error indicates that the specified variable cannot be found in the referenced scope."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This could indicate that:</p>",
-          "text": "This could indicate that:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Create event<br>\n    var atk = 1;<br>\n    if (atk &lt; 50) {&nbsp; &nbsp; // Error! 'atk' is a local variable in Create<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;with (other) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hp -= atk; // Error! 'atk' is in the original scope!<br>\n    &nbsp; &nbsp; }<br>\n    &nbsp; &nbsp;&nbsp;<br>\n    &nbsp; &nbsp; attack *= 2;&nbsp; &nbsp;// Error! Typo'd 'atk' as 'attack'<br>\n    }<br>\n    <br>\n    // Script - Item<br>\n    function Item(_name, _value) constructor {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;name = _name;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;value = _value;<br>\n    }<br>\n    <br>\n    // Create - objInventory<br>\n    hp = 100;<br>\n    items = [];<br>\n    var _sword = new Item(\"Sword\", 10);<br>\n    array_push(items, _sword);<br>\n    var _shield = new Item(\"Shield\", 10);<br>\n    _shield.defense = 10;<br>\n    array_push(items, _shield);<br>\n    <br>\n    // Collision - par_mob<br>\n    var _dmg = other.dmg;<br>\n    var _len = array_length(items);<br>\n    for (var i = 0; i &lt; _len; ++i) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _item = items[i];<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;_dmg -= _item.defense; // Error! 'defense' is conditionally defined<br>\n    }<br>\n    <br>\n    hp -= max(0, _dmg);\n  </p>",
-          "text": "// Create event\n\n    var atk = 1;\n\n    if (atk < 50) {    // Error! 'atk' is a local variable in Create\n\n        with (other) {\n\n            hp -= atk; // Error! 'atk' is in the original scope!\n\n        }\n\n\n\n        attack *= 2;   // Error! Typo'd 'atk' as 'attack'\n\n    }\n\n\n\n    // Script - Item\n\n    function Item(_name, _value) constructor {\n\n        name = _name;\n\n        value = _value;\n\n    }\n\n\n\n    // Create - objInventory\n\n    hp = 100;\n\n    items = [];\n\n    var _sword = new Item(\"Sword\", 10);\n\n    array_push(items, _sword);\n\n    var _shield = new Item(\"Shield\", 10);\n\n    _shield.defense = 10;\n\n    array_push(items, _shield);\n\n\n\n    // Collision - par_mob\n\n    var _dmg = other.dmg;\n\n    var _len = array_length(items);\n\n    for (var i = 0; i < _len; ++i) {\n\n        var _item = items[i];\n\n        _dmg -= _item.defense; // Error! 'defense' is conditionally defined\n\n    }\n\n\n\n    hp -= max(0, _dmg);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this issue depends on which of the aforementioned conditions applies to your situation.</p>",
-          "text": "Correcting this issue depends on which of the aforementioned conditions applies to your situation."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Create event<br>\n    atk = 1; // Fix! Make this an instance variable by removing 'var'<br>\n    // Collision - par_mob<br>\n    if (atk &lt; 50) { // Good!<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;with (other) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hp -= other.atk; // Fix! Reference 'other.atk'<br>\n    &nbsp; &nbsp; }<br>\n    &nbsp; &nbsp;&nbsp;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;atk *= 2; // Fix! Rename to 'atk'<br>\n    }<br>\n    <br>\n    // Script - Item<br>\n    function Item(_name, _value) constructor {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;name = _name;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;value = _value;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;defense = 0; // Possible Fix! Declare a default value<br>\n    }<br>\n    <br>\n    // Create - objInventory<br>\n    hp = 100;<br>\n    items = [];<br>\n    var _sword = new Item(\"Sword\", 10);<br>\n    array_push(items, _sword);<br>\n    var _shield = new Item(\"Shield\", 10);<br>\n    _shield.defense = 10;<br>\n    array_push(items, _shield);<br>\n    <br>\n    // Collision - par_mob<br>\n    var _dmg = other.dmg;<br>\n    var _len = array_length(items);<br>\n    for (var i = 0; i &lt; _len; ++i) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _item = items[i];<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;_dmg -= _item.defense; // Fix! 'defense' has default value<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;// Or Possible Fix! Check variable exists (not as recommended)<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;if (struct_exists(_item, \"defense\")) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_dmg -= _item.defense; // Feather knows this variable exists now<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;}<br>\n    }<br>\n    <br>\n    hp -= max(0, _dmg);\n  </p>",
-          "text": "// Create event\n\n    atk = 1; // Fix! Make this an instance variable by removing 'var'\n\n    // Collision - par_mob\n\n    if (atk < 50) { // Good!\n\n        with (other) {\n\n            hp -= other.atk; // Fix! Reference 'other.atk'\n\n        }\n\n\n\n        atk *= 2; // Fix! Rename to 'atk'\n\n    }\n\n\n\n    // Script - Item\n\n    function Item(_name, _value) constructor {\n\n        name = _name;\n\n        value = _value;\n\n        defense = 0; // Possible Fix! Declare a default value\n\n    }\n\n\n\n    // Create - objInventory\n\n    hp = 100;\n\n    items = [];\n\n    var _sword = new Item(\"Sword\", 10);\n\n    array_push(items, _sword);\n\n    var _shield = new Item(\"Shield\", 10);\n\n    _shield.defense = 10;\n\n    array_push(items, _shield);\n\n\n\n    // Collision - par_mob\n\n    var _dmg = other.dmg;\n\n    var _len = array_length(items);\n\n    for (var i = 0; i < _len; ++i) {\n\n        var _item = items[i];\n\n        _dmg -= _item.defense; // Fix! 'defense' has default value\n\n        // Or Possible Fix! Check variable exists (not as recommended)\n\n        if (struct_exists(_item, \"defense\")) {\n\n            _dmg -= _item.defense; // Feather knows this variable exists now\n\n        }\n\n    }\n\n\n\n    hp -= max(0, _dmg);"
-        }
-      ]
+      "description": "This error indicates that the specified variable cannot be found in the referenced scope.\n\nThis could indicate that:",
+      "badExample": "// Create event\n\n    var atk = 1;\n\n    if (atk < 50) {    // Error! 'atk' is a local variable in Create\n\n        with (other) {\n\n            hp -= atk; // Error! 'atk' is in the original scope!\n\n        }\n\n\n\n        attack *= 2;   // Error! Typo'd 'atk' as 'attack'\n\n    }\n\n\n\n    // Script - Item\n\n    function Item(_name, _value) constructor {\n\n        name = _name;\n\n        value = _value;\n\n    }\n\n\n\n    // Create - objInventory\n\n    hp = 100;\n\n    items = [];\n\n    var _sword = new Item(\"Sword\", 10);\n\n    array_push(items, _sword);\n\n    var _shield = new Item(\"Shield\", 10);\n\n    _shield.defense = 10;\n\n    array_push(items, _shield);\n\n\n\n    // Collision - par_mob\n\n    var _dmg = other.dmg;\n\n    var _len = array_length(items);\n\n    for (var i = 0; i < _len; ++i) {\n\n        var _item = items[i];\n\n        _dmg -= _item.defense; // Error! 'defense' is conditionally defined\n\n    }\n\n\n\n    hp -= max(0, _dmg);",
+      "goodExample": "// Create event\n\n    atk = 1; // Fix! Make this an instance variable by removing 'var'\n\n    // Collision - par_mob\n\n    if (atk < 50) { // Good!\n\n        with (other) {\n\n            hp -= other.atk; // Fix! Reference 'other.atk'\n\n        }\n\n\n\n        atk *= 2; // Fix! Rename to 'atk'\n\n    }\n\n\n\n    // Script - Item\n\n    function Item(_name, _value) constructor {\n\n        name = _name;\n\n        value = _value;\n\n        defense = 0; // Possible Fix! Declare a default value\n\n    }\n\n\n\n    // Create - objInventory\n\n    hp = 100;\n\n    items = [];\n\n    var _sword = new Item(\"Sword\", 10);\n\n    array_push(items, _sword);\n\n    var _shield = new Item(\"Shield\", 10);\n\n    _shield.defense = 10;\n\n    array_push(items, _shield);\n\n\n\n    // Collision - par_mob\n\n    var _dmg = other.dmg;\n\n    var _len = array_length(items);\n\n    for (var i = 0; i < _len; ++i) {\n\n        var _item = items[i];\n\n        _dmg -= _item.defense; // Fix! 'defense' has default value\n\n        // Or Possible Fix! Check variable exists (not as recommended)\n\n        if (struct_exists(_item, \"defense\")) {\n\n            _dmg -= _item.defense; // Feather knows this variable exists now\n\n        }\n\n    }\n\n\n\n    hp -= max(0, _dmg);",
+      "correction": "Correcting this issue depends on which of the aforementioned conditions applies to your situation."
     },
     {
       "id": "GM1014",
       "title": "The enum 'ENUM' does not contain the value 'IDENTIFIER'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This error is raised when an Enum Member is referenced which does not exist.</p>",
-          "text": "This error is raised when an Enum Member is referenced which does not exist."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This could indicate that:</p>",
-          "text": "This could indicate that:"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum FRUIT {<br>\n    &nbsp; &nbsp; NONE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;CANTALOUPE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;SIZEOF<br>\n    }<br>\n    var _best_fruit = FRUIT.KIWI; // Error! KIWI is not defined<br>\n    var _underrated_fruit = FRUIT.CANALOPE; // Error! CANTALOUPE is typo'd</p>",
-          "text": "enum FRUIT {\n\n        NONE,\n\n        ORANGE,\n\n        APPLE,\n\n        CANTALOUPE,\n\n        SIZEOF\n\n    }\n\n    var _best_fruit = FRUIT.KIWI; // Error! KIWI is not defined\n\n    var _underrated_fruit = FRUIT.CANALOPE; // Error! CANTALOUPE is typo'd"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correcting this issue depends on which of the aforementioned conditions applies to your situation.</p>",
-          "text": "Correcting this issue depends on which of the aforementioned conditions applies to your situation."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">enum FRUIT {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;NONE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;ORANGE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;APPLE,<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;CANTALOUPE,<br>\n    &nbsp; &nbsp; KIWI, // Fix! Define KIWI<br>\n    &nbsp; &nbsp; SIZEOF<br>\n    }<br>\n    var _best_fruit&nbsp;= FRUIT.KIWI; // Good!<br>\n    var _underrated_fruit = FRUIT.CANTALOUPE; // Fix! No longer typo'd</p>",
-          "text": "enum FRUIT {\n\n        NONE,\n\n        ORANGE,\n\n        APPLE,\n\n        CANTALOUPE,\n\n        KIWI, // Fix! Define KIWI\n\n        SIZEOF\n\n    }\n\n    var _best_fruit = FRUIT.KIWI; // Good!\n\n    var _underrated_fruit = FRUIT.CANTALOUPE; // Fix! No longer typo'd"
-        }
-      ]
+      "description": "This error is raised when an Enum Member is referenced which does not exist.\n\nThis could indicate that:",
+      "badExample": "enum FRUIT {\n\n        NONE,\n\n        ORANGE,\n\n        APPLE,\n\n        CANTALOUPE,\n\n        SIZEOF\n\n    }\n\n    var _best_fruit = FRUIT.KIWI; // Error! KIWI is not defined\n\n    var _underrated_fruit = FRUIT.CANALOPE; // Error! CANTALOUPE is typo'd",
+      "goodExample": "enum FRUIT {\n\n        NONE,\n\n        ORANGE,\n\n        APPLE,\n\n        CANTALOUPE,\n\n        KIWI, // Fix! Define KIWI\n\n        SIZEOF\n\n    }\n\n    var _best_fruit = FRUIT.KIWI; // Good!\n\n    var _underrated_fruit = FRUIT.CANTALOUPE; // Fix! No longer typo'd",
+      "correction": "Correcting this issue depends on which of the aforementioned conditions applies to your situation."
     },
     {
       "id": "GM1015",
       "title": "Cannot divide or modulo expression by 0.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This error is raised when you directly&nbsp;divide or modulo by 0.</p>",
-          "text": "This error is raised when you directly divide or modulo by 0."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Note: GM1015 is NOT&nbsp;raised if 0 is stored in a variable and then you divide by that variable; Feather does not track the individual values of variables, only the types of variables.</p>",
-          "text": "Note: GM1015 is NOT raised if 0 is stored in a variable and then you divide by that variable; Feather does not track the individual values of variables, only the types of variables."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _hp = 100;<br>\n    _hp /= 0; // Error! Cannot divide by 0<br>\n    _hp %= 0; // Error! Cannot modulo by 0</p>",
-          "text": "var _hp = 100;\n\n    _hp /= 0; // Error! Cannot divide by 0\n\n    _hp %= 0; // Error! Cannot modulo by 0"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The solution is to use any number other than 0.</p>",
-          "text": "The solution is to use any number other than 0."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _hp = 100;<br>\n    _hp /= 100; // Good!<br>\n    _hp %= 100; // Good!</p>",
-          "text": "var _hp = 100;\n\n    _hp /= 100; // Good!\n\n    _hp %= 100; // Good!"
-        }
-      ]
+      "description": "This error is raised when you directly divide or modulo by 0.\n\nNote: GM1015 is NOT raised if 0 is stored in a variable and then you divide by that variable; Feather does not track the individual values of variables, only the types of variables.",
+      "badExample": "var _hp = 100;\n\n    _hp /= 0; // Error! Cannot divide by 0\n\n    _hp %= 0; // Error! Cannot modulo by 0",
+      "goodExample": "var _hp = 100;\n\n    _hp /= 100; // Good!\n\n    _hp %= 100; // Good!",
+      "correction": "The solution is to use any number other than 0."
     },
     {
       "id": "GM1016",
       "title": "A boolean literal was unexpected at this time.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that a boolean value (<span class=\"inline2\">true</span> or <span class=\"inline2\">false</span>) has appeared outside of a conditional or expression. Typically you would only see these kinds of values used in <span class=\"inline2\">if</span> statements and friends.</p>",
-          "text": "This message indicates that a boolean value (true or false) has appeared outside of a conditional or expression. Typically you would only see these kinds of values used in if statements and friends."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">true; // Error! A lone true without a conditional</p>",
-          "text": "true; // Error! A lone true without a conditional"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Use boolean values in a way that the compiler understands. For example:</p>",
-          "text": "Use boolean values in a way that the compiler understands. For example:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = true; // Good! Right-hand side is an expression<br>\n    var _b = true ? 1 : 0; // Good! Right-hand side is an expression<br>\n    if (true) {<br>\n    &nbsp; &nbsp; // Good! Appears inside a conditional<br>\n    }</p>",
-          "text": "var _a = true; // Good! Right-hand side is an expression\n\n    var _b = true ? 1 : 0; // Good! Right-hand side is an expression\n\n    if (true) {\n\n        // Good! Appears inside a conditional\n\n    }"
-        }
-      ]
+      "description": "This message indicates that a boolean value (true or false) has appeared outside of a conditional or expression. Typically you would only see these kinds of values used in if statements and friends.",
+      "badExample": "true; // Error! A lone true without a conditional",
+      "goodExample": "var _a = true; // Good! Right-hand side is an expression\n\n    var _b = true ? 1 : 0; // Good! Right-hand side is an expression\n\n    if (true) {\n\n        // Good! Appears inside a conditional\n\n    }",
+      "correction": "Use boolean values in a way that the compiler understands. For example:"
     },
     {
       "id": "GM1017",
       "title": "The function 'FUNCTION NAME' is deprecated and usage is discouraged.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you are using either a built-in function or user-defined function that is deprecated. Deprecation means that while the function, variable, or feature is still available for usage that it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update&nbsp;<span data-keyref=\"GameMaker Name\">GameMaker</span> to newer versions.</p>",
-          "text": "This message indicates that you are using either a built-in function or user-defined function that is deprecated. Deprecation means that while the function, variable, or feature is still available for usage that it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Note that user-defined functions can also be marked as deprecated using the <span class=\"inline2\">@deprecated</span> tag.</p>",
-          "text": "Note that user-defined functions can also be marked as deprecated using the @deprecated tag."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// @deprecated<br>\n    function make_game() {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;// Deprecated in favour of writing more code to do that same thing!<br>\n    }<br>\n    <br>\n    username = get_string(\"Username:\", \"\"); // Suggestion!<br>\n    make_game(); //&nbsp;Suggestion!\n  </p>",
-          "text": "// @deprecated\n\n    function make_game() {\n\n        // Deprecated in favour of writing more code to do that same thing!\n\n    }\n\n\n\n    username = get_string(\"Username:\", \"\"); // Suggestion!\n\n    make_game(); // Suggestion!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Find the alternative functions or approach to use, and refactor your code to do that instead.</p>",
-          "text": "Find the alternative functions or approach to use, and refactor your code to do that instead."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">username&nbsp;= get_string_async(\"Username:\", \"\"); // Fix!</p>",
-          "text": "username = get_string_async(\"Username:\", \"\"); // Fix!"
-        }
-      ]
+      "description": "This message indicates that you are using either a built-in function or user-defined function that is deprecated. Deprecation means that while the function, variable, or feature is still available for usage that it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions.\n\nNote that user-defined functions can also be marked as deprecated using the @deprecated tag.",
+      "badExample": "// @deprecated\n\n    function make_game() {\n\n        // Deprecated in favour of writing more code to do that same thing!\n\n    }\n\n\n\n    username = get_string(\"Username:\", \"\"); // Suggestion!\n\n    make_game(); // Suggestion!",
+      "goodExample": "username = get_string_async(\"Username:\", \"\"); // Fix!",
+      "correction": "Find the alternative functions or approach to use, and refactor your code to do that instead."
     },
     {
       "id": "GM1019",
       "title": "The function 'FUNCTION NAME' takes no more than NUMBER arguments but NUMBER are provided.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when more arguments are passed to a function than that function takes, including optional parameters (if they exist).</p>",
-          "text": "This message is shown when more arguments are passed to a function than that function takes, including optional parameters (if they exist)."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>There are essentially two reasons you might run into this problem:</p>",
-          "text": "There are essentially two reasons you might run into this problem:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>You're nesting function calls and missed a closing parenthesis <span class=\"inline2\">)</span></li>\n    <li>You have miscounted your arguments</li>\n  </ul>",
-          "text": "You're nesting function calls and missed a closing parenthesis )\n    You have miscounted your arguments"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The solution to fixing either of these is to refactor your code to reflect your actual intentions.</p>",
-          "text": "The solution to fixing either of these is to refactor your code to reflect your actual intentions."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _dmg = clamp(lerp(dmg1, dmg2, 0.5, 0, 100)); // Error!</p>",
-          "text": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5, 0, 100)); // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the above example we have accidentally put the closing parenthesis for <span class=\"inline2\">lerp</span> in the wrong place.</p>",
-          "text": "In the above example we have accidentally put the closing parenthesis for lerp in the wrong place."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!</p>",
-          "text": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!"
-        }
-      ]
+      "description": "This message is shown when more arguments are passed to a function than that function takes, including optional parameters (if they exist).\n\nThere are essentially two reasons you might run into this problem:\n\nYou're nesting function calls and missed a closing parenthesis )\nYou have miscounted your arguments\n\nThe solution to fixing either of these is to refactor your code to reflect your actual intentions.",
+      "badExample": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5, 0, 100)); // Error!",
+      "goodExample": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!",
+      "correction": "In the above example we have accidentally put the closing parenthesis for lerp in the wrong place."
     },
     {
       "id": "GM1020",
       "title": "The function 'FUNCTION NAME' takes no less than NUMBER arguments but NUMBER are provided.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when less arguments are passed to a function than that function takes.</p>",
-          "text": "This message is shown when less arguments are passed to a function than that function takes."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Possible causes can be:</p>",
-          "text": "Possible causes can be:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>You're nesting function calls and missed a closing parenthesis <span class=\"inline2\">)</span></li>\n    <li>You have miscounted your arguments</li>\n  </ul>",
-          "text": "You're nesting function calls and missed a closing parenthesis )\n    You have miscounted your arguments"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _dmg = clamp(lerp(dmg1, dmg2), 0.5, 0, 100); // Error!</p>",
-          "text": "var _dmg = clamp(lerp(dmg1, dmg2), 0.5, 0, 100); // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The closing parenthesis for <span class=\"inline2\">lerp</span> is in the wrong place. &nbsp;Placing it after the 0.5 value instead fixes the error.</p>",
-          "text": "The closing parenthesis for lerp is in the wrong place. Placing it after the 0.5 value instead fixes the error."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!</p>",
-          "text": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!"
-        }
-      ]
+      "description": "This message is shown when less arguments are passed to a function than that function takes.\n\nPossible causes can be:\n\nYou're nesting function calls and missed a closing parenthesis )\nYou have miscounted your arguments",
+      "badExample": "var _dmg = clamp(lerp(dmg1, dmg2), 0.5, 0, 100); // Error!",
+      "goodExample": "var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100); // Fix!",
+      "correction": "The closing parenthesis for lerp is in the wrong place. Placing it after the 0.5 value instead fixes the error."
     },
     {
       "id": "GM1021",
       "title": "The function or script 'FUNCTION/SCRIPT NAME' does not exist.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when a call to a non-existent script or function is made. This may be shown if you typo the function name, or have deleted the function.</p>",
-          "text": "This message is shown when a call to a non-existent script or function is made. This may be shown if you typo the function name, or have deleted the function."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function make_game(_genre) { /* ... */ }<br>\n    make_gaem(\"RPG\"); // GM1021<br>\n    var _x = clam(x, 0, 100); //&nbsp;GM1021</p>",
-          "text": "function make_game(_genre) { /* ... */ }\n\n    make_gaem(\"RPG\"); // GM1021\n\n    var _x = clam(x, 0, 100); // GM1021"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Correct any typos, and ensure the functions you're trying to call exist.</p>",
-          "text": "Correct any typos, and ensure the functions you're trying to call exist."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function make_game(_genre) { /* ... */ }<br>\n    make_game(\"RPG\"); //&nbsp;Fix!<br>\n    var _x = clamp(x, 0, 100); //&nbsp;Fix!</p>",
-          "text": "function make_game(_genre) { /* ... */ }\n\n    make_game(\"RPG\"); // Fix!\n\n    var _x = clamp(x, 0, 100); // Fix!"
-        }
-      ]
+      "description": "This message is shown when a call to a non-existent script or function is made. This may be shown if you typo the function name, or have deleted the function.",
+      "badExample": "function make_game(_genre) { /* ... */ }\n\n    make_gaem(\"RPG\"); // GM1021\n\n    var _x = clam(x, 0, 100); // GM1021",
+      "goodExample": "function make_game(_genre) { /* ... */ }\n\n    make_game(\"RPG\"); // Fix!\n\n    var _x = clamp(x, 0, 100); // Fix!",
+      "correction": "Correct any typos, and ensure the functions you're trying to call exist."
     },
     {
       "id": "GM1022",
       "title": "An assignment was expected at this time.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when a variable name is written as the left-hand side of an assignment and isn't followed by the assignment operator <span class=\"inline2\">=</span>.</p>",
-          "text": "This message is shown when a variable name is written as the left-hand side of an assignment and isn't followed by the assignment operator =."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Note that this does not apply to the <span class=\"inline2\">var</span> statement, as <span class=\"inline2\">var a;</span> suffices as a declaration.</p>",
-          "text": "Note that this does not apply to the var statement, as var a; suffices as a declaration."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">username &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;// Error!<br>\n    // OR<br>\n    username; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; // Error!</p>",
-          "text": "username                                // Error!\n\n    // OR\n\n    username;                               // Error!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>An identifier cannot stand on its own in a statement. The issue can be fixed by using it in an assignment or by calling it as a function (in case it refers to a valid script function).</p>",
-          "text": "An identifier cannot stand on its own in a statement. The issue can be fixed by using it in an assignment or by calling it as a function (in case it refers to a valid script function)."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">username = get_string(\"Username:\", \"\"); // Valid Assignment!<br>\n    username(); // Function Call is also possible</p>",
-          "text": "username = get_string(\"Username:\", \"\"); // Valid Assignment!\n\n    username(); // Function Call is also possible"
-        }
-      ]
+      "description": "This message is shown when a variable name is written as the left-hand side of an assignment and isn't followed by the assignment operator =.\n\nNote that this does not apply to the var statement, as var a; suffices as a declaration.",
+      "badExample": "username                                // Error!\n\n    // OR\n\n    username;                               // Error!",
+      "goodExample": "username = get_string(\"Username:\", \"\"); // Valid Assignment!\n\n    username(); // Function Call is also possible",
+      "correction": "An identifier cannot stand on its own in a statement. The issue can be fixed by using it in an assignment or by calling it as a function (in case it refers to a valid script function)."
     },
     {
       "id": "GM1023",
       "title": "The constant 'BUILT-IN CONSTANT' is deprecated and usage is discouraged.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you're using a built-in constant that is deprecated.</p>",
-          "text": "This message indicates that you're using a built-in constant that is deprecated."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Deprecation means that while the constant&nbsp;is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update&nbsp;<span data-keyref=\"GameMaker Name\">GameMaker</span> to newer versions.</p>",
-          "text": "Deprecation means that while the constant is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">if (os_type == os_win32) { // GM1023 - Constant 'os_win32' is deprecated<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 0;<br>\n    }<br>\n    else if (os_type == os_macosx) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 1;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 2;<br>\n    }</p>",
-          "text": "if (os_type == os_win32) { // GM1023 - Constant 'os_win32' is deprecated\n\n        global.config = 0;\n\n    }\n\n    else if (os_type == os_macosx) {\n\n        global.config = 1;\n\n        global.config = 2;\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Depending on the constant, a replacement may be available. Check the manual to see if the page mentions this replacement. For the above example, the modern constant is <span class=\"inline2\">os_windows</span>&nbsp;(as to not imply a difference between detection of 32-bit and 64-bit Windows).</p>",
-          "text": "Depending on the constant, a replacement may be available. Check the manual to see if the page mentions this replacement. For the above example, the modern constant is os_windows (as to not imply a difference between detection of 32-bit and 64-bit Windows)."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">if (os_type == os_windows) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 0;<br>\n    }<br>\n    else if (os_type == os_macosx) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 1;<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;global.config = 2;<br>\n    }</p>",
-          "text": "if (os_type == os_windows) {\n\n        global.config = 0;\n\n    }\n\n    else if (os_type == os_macosx) {\n\n        global.config = 1;\n\n        global.config = 2;\n\n    }"
-        }
-      ]
+      "description": "This message indicates that you're using a built-in constant that is deprecated.\n\nDeprecation means that while the constant is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions.",
+      "badExample": "if (os_type == os_win32) { // GM1023 - Constant 'os_win32' is deprecated\n\n        global.config = 0;\n\n    }\n\n    else if (os_type == os_macosx) {\n\n        global.config = 1;\n\n        global.config = 2;\n\n    }",
+      "goodExample": "if (os_type == os_windows) {\n\n        global.config = 0;\n\n    }\n\n    else if (os_type == os_macosx) {\n\n        global.config = 1;\n\n        global.config = 2;\n\n    }",
+      "correction": "Depending on the constant, a replacement may be available. Check the manual to see if the page mentions this replacement. For the above example, the modern constant is os_windows (as to not imply a difference between detection of 32-bit and 64-bit Windows)."
     },
     {
       "id": "GM1024",
       "title": "The built-in variable 'BUILT-IN VARIABLE' is deprecated and usage is discouraged.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you're using a built-in variable that is deprecated.</p>",
-          "text": "This message indicates that you're using a built-in variable that is deprecated."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Deprecation means that while the variable is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update&nbsp;<span data-keyref=\"GameMaker Name\">GameMaker</span> to newer versions.</p>",
-          "text": "Deprecation means that while the variable is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    score = 0;<br>\n    <br>\n    /// Step Event<br>\n    var _ins =&nbsp;instance_position(mouse_x, mouse_y, obj_balloon);<br>\n    if (_ins != noone)<br>\n    {<br>\n    &nbsp; &nbsp; score++;<br>\n    &nbsp; &nbsp; instance_destroy(_ins);<br>\n    }\n  </p>",
-          "text": "/// Create Event\n\n    score = 0;\n\n\n\n    /// Step Event\n\n    var _ins = instance_position(mouse_x, mouse_y, obj_balloon);\n\n    if (_ins != noone)\n\n    {\n\n        score++;\n\n        instance_destroy(_ins);\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Replace the variable with a custom variable or a macro, depending on what works best in the specific case.</p>",
-          "text": "Replace the variable with a custom variable or a macro, depending on what works best in the specific case."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    points = 0;<br>\n    <br>\n    /// Step Event<br>\n    var _ins =&nbsp;instance_position(mouse_x, mouse_y, obj_balloon);<br>\n    if (_ins != noone)<br>\n    {<br>\n    &nbsp; &nbsp; points++;<br>\n    &nbsp; &nbsp; instance_destroy(_ins);<br>\n    }\n  </p>",
-          "text": "/// Create Event\n\n    points = 0;\n\n\n\n    /// Step Event\n\n    var _ins = instance_position(mouse_x, mouse_y, obj_balloon);\n\n    if (_ins != noone)\n\n    {\n\n        points++;\n\n        instance_destroy(_ins);\n\n    }"
-        }
-      ]
+      "description": "This message indicates that you're using a built-in variable that is deprecated.\n\nDeprecation means that while the variable is still available for usage, it is planned to be removed in the future. Typically when something is deprecated a superior approach exists and is intended to be used instead. You should research what the alternative is and use that instead to avoid your code from breaking when you update GameMaker to newer versions.",
+      "badExample": "/// Create Event\n\n    score = 0;\n\n\n\n    /// Step Event\n\n    var _ins = instance_position(mouse_x, mouse_y, obj_balloon);\n\n    if (_ins != noone)\n\n    {\n\n        score++;\n\n        instance_destroy(_ins);\n\n    }",
+      "goodExample": "/// Create Event\n\n    points = 0;\n\n\n\n    /// Step Event\n\n    var _ins = instance_position(mouse_x, mouse_y, obj_balloon);\n\n    if (_ins != noone)\n\n    {\n\n        points++;\n\n        instance_destroy(_ins);\n\n    }",
+      "correction": "Replace the variable with a custom variable or a macro, depending on what works best in the specific case."
     },
     {
       "id": "GM1025",
       "title": "A number literal was unexpected at this time.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you use a number literal outside of an expression where it cannot be used. It can occur when:</p>",
-          "text": "This message is shown when you use a number literal outside of an expression where it cannot be used. It can occur when:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>A number literal is on its own in a statement</li>\n    <li>A number literal is used as the left-hand side of an assignment</li>\n  </ul>",
-          "text": "A number literal is on its own in a statement\n    A number literal is used as the left-hand side of an assignment"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">#AEF033 // Error! Lone number literal<br>\n    // OR:<br>\n    #AEF033; // Error! Lone number literal<br>\n    // OR:<br>\n    0xFFDE31 = \"value\"; // Error! Left-hand side is not a variable</p>",
-          "text": "#AEF033 // Error! Lone number literal\n\n    // OR:\n\n    #AEF033; // Error! Lone number literal\n\n    // OR:\n\n    0xFFDE31 = \"value\"; // Error! Left-hand side is not a variable"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The number literal has to be used as a function parameter or as the right-hand side of an assignment.</p>",
-          "text": "The number literal has to be used as a function parameter or as the right-hand side of an assignment."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">colour = #AEF033;</p>",
-          "text": "colour = #AEF033;"
-        }
-      ]
+      "description": "This message is shown when you use a number literal outside of an expression where it cannot be used. It can occur when:\n\nA number literal is on its own in a statement\nA number literal is used as the left-hand side of an assignment",
+      "badExample": "#AEF033 // Error! Lone number literal\n\n    // OR:\n\n    #AEF033; // Error! Lone number literal\n\n    // OR:\n\n    0xFFDE31 = \"value\"; // Error! Left-hand side is not a variable",
+      "goodExample": "colour = #AEF033;",
+      "correction": "The number literal has to be used as a function parameter or as the right-hand side of an assignment."
     },
     {
       "id": "GM1026",
       "title": "Left-hand side of postfix expression must be a variable.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you use a postfix increment (<span class=\"inline2\">var++</span>) or decrement operator (<span class=\"inline2\">var--</span>) on something that is not a variable. More precisely, it must be possible to assign to that which you'd normally write on the left-hand side of the equivalent equation:</p>",
-          "text": "This message is shown when you use a postfix increment (var++) or decrement operator (var--) on something that is not a variable. More precisely, it must be possible to assign to that which you'd normally write on the left-hand side of the equivalent equation:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vari = vari + 1;&nbsp; &nbsp; // Equivalent of vari++; - Variable can be written to and so can go on the left-hand side<br>\n    <br>\n    pi = pi + 1; &nbsp; &nbsp; &nbsp;// Equivalent of pi++; - Constant cannot be written to so cannot go on left-hand side\n  </p>",
-          "text": "vari = vari + 1;    // Equivalent of vari++; - Variable can be written to and so can go on the left-hand side\n\n\n\n    pi = pi + 1;      // Equivalent of pi++; - Constant cannot be written to so cannot go on left-hand side"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">pi++; &nbsp; &nbsp;// GM1026 Cannot increment a constant<br>\n    // OR:<br>\n    show_debug_message--; // GM1026 Cannot decrement a function name</p>",
-          "text": "pi++;    // GM1026 Cannot increment a constant\n\n    // OR:\n\n    show_debug_message--; // GM1026 Cannot decrement a function name"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example, <span class=\"inline2\">pi</span> is a constant and cannot be changed by definition. <span class=\"inline2\">show_debug_message()</span> is a function and is not a number which can be incremented/decremented. If you want to perform these operations you must first ensure the value is assigned to a variable.</p>",
-          "text": "In the code example, pi is a constant and cannot be changed by definition. show_debug_message() is a function and is not a number which can be incremented/decremented. If you want to perform these operations you must first ensure the value is assigned to a variable."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _pi = pi;<br>\n    _pi++;</p>",
-          "text": "var _pi = pi;\n\n    _pi++;"
-        }
-      ]
+      "description": "This message is shown when you use a postfix increment (var++) or decrement operator (var--) on something that is not a variable. More precisely, it must be possible to assign to that which you'd normally write on the left-hand side of the equivalent equation:\n\nvari = vari + 1;    // Equivalent of vari++; - Variable can be written to and so can go on the left-hand side\n\n\n\n    pi = pi + 1;      // Equivalent of pi++; - Constant cannot be written to so cannot go on left-hand side",
+      "badExample": "pi++;    // GM1026 Cannot increment a constant\n\n    // OR:\n\n    show_debug_message--; // GM1026 Cannot decrement a function name",
+      "goodExample": "var _pi = pi;\n\n    _pi++;",
+      "correction": "In the code example, pi is a constant and cannot be changed by definition. show_debug_message() is a function and is not a number which can be incremented/decremented. If you want to perform these operations you must first ensure the value is assigned to a variable."
     },
     {
       "id": "GM1027",
       "title": "A string literal was unexpected at this time.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when a string literal exists outside of a valid expression.</p>",
-          "text": "This message is shown when a string literal exists outside of a valid expression."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">\"this is a string\" // GM1027! A lone string!</p>",
-          "text": "\"this is a string\" // GM1027! A lone string!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The string literal should be assigned to a variable, or compared to a variable, or passed as an argument to a function call.</p>",
-          "text": "The string literal should be assigned to a variable, or compared to a variable, or passed as an argument to a function call."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">text = \"this is a string\";<br>\n    if (text == \"this is a string\")<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"this is a string\");<br>\n    }</p>",
-          "text": "text = \"this is a string\";\n\n    if (text == \"this is a string\")\n\n    {\n\n        show_debug_message(\"this is a string\");\n\n    }"
-        }
-      ]
+      "description": "This message is shown when a string literal exists outside of a valid expression.",
+      "badExample": "\"this is a string\" // GM1027! A lone string!",
+      "goodExample": "text = \"this is a string\";\n\n    if (text == \"this is a string\")\n\n    {\n\n        show_debug_message(\"this is a string\");\n\n    }",
+      "correction": "The string literal should be assigned to a variable, or compared to a variable, or passed as an argument to a function call."
     },
     {
       "id": "GM1028",
       "title": "Accessor is intended for type of 'TYPE' but 'TYPE' appears instead.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you address an element of a data structure using the accessor syntax and don't use the right operator for the data structure's type. Each type of data structure has its own accessor symbol that is used with it. See&nbsp;<a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Accessors.htm\">Accessors</a> for the full list.</p>",
-          "text": "This message is shown when you address an element of a data structure using the accessor syntax and don't use the right operator for the data structure's type. Each type of data structure has its own accessor symbol that is used with it. See Accessors for the full list."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Possible causes of this error can be:</p>",
-          "text": "Possible causes of this error can be:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>You've accidentally used the wrong accessor for the type of data structure you're accessing.</li>\n    <li>You forgot the accessor symbol. In this case the lookup is interpreted as an array lookup.</li>\n  </ul>",
-          "text": "You've accidentally used the wrong accessor for the type of data structure you're accessing.\n    You forgot the accessor symbol. In this case the lookup is interpreted as an array lookup."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">lst_instances = ds_list_create();<br>\n    if&nbsp;(instance_place_list(x, y, obj_enemy, lst_instances, true))<br>\n    {<br>\n    &nbsp; &nbsp; var _ins = lst_instances[? 0]; // GM1028! Wrong accessor<br>\n    &nbsp; &nbsp; show_debug_message($\"The&nbsp;closest&nbsp;instance is&nbsp;{real(_ins)}.\");<br>\n    }</p>",
-          "text": "lst_instances = ds_list_create();\n\n    if (instance_place_list(x, y, obj_enemy, lst_instances, true))\n\n    {\n\n        var _ins = lst_instances[? 0]; // GM1028! Wrong accessor\n\n        show_debug_message($\"The closest instance is {real(_ins)}.\");\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, a DS list is populated with instances of an object <span class=\"inline2\">obj_enemy</span>. When there are any instances in the list, the first one is accessed. The pipe character <span class=\"inline2\">|</span> is for accessing DS lists, however the list is incorrectly accessed with a <span class=\"inline2\">?</span>, which is for DS maps. Changing the operator fixes the issue by addressing the data structure using the correct accessor.</p>",
-          "text": "In the code example above, a DS list is populated with instances of an object obj_enemy. When there are any instances in the list, the first one is accessed. The pipe character | is for accessing DS lists, however the list is incorrectly accessed with a ?, which is for DS maps. Changing the operator fixes the issue by addressing the data structure using the correct accessor."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">lst_instances = ds_list_create();<br>\n    if&nbsp;(instance_place_list(x, y, obj_enemy, lst_instances, true))<br>\n    {<br>\n    &nbsp; &nbsp; var _ins = lst_instances[| 0]; // Good!<br>\n    &nbsp; &nbsp; show_debug_message($\"The closest instance is {real(_ins)}.\");<br>\n    }</p>",
-          "text": "lst_instances = ds_list_create();\n\n    if (instance_place_list(x, y, obj_enemy, lst_instances, true))\n\n    {\n\n        var _ins = lst_instances[| 0]; // Good!\n\n        show_debug_message($\"The closest instance is {real(_ins)}.\");\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you address an element of a data structure using the accessor syntax and don't use the right operator for the data structure's type. Each type of data structure has its own accessor symbol that is used with it. See Accessors for the full list.\n\nPossible causes of this error can be:\n\nYou've accidentally used the wrong accessor for the type of data structure you're accessing.\nYou forgot the accessor symbol. In this case the lookup is interpreted as an array lookup.",
+      "badExample": "lst_instances = ds_list_create();\n\n    if (instance_place_list(x, y, obj_enemy, lst_instances, true))\n\n    {\n\n        var _ins = lst_instances[? 0]; // GM1028! Wrong accessor\n\n        show_debug_message($\"The closest instance is {real(_ins)}.\");\n\n    }",
+      "goodExample": "lst_instances = ds_list_create();\n\n    if (instance_place_list(x, y, obj_enemy, lst_instances, true))\n\n    {\n\n        var _ins = lst_instances[| 0]; // Good!\n\n        show_debug_message($\"The closest instance is {real(_ins)}.\");\n\n    }",
+      "correction": "In the code example above, a DS list is populated with instances of an object obj_enemy. When there are any instances in the list, the first one is accessed. The pipe character | is for accessing DS lists, however the list is incorrectly accessed with a ?, which is for DS maps. Changing the operator fixes the issue by addressing the data structure using the correct accessor."
     },
     {
       "id": "GM1029",
       "title": "Potentially dangerous or unintended implicit cast from 'TYPE' to 'TYPE'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you pass an argument to a function parameter whose type differs from the type expected, but can and will be converted to the expected. While legal, this tends to be unfavourable code as the runtime&nbsp;does its best guess as to how the data should be converted which may lead to unexpected bugs or errors. For example, passing the string <span class=\"inline2\">\"1234\"</span> to <span class=\"inline2\">draw_sprite()</span>'s 3rd parameter <span class=\"inline2\">x</span> is legal, the runtime will convert the String to the Real of the same value. However, if the string value could not convert to a type Real value then you would encounter a runtime error. The cast is implicit since the runtime does it for you instead of you calling the <span class=\"inline2\">real()</span> built-in function, and it's dangerous because it may or may not crash at runtime depending on how sanitary you keep your data.</p>",
-          "text": "This message is shown when you pass an argument to a function parameter whose type differs from the type expected, but can and will be converted to the expected. While legal, this tends to be unfavourable code as the runtime does its best guess as to how the data should be converted which may lead to unexpected bugs or errors. For example, passing the string \"1234\" to draw_sprite()'s 3rd parameter x is legal, the runtime will convert the String to the Real of the same value. However, if the string value could not convert to a type Real value then you would encounter a runtime error. The cast is implicit since the runtime does it for you instead of you calling the real() built-in function, and it's dangerous because it may or may not crash at runtime depending on how sanitary you keep your data."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _x = \"1234\";<br>\n    var _y = \"4321\";<br>\n    draw_sprite(sprite_index, image_index, _x, _y); //&nbsp;GM1029</p>",
-          "text": "var _x = \"1234\";\n\n    var _y = \"4321\";\n\n    draw_sprite(sprite_index, image_index, _x, _y); // GM1029"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix for this message is to either make the cast explicit using one of the built-in functions (e.g. <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Strings/string.htm\">string</a></span>, <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Variable_Functions/real.htm\">real</a></span>, etc.) or to rewrite the code so that you do not depend on the dangerous usage of that data type.</p>",
-          "text": "The fix for this message is to either make the cast explicit using one of the built-in functions (e.g. string, real, etc.) or to rewrite the code so that you do not depend on the dangerous usage of that data type."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _x = 1234;<br>\n    var _y = y;<br>\n    draw_sprite(sprite_index, image_index, _x, real(_y)); // Fix!</p>",
-          "text": "var _x = 1234;\n\n    var _y = y;\n\n    draw_sprite(sprite_index, image_index, _x, real(_y)); // Fix!"
-        }
-      ]
+      "description": "This message is shown when you pass an argument to a function parameter whose type differs from the type expected, but can and will be converted to the expected. While legal, this tends to be unfavourable code as the runtime does its best guess as to how the data should be converted which may lead to unexpected bugs or errors. For example, passing the string \"1234\" to draw_sprite()'s 3rd parameter x is legal, the runtime will convert the String to the Real of the same value. However, if the string value could not convert to a type Real value then you would encounter a runtime error. The cast is implicit since the runtime does it for you instead of you calling the real() built-in function, and it's dangerous because it may or may not crash at runtime depending on how sanitary you keep your data.",
+      "badExample": "var _x = \"1234\";\n\n    var _y = \"4321\";\n\n    draw_sprite(sprite_index, image_index, _x, _y); // GM1029",
+      "goodExample": "var _x = 1234;\n\n    var _y = y;\n\n    draw_sprite(sprite_index, image_index, _x, real(_y)); // Fix!",
+      "correction": "The fix for this message is to either make the cast explicit using one of the built-in functions (e.g. string, real, etc.) or to rewrite the code so that you do not depend on the dangerous usage of that data type."
     },
     {
       "id": "GM1030",
       "title": "The identifier 'NAME' is reserved and cannot be used as a variable or macro name.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>Some identifier names are reserved by the compiler and runtime and cannot be used in local or static variable declarations or in macro declarations. Keep in mind that in Constructor Function scopes some built-in variables are actually available for usage since they do not resolve to a built-in in those places. These tend to be built-in variables that modify some property of an Object such as <span class=\"inline2\">sprite_index</span>, or <span class=\"inline2\">x</span> and <span class=\"inline2\">y</span>.</p>",
-          "text": "Some identifier names are reserved by the compiler and runtime and cannot be used in local or static variable declarations or in macro declarations. Keep in mind that in Constructor Function scopes some built-in variables are actually available for usage since they do not resolve to a built-in in those places. These tend to be built-in variables that modify some property of an Object such as sprite_index, or x and y."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var image_index = 1; // GM1030<br>\n    function SpriteData() constructor {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var image_index = 1; //&nbsp;Good!<br>\n    }</p>",
-          "text": "var image_index = 1; // GM1030\n\n    function SpriteData() constructor {\n\n        var image_index = 1; // Good!\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix is to find another, non-conflicting name to use for your variable instead.</p>",
-          "text": "The fix is to find another, non-conflicting name to use for your variable instead."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _image_index = 1; // Fix!<br>\n    function SpriteData() constructor {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;var image_index = 1; // Good!<br>\n    }</p>",
-          "text": "var _image_index = 1; // Fix!\n\n    function SpriteData() constructor {\n\n         var image_index = 1; // Good!\n\n    }"
-        }
-      ]
+      "description": "Some identifier names are reserved by the compiler and runtime and cannot be used in local or static variable declarations or in macro declarations. Keep in mind that in Constructor Function scopes some built-in variables are actually available for usage since they do not resolve to a built-in in those places. These tend to be built-in variables that modify some property of an Object such as sprite_index, or x and y.",
+      "badExample": "var image_index = 1; // GM1030\n\n    function SpriteData() constructor {\n\n        var image_index = 1; // Good!\n\n    }",
+      "goodExample": "var _image_index = 1; // Fix!\n\n    function SpriteData() constructor {\n\n         var image_index = 1; // Good!\n\n    }",
+      "correction": "The fix is to find another, non-conflicting name to use for your variable instead."
     },
     {
       "id": "GM1031",
       "title": "The name 'IDENTIFIER' is an asset or constant and cannot be assigned to.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you try to assign a value to an asset or a constant. Assets and constants cannot be changed and are meant to be used stand alone on the right-hand side of statements, in conditionals, or in expressions.</p>",
-          "text": "This message is shown when you try to assign a value to an asset or a constant. Assets and constants cannot be changed and are meant to be used stand alone on the right-hand side of statements, in conditionals, or in expressions."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">obj_control = 75; // GM1035! Cannot assign value to Asset type<br>\n    pi = 1.618; // GM1035! Cannot assign value to constant</p>",
-          "text": "obj_control = 75; // GM1035! Cannot assign value to Asset type\n\n    pi = 1.618; // GM1035! Cannot assign value to constant"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Depending on the intention, either the name of the variable to be assigned to can be changed or the asset or constant should be moved to the right-hand side of the assignment.</p>",
-          "text": "Depending on the intention, either the name of the variable to be assigned to can be changed or the asset or constant should be moved to the right-hand side of the assignment."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">control = 75;<br>\n    value = pi;</p>",
-          "text": "control = 75;\n\n    value = pi;"
-        }
-      ]
+      "description": "This message is shown when you try to assign a value to an asset or a constant. Assets and constants cannot be changed and are meant to be used stand alone on the right-hand side of statements, in conditionals, or in expressions.",
+      "badExample": "obj_control = 75; // GM1035! Cannot assign value to Asset type\n\n    pi = 1.618; // GM1035! Cannot assign value to constant",
+      "goodExample": "control = 75;\n\n    value = pi;",
+      "correction": "Depending on the intention, either the name of the variable to be assigned to can be changed or the asset or constant should be moved to the right-hand side of the assignment."
     },
     {
       "id": "GM1032",
       "title": "No references to arguments INDEX, … but references argument INDEX",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when referencing an argument in a function via the argument0..argument15 built-in variables, and one or more indices have been skipped. While the arguments may be referenced in any order all indices 0..n must be referenced at least once; where n is the number of arguments in your function. If the code changes so that it no longer accesses e.g. <span class=\"inline2\">argument0</span>, all other arguments need to be changed; <span class=\"inline2\">argument1</span> becomes <span class=\"inline2\">argument0</span>, <span class=\"inline2\">argument2</span> becomes <span class=\"inline2\">argument1</span>, etc.</p>",
-          "text": "This message is shown when referencing an argument in a function via the argument0..argument15 built-in variables, and one or more indices have been skipped. While the arguments may be referenced in any order all indices 0..n must be referenced at least once; where n is the number of arguments in your function. If the code changes so that it no longer accesses e.g. argument0, all other arguments need to be changed; argument1 becomes argument0, argument2 becomes argument1, etc."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See:&nbsp;<a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/argument.htm\">argument</a></p>",
-          "text": "See: argument"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function args() {<br>\n    &nbsp; &nbsp; var _x = argument0;<br>\n    &nbsp; &nbsp; var&nbsp;_y = argument2; // GM1032! Missing reference to argument1<br>\n    }</p>",
-          "text": "function args() {\n\n        var _x = argument0;\n\n        var _y = argument2; // GM1032! Missing reference to argument1\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Replace the argument# variable with the first unused argument# variable.</p>",
-          "text": "Replace the argument# variable with the first unused argument# variable."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function args() {<br>\n    &nbsp; &nbsp; var&nbsp;_x = argument0;<br>\n    &nbsp; &nbsp; var _y = argument1; // Fix!<br>\n    }</p>",
-          "text": "function args() {\n\n        var _x = argument0;\n\n        var _y = argument1; // Fix!\n\n    }"
-        }
-      ]
+      "description": "This message is shown when referencing an argument in a function via the argument0..argument15 built-in variables, and one or more indices have been skipped. While the arguments may be referenced in any order all indices 0..n must be referenced at least once; where n is the number of arguments in your function. If the code changes so that it no longer accesses e.g. argument0, all other arguments need to be changed; argument1 becomes argument0, argument2 becomes argument1, etc.\n\nSee: argument",
+      "badExample": "function args() {\n\n        var _x = argument0;\n\n        var _y = argument2; // GM1032! Missing reference to argument1\n\n    }",
+      "goodExample": "function args() {\n\n        var _x = argument0;\n\n        var _y = argument1; // Fix!\n\n    }",
+      "correction": "Replace the argument# variable with the first unused argument# variable."
     },
     {
       "id": "GM1033",
       "title": "Possibly unintended or misplaced semicolon.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when there is a semicolon in the code that might be unnecessary at that position.</p>",
-          "text": "This message is shown when there is a semicolon in the code that might be unnecessary at that position."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = 3434;;</p>",
-          "text": "var _a = 3434;;"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The double semicolon is not needed and can be removed.</p>",
-          "text": "The double semicolon is not needed and can be removed."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _a = 3434;</p>",
-          "text": "var _a = 3434;"
-        }
-      ]
+      "description": "This message is shown when there is a semicolon in the code that might be unnecessary at that position.",
+      "badExample": "var _a = 3434;;",
+      "goodExample": "var _a = 3434;",
+      "correction": "The double semicolon is not needed and can be removed."
     },
     {
       "id": "GM1034",
       "title": "Argument cannot be referenced outside of script or function.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that one of the built-in variables <span class=\"inline2\">argument0</span> - <span class=\"inline2\">argument15</span> or the built-in variable argument (<span class=\"inline2\">argument[0]</span>, <span class=\"inline2\">argument[1]</span>, etc.) has been referenced outside of the scope of a function or script. These built-in variables are only legal inside functions, i.e. inside the opening and closing curly braces.</p>",
-          "text": "This message indicates that one of the built-in variables argument0 - argument15 or the built-in variable argument (argument[0], argument[1], etc.) has been referenced outside of the scope of a function or script. These built-in variables are only legal inside functions, i.e. inside the opening and closing curly braces."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function args()<br>\n    {<br>\n    &nbsp; &nbsp;&nbsp;<br>\n    }<br>\n    var _first_parameter = argument[0];<br>\n    var _second_parameter = argument[1];</p>",
-          "text": "function args()\n\n    {\n\n\n\n    }\n\n    var _first_parameter = argument[0];\n\n    var _second_parameter = argument[1];"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In this case the reference of the built-in variables is intended, they should be moved inside the curly braces. If the references aren't intended to be used, they should be removed.</p>",
-          "text": "In this case the reference of the built-in variables is intended, they should be moved inside the curly braces. If the references aren't intended to be used, they should be removed."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function args()<br>\n    {<br>\n    &nbsp; &nbsp; var _first_parameter = argument[0];<br>\n    &nbsp; &nbsp; var _second_parameter = argument[1];<br>\n    }</p>",
-          "text": "function args()\n\n    {\n\n        var _first_parameter = argument[0];\n\n        var _second_parameter = argument[1];\n\n    }"
-        }
-      ]
+      "description": "This message indicates that one of the built-in variables argument0 - argument15 or the built-in variable argument (argument[0], argument[1], etc.) has been referenced outside of the scope of a function or script. These built-in variables are only legal inside functions, i.e. inside the opening and closing curly braces.",
+      "badExample": "function args()\n\n    {\n\n\n\n    }\n\n    var _first_parameter = argument[0];\n\n    var _second_parameter = argument[1];",
+      "goodExample": "function args()\n\n    {\n\n        var _first_parameter = argument[0];\n\n        var _second_parameter = argument[1];\n\n    }",
+      "correction": "In this case the reference of the built-in variables is intended, they should be moved inside the curly braces. If the references aren't intended to be used, they should be removed."
     },
     {
       "id": "GM1035",
       "title": "Return type differs from previously established return type.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when your JSDoc differs from the type returned in code or if Feather determines that you've returned multiple different non-compatible types from the same function. A non-compatible type would be something like Real, and String both being returned from the same function. Where something like Real, and Undefined might be compatible since <span class=\"inline2\">undefined</span> is commonly used to indicate no result. Returning different types of data is sometimes a valid strategy but it is typically dangerous since consuming code may assume that only one type of data will be returned, which may result in runtime errors or strange behaviour in the calling code.</p>",
-          "text": "This message is shown when your JSDoc differs from the type returned in code or if Feather determines that you've returned multiple different non-compatible types from the same function. A non-compatible type would be something like Real, and String both being returned from the same function. Where something like Real, and Undefined might be compatible since undefined is commonly used to indicate no result. Returning different types of data is sometimes a valid strategy but it is typically dangerous since consuming code may assume that only one type of data will be returned, which may result in runtime errors or strange behaviour in the calling code."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @returns {real}<br>\n    function get_random_number() {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return \"1\"; // GM1035!<br>\n    }<br>\n    function get_random_number2() { // no JSDoc here<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;if (irandom(100) &lt; 50)<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; return 0; // Return type is established here as 'Real'<br>\n    &nbsp; &nbsp; return \"1\"; // GM1035!<br>\n    }</p>",
-          "text": "/// @returns {real}\n\n    function get_random_number() {\n\n        return \"1\"; // GM1035!\n\n    }\n\n    function get_random_number2() { // no JSDoc here\n\n        if (irandom(100) < 50)\n\n            return 0; // Return type is established here as 'Real'\n\n        return \"1\"; // GM1035!\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix for this is to either update your JSDoc accordingly, or to rewrite your code to ensure that the same type is returned from all return statements.</p>",
-          "text": "The fix for this is to either update your JSDoc accordingly, or to rewrite your code to ensure that the same type is returned from all return statements."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @returns {string}<br>\n    function get_random_number() {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return \"1\"; // Fixed! But maybe rename the function!<br>\n    }<br>\n    function get_random_number2() { // no JSDoc here<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;if (irandom(100) &lt; 50)<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; return 0; // Return type is established here as 'Real'<br>\n    &nbsp; &nbsp; return 1; // Fix!<br>\n    }</p>",
-          "text": "/// @returns {string}\n\n    function get_random_number() {\n\n        return \"1\"; // Fixed! But maybe rename the function!\n\n    }\n\n    function get_random_number2() { // no JSDoc here\n\n        if (irandom(100) < 50)\n\n            return 0; // Return type is established here as 'Real'\n\n        return 1; // Fix!\n\n    }"
-        }
-      ]
+      "description": "This message is shown when your JSDoc differs from the type returned in code or if Feather determines that you've returned multiple different non-compatible types from the same function. A non-compatible type would be something like Real, and String both being returned from the same function. Where something like Real, and Undefined might be compatible since undefined is commonly used to indicate no result. Returning different types of data is sometimes a valid strategy but it is typically dangerous since consuming code may assume that only one type of data will be returned, which may result in runtime errors or strange behaviour in the calling code.",
+      "badExample": "/// @returns {real}\n\n    function get_random_number() {\n\n        return \"1\"; // GM1035!\n\n    }\n\n    function get_random_number2() { // no JSDoc here\n\n        if (irandom(100) < 50)\n\n            return 0; // Return type is established here as 'Real'\n\n        return \"1\"; // GM1035!\n\n    }",
+      "goodExample": "/// @returns {string}\n\n    function get_random_number() {\n\n        return \"1\"; // Fixed! But maybe rename the function!\n\n    }\n\n    function get_random_number2() { // no JSDoc here\n\n        if (irandom(100) < 50)\n\n            return 0; // Return type is established here as 'Real'\n\n        return 1; // Fix!\n\n    }",
+      "correction": "The fix for this is to either update your JSDoc accordingly, or to rewrite your code to ensure that the same type is returned from all return statements."
     },
     {
       "id": "GM1036",
       "title": "Array cannot be indexed in this way.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown if you index into an array with either 0 indices, or too many indices for the dimensionality of the array. Keep in mind that the 2D array syntax is deprecated in favour of staggered array indexing.</p>",
-          "text": "This message is shown if you index into an array with either 0 indices, or too many indices for the dimensionality of the array. Keep in mind that the 2D array syntax is deprecated in favour of staggered array indexing."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function choose2d() {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _x = irandom(argument_count);<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _y = irandom(argument_count);<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return argument[_x, _y]; // GM1036! argument array is not 2d<br>\n    }<br>\n    var _arr = [ 1, 2, 3, 4&nbsp;];<br>\n    var _idx = _arr[]; //&nbsp;GM1036!</p>",
-          "text": "function choose2d() {\n\n        var _x = irandom(argument_count);\n\n        var _y = irandom(argument_count);\n\n        return argument[_x, _y]; // GM1036! argument array is not 2d\n\n    }\n\n    var _arr = [ 1, 2, 3, 4 ];\n\n    var _idx = _arr[]; // GM1036!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix for this issue is to either provide the index, or to rethink how you're accessing the array.</p>",
-          "text": "The fix for this issue is to either provide the index, or to rethink how you're accessing the array."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function choose2d(_arr) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _x = irandom(array_height_2d(_arr));<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;var _y = irandom(array_length_2d(_arr));<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return _arr[_x, _y]; // Fix! Keep in mind this syntax is deprecated<br>\n    }<br>\n    var _arr = [ 1, 2, 3, 4&nbsp;];<br>\n    var _idx = _arr[0]; // Fix!</p>",
-          "text": "function choose2d(_arr) {\n\n        var _x = irandom(array_height_2d(_arr));\n\n        var _y = irandom(array_length_2d(_arr));\n\n        return _arr[_x, _y]; // Fix! Keep in mind this syntax is deprecated\n\n    }\n\n    var _arr = [ 1, 2, 3, 4 ];\n\n    var _idx = _arr[0]; // Fix!"
-        }
-      ]
+      "description": "This message is shown if you index into an array with either 0 indices, or too many indices for the dimensionality of the array. Keep in mind that the 2D array syntax is deprecated in favour of staggered array indexing.",
+      "badExample": "function choose2d() {\n\n        var _x = irandom(argument_count);\n\n        var _y = irandom(argument_count);\n\n        return argument[_x, _y]; // GM1036! argument array is not 2d\n\n    }\n\n    var _arr = [ 1, 2, 3, 4 ];\n\n    var _idx = _arr[]; // GM1036!",
+      "goodExample": "function choose2d(_arr) {\n\n        var _x = irandom(array_height_2d(_arr));\n\n        var _y = irandom(array_length_2d(_arr));\n\n        return _arr[_x, _y]; // Fix! Keep in mind this syntax is deprecated\n\n    }\n\n    var _arr = [ 1, 2, 3, 4 ];\n\n    var _idx = _arr[0]; // Fix!",
+      "correction": "The fix for this issue is to either provide the index, or to rethink how you're accessing the array."
     },
     {
       "id": "GM1038",
       "title": "Macro with this name has been previously declared.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you defined a macro with the same name before, somewhere in your code. Project-wide search (<span class=\"shortcut\">Ctrl+Alt+F</span>) can be useful in this case to check how many occurrences of the macro are in your project. Look for <span class=\"inline2\">#macro &lt;macro_name&gt;</span> to find all definitions of this macro.</p>",
-          "text": "This message indicates that you defined a macro with the same name before, somewhere in your code. Project-wide search (Ctrl+Alt+F) can be useful in this case to check how many occurrences of the macro are in your project. Look for #macro <macro_name> to find all definitions of this macro."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Script Asset: Debug<br>\n    #macro dbg show_debug_message<br>\n    <br>\n    /// Script Asset: Utility<br>\n    #macro&nbsp;dbg&nbsp;show_debug_message\n  </p>",
-          "text": "/// Script Asset: Debug\n\n    #macro dbg show_debug_message\n\n\n\n    /// Script Asset: Utility\n\n    #macro dbg show_debug_message"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Remove all duplicate macro definitions until there is one left.</p>",
-          "text": "Remove all duplicate macro definitions until there is one left."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Script Asset: Debug<br>\n    #macro dbg show_debug_message</p>",
-          "text": "/// Script Asset: Debug\n\n    #macro dbg show_debug_message"
-        }
-      ]
+      "description": "This message indicates that you defined a macro with the same name before, somewhere in your code. Project-wide search (Ctrl+Alt+F) can be useful in this case to check how many occurrences of the macro are in your project. Look for #macro <macro_name> to find all definitions of this macro.",
+      "badExample": "/// Script Asset: Debug\n\n    #macro dbg show_debug_message\n\n\n\n    /// Script Asset: Utility\n\n    #macro dbg show_debug_message",
+      "goodExample": "/// Script Asset: Debug\n\n    #macro dbg show_debug_message",
+      "correction": "Remove all duplicate macro definitions until there is one left."
     },
     {
       "id": "GM1040",
       "title": "argument# and argument[#] referencing cannot be mixed.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that the <span class=\"inline2\">argument</span> array variable and <span class=\"inline2\">argument0</span> - <span class=\"inline2\">argument15</span> variables are used together in a function. The former is used in functions that support a variable number of arguments, the latter is used when you know the number of arguments in advance. In any function, you should only ever use one of the two.</p>",
-          "text": "This message indicates that the argument array variable and argument0 - argument15 variables are used together in a function. The former is used in functions that support a variable number of arguments, the latter is used when you know the number of arguments in advance. In any function, you should only ever use one of the two."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See: <a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/argument.htm\">argument</a></p>",
-          "text": "See: argument"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function func()<br>\n    {<br>\n    &nbsp; &nbsp;var _a = argument0;<br>\n    &nbsp; &nbsp;var _b = argument[1];<br>\n    }</p>",
-          "text": "function func()\n\n    {\n\n       var _a = argument0;\n\n       var _b = argument[1];\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Change all argument[n]/argumentn variables to the same type of referencing, depending on what's needed in the function.</p>",
-          "text": "Change all argument[n]/argumentn variables to the same type of referencing, depending on what's needed in the function."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function func()<br>\n    {<br>\n    &nbsp; &nbsp;var _a = argument0;<br>\n    &nbsp; &nbsp;var _b = argument1;<br>\n    }<br>\n    // OR:<br>\n    function&nbsp;func()<br>\n    {<br>\n    &nbsp; &nbsp;var&nbsp;_a&nbsp;=&nbsp;argument[0];<br>\n    &nbsp; &nbsp;var&nbsp;_b&nbsp;=&nbsp;argument[1];<br>\n    }</p>",
-          "text": "function func()\n\n    {\n\n       var _a = argument0;\n\n       var _b = argument1;\n\n    }\n\n    // OR:\n\n    function func()\n\n    {\n\n       var _a = argument[0];\n\n       var _b = argument[1];\n\n    }"
-        }
-      ]
+      "description": "This message indicates that the argument array variable and argument0 - argument15 variables are used together in a function. The former is used in functions that support a variable number of arguments, the latter is used when you know the number of arguments in advance. In any function, you should only ever use one of the two.\n\nSee: argument",
+      "badExample": "function func()\n\n    {\n\n       var _a = argument0;\n\n       var _b = argument[1];\n\n    }",
+      "goodExample": "function func()\n\n    {\n\n       var _a = argument0;\n\n       var _b = argument1;\n\n    }\n\n    // OR:\n\n    function func()\n\n    {\n\n       var _a = argument[0];\n\n       var _b = argument[1];\n\n    }",
+      "correction": "Change all argument[n]/argumentn variables to the same type of referencing, depending on what's needed in the function."
     },
     {
       "id": "GM1041",
       "title": "The type 'TYPE' appears where the type 'TYPE' is expected.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you pass an argument to a function call's parameter of a different type. For example, passing a <span class=\"inline2\">Id.Instance</span> to a <span class=\"inline2\">String</span> parameter.</p>",
-          "text": "This message is shown when you pass an argument to a function call's parameter of a different type. For example, passing a Id.Instance to a String parameter."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _inst = instance_create_depth(x, y, -100, \"obj_player\"); //&nbsp;GM1041!</p>",
-          "text": "var _inst = instance_create_depth(x, y, -100, \"obj_player\"); // GM1041!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix is to determine what the correct type to pass to the parameter is, and rewrite your code accordingly.</p>",
-          "text": "The fix is to determine what the correct type to pass to the parameter is, and rewrite your code accordingly."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _inst = instance_create_depth(x, y, -100, obj_player); // Fix!</p>",
-          "text": "var _inst = instance_create_depth(x, y, -100, obj_player); // Fix!"
-        }
-      ]
+      "description": "This message is shown when you pass an argument to a function call's parameter of a different type. For example, passing a Id.Instance to a String parameter.",
+      "badExample": "var _inst = instance_create_depth(x, y, -100, \"obj_player\"); // GM1041!",
+      "goodExample": "var _inst = instance_create_depth(x, y, -100, obj_player); // Fix!",
+      "correction": "The fix is to determine what the correct type to pass to the parameter is, and rewrite your code accordingly."
     },
     {
       "id": "GM1042",
       "title": "Parameter name 'PARAMETER' differs from 'PARAMETER' specified in jsdoc.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when there is a difference between a function's parameter name in the JSDoc and its corresponding parameter name in the argument list. This could have a couple of causes:</p>",
-          "text": "This message is shown when there is a difference between a function's parameter name in the JSDoc and its corresponding parameter name in the argument list. This could have a couple of causes:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>There is a typo in the variable name in the JSDoc or in the argument list.</li>\n    <li>You renamed the parameter name in the argument list but not in the JSDoc or vice versa.</li>\n  </ul>",
-          "text": "There is a typo in the variable name in the JSDoc or in the argument list.\n    You renamed the parameter name in the argument list but not in the JSDoc or vice versa."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @func sum(_v1, _v2);<br>\n    /// @desc This function returns the sum of two 3-component vectors<br>\n    /// @arg {Array&lt;Real&gt;} _v1 The first vector<br>\n    /// @arg {Array&lt;Real&gt;} _v2 The second vector<br>\n    function&nbsp;sum(_v, _v2)<br>\n    {<br>\n    &nbsp; &nbsp; return [<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[0] + _v2[0],<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[1] + _v2[1],<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[2] + _v2[2]<br>\n    &nbsp; &nbsp; ];<br>\n    }</p>",
-          "text": "/// @func sum(_v1, _v2);\n\n    /// @desc This function returns the sum of two 3-component vectors\n\n    /// @arg {Array<Real>} _v1 The first vector\n\n    /// @arg {Array<Real>} _v2 The second vector\n\n    function sum(_v, _v2)\n\n    {\n\n        return [\n\n            _v1[0] + _v2[0],\n\n            _v1[1] + _v2[1],\n\n            _v1[2] + _v2[2]\n\n        ];\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To fix this issue you need to change the incorrectly named variable to the correct one to make sure both names correspond.</p>",
-          "text": "To fix this issue you need to change the incorrectly named variable to the correct one to make sure both names correspond."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @func sum(_v1, _v2);<br>\n    /// @desc This function returns the sum of two 3-component vectors<br>\n    /// @arg {Array&lt;Real&gt;} _v1 The first vector<br>\n    /// @arg {Array&lt;Real&gt;} _v2 The second vector<br>\n    function&nbsp;sum(_v1, _v2)<br>\n    {<br>\n    &nbsp; &nbsp; return [<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[0] + _v2[0],<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[1] + _v2[1],<br>\n    &nbsp; &nbsp; &nbsp; &nbsp; _v1[2] + _v2[2]<br>\n    &nbsp; &nbsp; ];<br>\n    }</p>",
-          "text": "/// @func sum(_v1, _v2);\n\n    /// @desc This function returns the sum of two 3-component vectors\n\n    /// @arg {Array<Real>} _v1 The first vector\n\n    /// @arg {Array<Real>} _v2 The second vector\n\n    function sum(_v1, _v2)\n\n    {\n\n        return [\n\n            _v1[0] + _v2[0],\n\n            _v1[1] + _v2[1],\n\n            _v1[2] + _v2[2]\n\n        ];\n\n    }"
-        }
-      ]
+      "description": "This message is shown when there is a difference between a function's parameter name in the JSDoc and its corresponding parameter name in the argument list. This could have a couple of causes:\n\nThere is a typo in the variable name in the JSDoc or in the argument list.\nYou renamed the parameter name in the argument list but not in the JSDoc or vice versa.",
+      "badExample": "/// @func sum(_v1, _v2);\n\n    /// @desc This function returns the sum of two 3-component vectors\n\n    /// @arg {Array<Real>} _v1 The first vector\n\n    /// @arg {Array<Real>} _v2 The second vector\n\n    function sum(_v, _v2)\n\n    {\n\n        return [\n\n            _v1[0] + _v2[0],\n\n            _v1[1] + _v2[1],\n\n            _v1[2] + _v2[2]\n\n        ];\n\n    }",
+      "goodExample": "/// @func sum(_v1, _v2);\n\n    /// @desc This function returns the sum of two 3-component vectors\n\n    /// @arg {Array<Real>} _v1 The first vector\n\n    /// @arg {Array<Real>} _v2 The second vector\n\n    function sum(_v1, _v2)\n\n    {\n\n        return [\n\n            _v1[0] + _v2[0],\n\n            _v1[1] + _v2[1],\n\n            _v1[2] + _v2[2]\n\n        ];\n\n    }",
+      "correction": "To fix this issue you need to change the incorrectly named variable to the correct one to make sure both names correspond."
     },
     {
       "id": "GM1043",
       "title": "Potentially unintentional type reassignment from '{0}' to '{1}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you assign a new value to an existing variable and the type of the new value is different from the type that the variable currently holds.</p>",
-          "text": "This message is shown when you assign a new value to an existing variable and the type of the new value is different from the type that the variable currently holds."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This may not cause any issues, though it could make it more difficult to interpret your GML code correctly when you use the same variable name multiple times.</p>",
-          "text": "This may not cause any issues, though it could make it more difficult to interpret your GML code correctly when you use the same variable name multiple times."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>It is good practice to keep the data type that you store in a variable constant, even though&nbsp;<span data-keyref=\"GameMaker Name\">GameMaker</span> doesn't enforce this in any way.</p>",
-          "text": "It is good practice to keep the data type that you store in a variable constant, even though GameMaker doesn't enforce this in any way."
-        },
-        {
-          "type": "html",
-          "html": "<div data-conref=\"../../assets/snippets/Feather_rule_only_shown_when_strict_mode.hts\"> </div>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Store a real number in my_var<br>\n    my_var = 5;<br>\n    <br>\n    // Next store a string in my_var<br>\n    my_var = \"I'm a string\"; &nbsp;// type reassignment!\n  </p>",
-          "text": "// Store a real number in my_var\n\n    my_var = 5;\n\n\n\n    // Next store a string in my_var\n\n    my_var = \"I'm a string\";  // type reassignment!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This issue can be fixed in multiple ways, it depends on what you're trying to do in your code. If the string has a different purpose in your code you could store it in a different variable with an appropriate name.</p>",
-          "text": "This issue can be fixed in multiple ways, it depends on what you're trying to do in your code. If the string has a different purpose in your code you could store it in a different variable with an appropriate name."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Store a real number in my_var<br>\n    my_var = 5;<br>\n    <br>\n    // Store a new real number in my_var<br>\n    my_var = 100;<br>\n    <br>\n    // Store a string in a new variable my_string<br>\n    my_string = \"I'm a string\";\n  </p>",
-          "text": "// Store a real number in my_var\n\n    my_var = 5;\n\n\n\n    // Store a new real number in my_var\n\n    my_var = 100;\n\n\n\n    // Store a string in a new variable my_string\n\n    my_string = \"I'm a string\";"
-        }
-      ]
+      "description": "This message is shown when you assign a new value to an existing variable and the type of the new value is different from the type that the variable currently holds.\n\nThis may not cause any issues, though it could make it more difficult to interpret your GML code correctly when you use the same variable name multiple times.\n\nIt is good practice to keep the data type that you store in a variable constant, even though GameMaker doesn't enforce this in any way.",
+      "badExample": "// Store a real number in my_var\n\n    my_var = 5;\n\n\n\n    // Next store a string in my_var\n\n    my_var = \"I'm a string\";  // type reassignment!",
+      "goodExample": "// Store a real number in my_var\n\n    my_var = 5;\n\n\n\n    // Store a new real number in my_var\n\n    my_var = 100;\n\n\n\n    // Store a string in a new variable my_string\n\n    my_string = \"I'm a string\";",
+      "correction": "This issue can be fixed in multiple ways, it depends on what you're trying to do in your code. If the string has a different purpose in your code you could store it in a different variable with an appropriate name."
     },
     {
       "id": "GM1044",
       "title": "Constant is expected to be one of the following: {0}",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown whenever one constant from a group of constants is expected as an argument and you've provided a value that's not in that group. Examples of these groups of constants are the Mouse Button Constants, the Game Speed Constants&nbsp;and the Primitive Type Constants. A constant from another group or a real number may accidentally work but it is not good practice to use them. Using the right constant in the right place helps increase the readability of your code.</p>",
-          "text": "This message is shown whenever one constant from a group of constants is expected as an argument and you've provided a value that's not in that group. Examples of these groups of constants are the Mouse Button Constants, the Game Speed Constants and the Primitive Type Constants. A constant from another group or a real number may accidentally work but it is not good practice to use them. Using the right constant in the right place helps increase the readability of your code."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Example 1<br>\n    if mouse_check_button_pressed(mb_midle)<br>\n    {<br>\n    }<br>\n    <br>\n    // Example 2<br>\n    if mouse_check_button_pressed(vk_left)<br>\n    {<br>\n    }\n  </p>",
-          "text": "// Example 1\n\n    if mouse_check_button_pressed(mb_midle)\n\n    {\n\n    }\n\n\n\n    // Example 2\n\n    if mouse_check_button_pressed(vk_left)\n\n    {\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>If this was caused by a typo, then fixing the typo fixes it. In other cases the constant needs to be changed to a valid one.</p>",
-          "text": "If this was caused by a typo, then fixing the typo fixes it. In other cases the constant needs to be changed to a valid one."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Example 1<br>\n    if mouse_check_button_pressed(mb_middle)<br>\n    {<br>\n    }<br>\n    <br>\n    // Example 2<br>\n    if mouse_check_button_pressed(mb_left)<br>\n    {<br>\n    }\n  </p>",
-          "text": "// Example 1\n\n    if mouse_check_button_pressed(mb_middle)\n\n    {\n\n    }\n\n\n\n    // Example 2\n\n    if mouse_check_button_pressed(mb_left)\n\n    {\n\n    }"
-        }
-      ]
+      "description": "This message is shown whenever one constant from a group of constants is expected as an argument and you've provided a value that's not in that group. Examples of these groups of constants are the Mouse Button Constants, the Game Speed Constants and the Primitive Type Constants. A constant from another group or a real number may accidentally work but it is not good practice to use them. Using the right constant in the right place helps increase the readability of your code.",
+      "badExample": "// Example 1\n\n    if mouse_check_button_pressed(mb_midle)\n\n    {\n\n    }\n\n\n\n    // Example 2\n\n    if mouse_check_button_pressed(vk_left)\n\n    {\n\n    }",
+      "goodExample": "// Example 1\n\n    if mouse_check_button_pressed(mb_middle)\n\n    {\n\n    }\n\n\n\n    // Example 2\n\n    if mouse_check_button_pressed(mb_left)\n\n    {\n\n    }",
+      "correction": "If this was caused by a typo, then fixing the typo fixes it. In other cases the constant needs to be changed to a valid one."
     },
     {
       "id": "GM1045",
       "title": "Type '{0}' differs from type '{1}' specified in jsdoc.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when Feather detects that the type of a variable in your code doesn't correspond to the type the JSDoc says that variable should be.</p>",
-          "text": "This message is shown when Feather detects that the type of a variable in your code doesn't correspond to the type the JSDoc says that variable should be."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This can happen when you write the JSDoc already, but decide to change the code afterwards. In that case, the JSDoc will no longer be up to date and needs to be changed to reflect the changes.</p>",
-          "text": "This can happen when you write the JSDoc already, but decide to change the code afterwards. In that case, the JSDoc will no longer be up to date and needs to be changed to reflect the changes."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @func return_something()<br>\n    /// @desc This function returns something<br>\n    ///<br>\n    /// @returns {Id.Instance} A new instance<br>\n    ///<br>\n    function&nbsp;return_something()<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;\"something\";<br>\n    }</p>",
-          "text": "/// @func return_something()\n\n    /// @desc This function returns something\n\n    ///\n\n    /// @returns {Id.Instance} A new instance\n\n    ///\n\n    function return_something()\n\n    {\n\n        return \"something\";\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above the JSDoc says the function returns an instance ID, but the code actually returns a string. If this is the intent, the type in the JSDoc needs to be changed to <span class=\"inline2\">String</span> to reflect that. If not, the code needs to be changed so it returns an instance.</p>",
-          "text": "In the code example above the JSDoc says the function returns an instance ID, but the code actually returns a string. If this is the intent, the type in the JSDoc needs to be changed to String to reflect that. If not, the code needs to be changed so it returns an instance."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @func return_something()<br>\n    /// @desc This function returns something<br>\n    ///<br>\n    /// @returns {String} The string \"something\"<br>\n    ///<br>\n    function&nbsp;return_something()<br>\n    {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;\"something\";<br>\n    }</p>",
-          "text": "/// @func return_something()\n\n    /// @desc This function returns something\n\n    ///\n\n    /// @returns {String} The string \"something\"\n\n    ///\n\n    function return_something()\n\n    {\n\n        return \"something\";\n\n    }"
-        }
-      ]
+      "description": "This message is shown when Feather detects that the type of a variable in your code doesn't correspond to the type the JSDoc says that variable should be.\n\nThis can happen when you write the JSDoc already, but decide to change the code afterwards. In that case, the JSDoc will no longer be up to date and needs to be changed to reflect the changes.",
+      "badExample": "/// @func return_something()\n\n    /// @desc This function returns something\n\n    ///\n\n    /// @returns {Id.Instance} A new instance\n\n    ///\n\n    function return_something()\n\n    {\n\n        return \"something\";\n\n    }",
+      "goodExample": "/// @func return_something()\n\n    /// @desc This function returns something\n\n    ///\n\n    /// @returns {String} The string \"something\"\n\n    ///\n\n    function return_something()\n\n    {\n\n        return \"something\";\n\n    }",
+      "correction": "In the code example above the JSDoc says the function returns an instance ID, but the code actually returns a string. If this is the intent, the type in the JSDoc needs to be changed to String to reflect that. If not, the code needs to be changed so it returns an instance."
     },
     {
       "id": "GM1050",
       "title": "The identifier '{0}' is declared as a local variable and cannot be accessed in this way.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you attempt to access a local variable (defined with the <span class=\"inline2\">var</span> keyword) using the dot operator.&nbsp;The dot operator accesses a different scope, though local variables are already in the current scope.</p>",
-          "text": "This message is shown when you attempt to access a local variable (defined with the var keyword) using the dot operator. The dot operator accesses a different scope, though local variables are already in the current scope."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    var _condition = false;<br>\n    if (self._condition) &nbsp; &nbsp;// Error! Variable is local...<br>\n    {<br>\n    }</p>",
-          "text": "/// Create Event\n\n    var _condition = false;\n\n    if (self._condition)    // Error! Variable is local...\n\n    {\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A local (or temporary) variable should always be used without a prefix that refers to a scope. The scope of local variables is always the current block of code.</p>",
-          "text": "A local (or temporary) variable should always be used without a prefix that refers to a scope. The scope of local variables is always the current block of code."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _condition = false;<br>\n    if (_condition)<br>\n    {<br>\n    }</p>",
-          "text": "var _condition = false;\n\n    if (_condition)\n\n    {\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you attempt to access a local variable (defined with the var keyword) using the dot operator. The dot operator accesses a different scope, though local variables are already in the current scope.",
+      "badExample": "/// Create Event\n\n    var _condition = false;\n\n    if (self._condition)    // Error! Variable is local...\n\n    {\n\n    }",
+      "goodExample": "var _condition = false;\n\n    if (_condition)\n\n    {\n\n    }",
+      "correction": "A local (or temporary) variable should always be used without a prefix that refers to a scope. The scope of local variables is always the current block of code."
     },
     {
       "id": "GM1051",
       "title": "Macro expressions should not be terminated with a ';' semicolon.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you end a macro definition with a semicolon. Macros can go anywhere in your code and are replaced by their value. Any semicolons in the macro's value are also inserted and may end up in places where they cause a syntax error.</p>",
-          "text": "This message is shown when you end a macro definition with a semicolon. Macros can go anywhere in your code and are replaced by their value. Any semicolons in the macro's value are also inserted and may end up in places where they cause a syntax error."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See the section on Macros on the <a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Variables/Constants.htm\">Constants</a>&nbsp;page for more info.</p>",
-          "text": "See the section on Macros on the Constants page for more info."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">randomise();<br>\n    <br>\n    #macro&nbsp;NEW_COLOR&nbsp;make_color_rgb(random(255),&nbsp;random(255),&nbsp;random(255));<br>\n    <br>\n    draw_primitive_begin(pr_trianglelist);<br>\n    <br>\n    repeat(3)<br>\n    {<br>\n    &nbsp; &nbsp;&nbsp;draw_vertex_color(random(room_width),&nbsp;random(room_height),&nbsp;NEW_COLOR,&nbsp;1); &nbsp; &nbsp;// Issue!<br>\n    }<br>\n    <br>\n    draw_primitive_end();\n  </p>",
-          "text": "randomise();\n\n\n\n    #macro NEW_COLOR make_color_rgb(random(255), random(255), random(255));\n\n\n\n    draw_primitive_begin(pr_trianglelist);\n\n\n\n    repeat(3)\n\n    {\n\n        draw_vertex_color(random(room_width), random(room_height), NEW_COLOR, 1);    // Issue!\n\n    }\n\n\n\n    draw_primitive_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Inserting the macro into the function call leads to a semicolon being inserted right after the third argument. This is incorrect, since this semicolon marks the end of the statement while the function call still needs an additional parameter and also has to be closed with a parenthesis. Removing the semicolon at the end of the macro fixes the issue.</p>",
-          "text": "Inserting the macro into the function call leads to a semicolon being inserted right after the third argument. This is incorrect, since this semicolon marks the end of the statement while the function call still needs an additional parameter and also has to be closed with a parenthesis. Removing the semicolon at the end of the macro fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// The semicolon that gets inserted as part of the macro causes a syntax error:<br>\n    // draw_vertex_color(random(room_width), random(room_height), make_color_rgb(random(255), random(255), random(255));, 1);<br>\n    randomise();<br>\n    <br>\n    #macro&nbsp;NEW_COLOR&nbsp;make_color_rgb(random(255),&nbsp;random(255),&nbsp;random(255))<br>\n    <br>\n    draw_primitive_begin(pr_trianglelist);<br>\n    <br>\n    repeat(3)<br>\n    {<br>\n    &nbsp; &nbsp;&nbsp;draw_vertex_color(random(room_width),&nbsp;random(room_height),&nbsp;NEW_COLOR,&nbsp;1); &nbsp; &nbsp;// Fixed!<br>\n    }<br>\n    <br>\n    draw_primitive_end();\n  </p>",
-          "text": "// The semicolon that gets inserted as part of the macro causes a syntax error:\n\n    // draw_vertex_color(random(room_width), random(room_height), make_color_rgb(random(255), random(255), random(255));, 1);\n\n    randomise();\n\n\n\n    #macro NEW_COLOR make_color_rgb(random(255), random(255), random(255))\n\n\n\n    draw_primitive_begin(pr_trianglelist);\n\n\n\n    repeat(3)\n\n    {\n\n        draw_vertex_color(random(room_width), random(room_height), NEW_COLOR, 1);    // Fixed!\n\n    }\n\n\n\n    draw_primitive_end();"
-        }
-      ]
+      "description": "This message is shown when you end a macro definition with a semicolon. Macros can go anywhere in your code and are replaced by their value. Any semicolons in the macro's value are also inserted and may end up in places where they cause a syntax error.\n\nSee the section on Macros on the Constants page for more info.",
+      "badExample": "randomise();\n\n\n\n    #macro NEW_COLOR make_color_rgb(random(255), random(255), random(255));\n\n\n\n    draw_primitive_begin(pr_trianglelist);\n\n\n\n    repeat(3)\n\n    {\n\n        draw_vertex_color(random(room_width), random(room_height), NEW_COLOR, 1);    // Issue!\n\n    }\n\n\n\n    draw_primitive_end();",
+      "goodExample": "// The semicolon that gets inserted as part of the macro causes a syntax error:\n\n    // draw_vertex_color(random(room_width), random(room_height), make_color_rgb(random(255), random(255), random(255));, 1);\n\n    randomise();\n\n\n\n    #macro NEW_COLOR make_color_rgb(random(255), random(255), random(255))\n\n\n\n    draw_primitive_begin(pr_trianglelist);\n\n\n\n    repeat(3)\n\n    {\n\n        draw_vertex_color(random(room_width), random(room_height), NEW_COLOR, 1);    // Fixed!\n\n    }\n\n\n\n    draw_primitive_end();",
+      "correction": "Inserting the macro into the function call leads to a semicolon being inserted right after the third argument. This is incorrect, since this semicolon marks the end of the statement while the function call still needs an additional parameter and also has to be closed with a parenthesis. Removing the semicolon at the end of the macro fixes the issue."
     },
     {
       "id": "GM1052",
       "title": "The delete operator can only act on a variable of type 'struct'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/new.htm\">new</a></span> and&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/delete.htm\">delete</a></span> operators are specifically for use with structs. Instances are destroyed using <span class=\"inline2\">instance_destroy()</span>, arrays are garbage-collected once they're no longer referenced and other resource types have their own functions to handle deleting/freeing them (a <span class=\"inline2\">*_destroy</span> or <span class=\"inline2\">*_free</span> function).</p>",
-          "text": "The new and delete operators are specifically for use with structs. Instances are destroyed using instance_destroy(), arrays are garbage-collected once they're no longer referenced and other resource types have their own functions to handle deleting/freeing them (a *_destroy or *_free function)."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">values = [2, 403, 202, 303, 773, 573];<br>\n    delete values;</p>",
-          "text": "values = [2, 403, 202, 303, 773, 573];\n\n    delete values;"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To fix this the appropriate function or method should be used which, for arrays, is setting the variable to <span class=\"inline2\">undefined</span>.</p>",
-          "text": "To fix this the appropriate function or method should be used which, for arrays, is setting the variable to undefined."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">values = undefined;</p>",
-          "text": "values = undefined;"
-        }
-      ]
+      "description": "The new and delete operators are specifically for use with structs. Instances are destroyed using instance_destroy(), arrays are garbage-collected once they're no longer referenced and other resource types have their own functions to handle deleting/freeing them (a *_destroy or *_free function).",
+      "badExample": "values = [2, 403, 202, 303, 773, 573];\n\n    delete values;",
+      "goodExample": "values = undefined;",
+      "correction": "To fix this the appropriate function or method should be used which, for arrays, is setting the variable to undefined."
     },
     {
       "id": "GM1054",
       "title": "Cannot inherit from non-existent function '{0}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when the constructor that a constructor is inheriting from doesn't exist. Possible causes are:</p>",
-          "text": "This message is shown when the constructor that a constructor is inheriting from doesn't exist. Possible causes are:"
-        },
-        {
-          "type": "list",
-          "html": "<ul class=\"colour\">\n    <li>The constructor to inherit from still needs to be defined.</li>\n    <li>The function must be marked as a constructor by adding the <span class=\"inline2\">constructor</span> keyword.</li>\n    <li>There is a typo in the inherited constructor name.</li>\n  </ul>",
-          "text": "The constructor to inherit from still needs to be defined.\n    The function must be marked as a constructor by adding the constructor keyword.\n    There is a typo in the inherited constructor name."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See:&nbsp;<a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Structs.htm\">Structs &amp; Constructors</a></p>",
-          "text": "See: Structs & Constructors"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function vec2() : vec()<br>\n    {<br>\n    }</p>",
-          "text": "function vec2() : vec()\n\n    {\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The code example above attempts to create an inherited constructor function, but some things are missing. First, the constructor to inherit from, <span class=\"inline2\">vec</span>, isn't defined yet. Second, the function isn't marked as a constructor with the <span class=\"inline2\">constructor</span> keyword. To fix the error the parent constructor should be defined and the <span class=\"inline2\">constructor</span> keyword be added to both.</p>",
-          "text": "The code example above attempts to create an inherited constructor function, but some things are missing. First, the constructor to inherit from, vec, isn't defined yet. Second, the function isn't marked as a constructor with the constructor keyword. To fix the error the parent constructor should be defined and the constructor keyword be added to both."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function vec() constructor {}<br>\n    function vec2() : vec() constructor<br>\n    {<br>\n    }</p>",
-          "text": "function vec() constructor {}\n\n    function vec2() : vec() constructor\n\n    {\n\n    }"
-        }
-      ]
+      "description": "This message is shown when the constructor that a constructor is inheriting from doesn't exist. Possible causes are:\n\nThe constructor to inherit from still needs to be defined.\nThe function must be marked as a constructor by adding the constructor keyword.\nThere is a typo in the inherited constructor name.\n\nSee: Structs & Constructors",
+      "badExample": "function vec2() : vec()\n\n    {\n\n    }",
+      "goodExample": "function vec() constructor {}\n\n    function vec2() : vec() constructor\n\n    {\n\n    }",
+      "correction": "The code example above attempts to create an inherited constructor function, but some things are missing. First, the constructor to inherit from, vec, isn't defined yet. Second, the function isn't marked as a constructor with the constructor keyword. To fix the error the parent constructor should be defined and the constructor keyword be added to both."
     },
     {
       "id": "GM1055",
       "title": "Cannot mix argument# and named parameters.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've used one of the argumentn variables while the function parameters are defined as named parameters. For every function either one or the other should be used.</p>",
-          "text": "This message indicates that you've used one of the argumentn variables while the function parameters are defined as named parameters. For every function either one or the other should be used."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function&nbsp;func(_a, _b, _c) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;show_debug_message($\"{argument0}, {argument1}, {argument2}\");<br>\n    }</p>",
-          "text": "function func(_a, _b, _c) {\n\n        show_debug_message($\"{argument0}, {argument1}, {argument2}\");\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above the parameters are already defined as named parameters. Replacing the occurrences of <span class=\"inline2\">argument0</span> - <span class=\"inline2\">argument2</span> in the function body fixes this issue. <span class=\"inline2\">argument0</span> is replaced with <span class=\"inline2\">_a</span>, <span class=\"inline2\">argument1</span> is replaced with <span class=\"inline2\">_b</span> and <span class=\"inline2\">argument2</span> is replaced with <span class=\"inline2\">_c</span>. So every argument is replaced with the named argument at the corresponding index.</p>",
-          "text": "In the code example above the parameters are already defined as named parameters. Replacing the occurrences of argument0 - argument2 in the function body fixes this issue. argument0 is replaced with _a, argument1 is replaced with _b and argument2 is replaced with _c. So every argument is replaced with the named argument at the corresponding index."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function&nbsp;func(_a, _b, _c) {<br>\n    &nbsp;&nbsp;&nbsp;&nbsp;show_debug_message($\"{_a}, {_b}, {_c}\");<br>\n    }</p>",
-          "text": "function func(_a, _b, _c) {\n\n        show_debug_message($\"{_a}, {_b}, {_c}\");\n\n    }"
-        }
-      ]
+      "description": "This message indicates that you've used one of the argumentn variables while the function parameters are defined as named parameters. For every function either one or the other should be used.",
+      "badExample": "function func(_a, _b, _c) {\n\n        show_debug_message($\"{argument0}, {argument1}, {argument2}\");\n\n    }",
+      "goodExample": "function func(_a, _b, _c) {\n\n        show_debug_message($\"{_a}, {_b}, {_c}\");\n\n    }",
+      "correction": "In the code example above the parameters are already defined as named parameters. Replacing the occurrences of argument0 - argument2 in the function body fixes this issue. argument0 is replaced with _a, argument1 is replaced with _b and argument2 is replaced with _c. So every argument is replaced with the named argument at the corresponding index."
     },
     {
       "id": "GM1056",
       "title": "Bad practice to declare non-optional parameter after an optional parameter.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you list optional parameters before non-optional parameters. As a consequence, in order to use the default value of those optional parameters it's necessary to omit the argument. All optional parameters should go at the end of the parameter list.</p>",
-          "text": "This message is shown when you list optional parameters before non-optional parameters. As a consequence, in order to use the default value of those optional parameters it's necessary to omit the argument. All optional parameters should go at the end of the parameter list."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See the section on <a data-xref=\"{text}\" href=\"../../GameMaker_Language/GML_Overview/Script_Functions.htm#h\">Optional Arguments</a> on the <a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Script_Functions.htm\">Script Functions And Variables</a>&nbsp;page.</p>",
-          "text": "See the section on Optional Arguments on the Script Functions And Variables page."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function func(arg1, arg2, arg3=7, arg4)<br>\n    {<br>\n    }<br>\n    func(4, 5, , 8); &nbsp;// the third parameter has to be omitted to use the default value</p>",
-          "text": "function func(arg1, arg2, arg3=7, arg4)\n\n    {\n\n    }\n\n    func(4, 5, , 8);  // the third parameter has to be omitted to use the default value"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This can be fixed by changing the order of the function parameters such that all optional parameters and their default values go at the end of the parameter list.</p>",
-          "text": "This can be fixed by changing the order of the function parameters such that all optional parameters and their default values go at the end of the parameter list."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function func(arg1, arg2, arg4, arg3=7)<br>\n    {<br>\n    }<br>\n    func(4, 5, 8);</p>",
-          "text": "function func(arg1, arg2, arg4, arg3=7)\n\n    {\n\n    }\n\n    func(4, 5, 8);"
-        }
-      ]
+      "description": "This message is shown when you list optional parameters before non-optional parameters. As a consequence, in order to use the default value of those optional parameters it's necessary to omit the argument. All optional parameters should go at the end of the parameter list.\n\nSee the section on Optional Arguments on the Script Functions And Variables page.",
+      "badExample": "function func(arg1, arg2, arg3=7, arg4)\n\n    {\n\n    }\n\n    func(4, 5, , 8);  // the third parameter has to be omitted to use the default value",
+      "goodExample": "function func(arg1, arg2, arg4, arg3=7)\n\n    {\n\n    }\n\n    func(4, 5, 8);",
+      "correction": "This can be fixed by changing the order of the function parameters such that all optional parameters and their default values go at the end of the parameter list."
     },
     {
       "id": "GM1058",
       "title": "Cannot 'new' the identifier '{0}' as it is not a constructor function.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you try to call the&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/new.htm\">new</a></span> operator with a valid function name that's not marked as a constructor.</p>",
-          "text": "This message is shown when you try to call the new operator with a valid function name that's not marked as a constructor."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function item()<br>\n    {<br>\n    }<br>\n    sword = new item();</p>",
-          "text": "function item()\n\n    {\n\n    }\n\n    sword = new item();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In order to fix this error the constructor keyword must be added to the function definition.</p>",
-          "text": "In order to fix this error the constructor keyword must be added to the function definition."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function item() constructor<br>\n    {<br>\n    }<br>\n    sword = new item();</p>",
-          "text": "function item() constructor\n\n    {\n\n    }\n\n    sword = new item();"
-        }
-      ]
+      "description": "This message is shown when you try to call the new operator with a valid function name that's not marked as a constructor.",
+      "badExample": "function item()\n\n    {\n\n    }\n\n    sword = new item();",
+      "goodExample": "function item() constructor\n\n    {\n\n    }\n\n    sword = new item();",
+      "correction": "In order to fix this error the constructor keyword must be added to the function definition."
     },
     {
       "id": "GM1059",
       "title": "The parameter '{0}' has been previously declared.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when the same parameter name occurs multiple times in a function's parameter list.</p>",
-          "text": "This message is shown when the same parameter name occurs multiple times in a function's parameter list."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">function&nbsp;func(_param1, _param2, _param1)<br>\n    {<br>\n    }</p>",
-          "text": "function func(_param1, _param2, _param1)\n\n    {\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Depending on what is intended, the parameter should either be removed or renamed.</p>",
-          "text": "Depending on what is intended, the parameter should either be removed or renamed."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Option 1: Remove double<br>\n    function func(_param1, _param2)<br>\n    {<br>\n    }<br>\n    // Option 2: Rename the parameter<br>\n    function func(_param1, _param2, _param3)<br>\n    {<br>\n    }</p>",
-          "text": "// Option 1: Remove double\n\n    function func(_param1, _param2)\n\n    {\n\n    }\n\n    // Option 2: Rename the parameter\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n    }"
-        }
-      ]
+      "description": "This message is shown when the same parameter name occurs multiple times in a function's parameter list.",
+      "badExample": "function func(_param1, _param2, _param1)\n\n    {\n\n    }",
+      "goodExample": "// Option 1: Remove double\n\n    function func(_param1, _param2)\n\n    {\n\n    }\n\n    // Option 2: Rename the parameter\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n    }",
+      "correction": "Depending on what is intended, the parameter should either be removed or renamed."
     },
     {
       "id": "GM1060",
       "title": "Dangerous call to variable of type '{0}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>Shown when you try to call something that is not a function.</p>",
-          "text": "Shown when you try to call something that is not a function."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">my_function = 100;<br>\n    my_function();<br>\n    my_function = pi;<br>\n    my_function();</p>",
-          "text": "my_function = 100;\n\n    my_function();\n\n    my_function = pi;\n\n    my_function();"
-        }
-      ]
+      "description": "Shown when you try to call something that is not a function.",
+      "badExample": "my_function = 100;\n\n    my_function();\n\n    my_function = pi;\n\n    my_function();",
+      "goodExample": null,
+      "correction": null
     },
     {
       "id": "GM1062",
       "title": "Malformed type '{0}' in jsdoc.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that Feather is unable to parse a parameter or return type in the function's JSDoc. The supported syntax is given on the&nbsp;<a data-xref=\"{title}\" href=\"Feather_Data_Types.htm\">Feather Data Types</a> page.</p>",
-          "text": "This message indicates that Feather is unable to parse a parameter or return type in the function's JSDoc. The supported syntax is given on the Feather Data Types page."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @function func(_param1, _param2, _param3)<br>\n    /// @desc This function does something<br>\n    /// @param {Array[String} _param1 This is parameter 1<br>\n    /// @param {String Array[String]} _param2 This is parameter 2<br>\n    /// @param {Id Instance} _param3 This is parameter 3<br>\n    function func(_param1, _param2, _param3)<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);<br>\n    }</p>",
-          "text": "/// @function func(_param1, _param2, _param3)\n\n    /// @desc This function does something\n\n    /// @param {Array[String} _param1 This is parameter 1\n\n    /// @param {String Array[String]} _param2 This is parameter 2\n\n    /// @param {Id Instance} _param3 This is parameter 3\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n        show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The JSDoc types in the code example above can be corrected as follows:</p>",
-          "text": "The JSDoc types in the code example above can be corrected as follows:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// @function func(_param1, _param2, _param3)<br>\n    /// @desc This function does something<br>\n    /// @param {Array[String]} _param1 This is parameter 1<br>\n    /// @param {String,Array[String]} _param2 This is parameter 2<br>\n    /// @param {Id.Instance} _param3 This is parameter 3<br>\n    function func(_param1, _param2, _param3)<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);<br>\n    }</p>",
-          "text": "/// @function func(_param1, _param2, _param3)\n\n    /// @desc This function does something\n\n    /// @param {Array[String]} _param1 This is parameter 1\n\n    /// @param {String,Array[String]} _param2 This is parameter 2\n\n    /// @param {Id.Instance} _param3 This is parameter 3\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n        show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);\n\n    }"
-        }
-      ]
+      "description": "This message indicates that Feather is unable to parse a parameter or return type in the function's JSDoc. The supported syntax is given on the Feather Data Types page.",
+      "badExample": "/// @function func(_param1, _param2, _param3)\n\n    /// @desc This function does something\n\n    /// @param {Array[String} _param1 This is parameter 1\n\n    /// @param {String Array[String]} _param2 This is parameter 2\n\n    /// @param {Id Instance} _param3 This is parameter 3\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n        show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);\n\n    }",
+      "goodExample": "/// @function func(_param1, _param2, _param3)\n\n    /// @desc This function does something\n\n    /// @param {Array[String]} _param1 This is parameter 1\n\n    /// @param {String,Array[String]} _param2 This is parameter 2\n\n    /// @param {Id.Instance} _param3 This is parameter 3\n\n    function func(_param1, _param2, _param3)\n\n    {\n\n        show_debug_message(\"The parameters are: {0}, {1} and {2}\", _param1, _param2, _param3);\n\n    }",
+      "correction": "The JSDoc types in the code example above can be corrected as follows:"
     },
     {
       "id": "GM1063",
       "title": "Ternary may yield differing types '{0}' and '{1}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when a ternary operator returns a type of value in the true case that's different from the type in the false case or vice versa. As a consequence, the variable that's assigned to may receive a different type, depending on the outcome of the condition.</p>",
-          "text": "This message is shown when a ternary operator returns a type of value in the true case that's different from the type in the false case or vice versa. As a consequence, the variable that's assigned to may receive a different type, depending on the outcome of the condition."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    tex = (texture_defined) ? sprite_get_texture(sprite_index, 0) : -1;<br>\n    <br>\n    /// Draw Event<br>\n    vertex_submit(vb, pr_trianglelist, tex);\n  </p>",
-          "text": "/// Create Event\n\n    tex = (texture_defined) ? sprite_get_texture(sprite_index, 0) : -1;\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_trianglelist, tex);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This can be fixed by explicitly converting the type returned in one of the cases to the type of the other case.</p>",
-          "text": "This can be fixed by explicitly converting the type returned in one of the cases to the type of the other case."
-        }
-      ]
+      "description": "This message is shown when a ternary operator returns a type of value in the true case that's different from the type in the false case or vice versa. As a consequence, the variable that's assigned to may receive a different type, depending on the outcome of the condition.",
+      "badExample": "/// Create Event\n\n    tex = (texture_defined) ? sprite_get_texture(sprite_index, 0) : -1;\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_trianglelist, tex);",
+      "goodExample": null,
+      "correction": "This can be fixed by explicitly converting the type returned in one of the cases to the type of the other case."
     },
     {
       "id": "GM1064",
       "title": "Redeclaration of global function '{0}' originally declared in '{1}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've already declared a global function with the same name in another script asset.</p>",
-          "text": "This message indicates that you've already declared a global function with the same name in another script asset."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Script1<br>\n    function make_game()<br>\n    {<br>\n    }<br>\n    <br>\n    /// Script2<br>\n    function make_game()<br>\n    {<br>\n    }\n  </p>",
-          "text": "/// Script1\n\n    function make_game()\n\n    {\n\n    }\n\n\n\n    /// Script2\n\n    function make_game()\n\n    {\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>One of the function definitions should be removed so that only one remains in the global namespace. If you want to create two functions with the same name then it is possible to create them as static functions within two different functions. The functions in which you define the static functions then act as a namespace.</p>",
-          "text": "One of the function definitions should be removed so that only one remains in the global namespace. If you want to create two functions with the same name then it is possible to create them as static functions within two different functions. The functions in which you define the static functions then act as a namespace."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Script1<br>\n    function make_game()<br>\n    {<br>\n    }</p>",
-          "text": "/// Script1\n\n    function make_game()\n\n    {\n\n    }"
-        }
-      ]
+      "description": "This message indicates that you've already declared a global function with the same name in another script asset.",
+      "badExample": "/// Script1\n\n    function make_game()\n\n    {\n\n    }\n\n\n\n    /// Script2\n\n    function make_game()\n\n    {\n\n    }",
+      "goodExample": "/// Script1\n\n    function make_game()\n\n    {\n\n    }",
+      "correction": "One of the function definitions should be removed so that only one remains in the global namespace. If you want to create two functions with the same name then it is possible to create them as static functions within two different functions. The functions in which you define the static functions then act as a namespace."
     },
     {
       "id": "GM1100",
       "title": "Syntax Error",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates a general syntax error in your code. Syntax errors cover a range of possible errors related to the syntax of your code.</p>",
-          "text": "This message indicates a general syntax error in your code. Syntax errors cover a range of possible errors related to the syntax of your code."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _this * something;<br>\n    = 48;</p>",
-          "text": "var _this * something;\n\n    = 48;"
-        }
-      ]
+      "description": "This message indicates a general syntax error in your code. Syntax errors cover a range of possible errors related to the syntax of your code.",
+      "badExample": "var _this * something;\n\n    = 48;",
+      "goodExample": null,
+      "correction": null
     },
     {
       "id": "GM2000",
       "title": "Not all code paths call gpu_set_blendmode(bm_normal) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you change the blend mode to a value different from <span class=\"inline2\">bm_normal</span> with a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_blendmode.htm\">gpu_set_blendmode</a></span> but don't change it back to <span class=\"inline2\">bm_normal</span> afterwards. After drawing something with a different blend mode it is important to set blending back to normal so everything that's drawn after it is drawn correctly.</p>",
-          "text": "This message is shown when you change the blend mode to a value different from bm_normal with a call to gpu_set_blendmode but don't change it back to bm_normal afterwards. After drawing something with a different blend mode it is important to set blending back to normal so everything that's drawn after it is drawn correctly."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_blendmode(bm_add);<br>\n    draw_self();<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, $\"Score: {score}\");\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_blendmode(bm_add);\n\n    draw_self();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Score: {score}\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The code in the example intends to draw an instance with added blending in its normal Draw event and some text with normal blending in its Draw GUI event. However, no call to reset the blend mode back to <span class=\"inline2\">bm_normal</span> is made in the Draw event and so the text in the Draw GUI event is also drawn using additive blending. Another call to <span class=\"inline3_func\">gpu_set_blendmode</span>&nbsp;needs to be added at the end of the Draw event to reset the blending back to <span class=\"inline2\">bm_normal</span>.</p>",
-          "text": "The code in the example intends to draw an instance with added blending in its normal Draw event and some text with normal blending in its Draw GUI event. However, no call to reset the blend mode back to bm_normal is made in the Draw event and so the text in the Draw GUI event is also drawn using additive blending. Another call to gpu_set_blendmode needs to be added at the end of the Draw event to reset the blending back to bm_normal."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_blendmode(bm_add);<br>\n    draw_self();<br>\n    gpu_set_blendmode(bm_normal);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, $\"Score: {score}\");\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_blendmode(bm_add);\n\n    draw_self();\n\n    gpu_set_blendmode(bm_normal);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Score: {score}\");"
-        }
-      ]
+      "description": "This message is shown when you change the blend mode to a value different from bm_normal with a call to gpu_set_blendmode but don't change it back to bm_normal afterwards. After drawing something with a different blend mode it is important to set blending back to normal so everything that's drawn after it is drawn correctly.",
+      "badExample": "/// Draw Event\n\n    gpu_set_blendmode(bm_add);\n\n    draw_self();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Score: {score}\");",
+      "goodExample": "/// Draw Event\n\n    gpu_set_blendmode(bm_add);\n\n    draw_self();\n\n    gpu_set_blendmode(bm_normal);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Score: {score}\");",
+      "correction": "The code in the example intends to draw an instance with added blending in its normal Draw event and some text with normal blending in its Draw GUI event. However, no call to reset the blend mode back to bm_normal is made in the Draw event and so the text in the Draw GUI event is also drawn using additive blending. Another call to gpu_set_blendmode needs to be added at the end of the Draw event to reset the blending back to bm_normal."
     },
     {
       "id": "GM2003",
       "title": "Not all code paths call shader_reset() before end of script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This error is shown when a call to the function&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_reset.htm\">shader_reset</a></span> is missing after drawing using a custom shader (set with <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Shaders/shader_set.htm\">shader_set</a></span>). When the shader isn't set back to the default shader after drawing using a custom shader, everything that's drawn after that is also drawn using that shader.</p>",
-          "text": "This error is shown when a call to the function shader_reset is missing after drawing using a custom shader (set with shader_set). When the shader isn't set back to the default shader after drawing using a custom shader, everything that's drawn after that is also drawn using that shader."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    shader_set(sh_fancy_lighting);<br>\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"World 1\"); &nbsp;// Also drawn using sh_fancy_lighting\n  </p>",
-          "text": "/// Draw Event\n\n    shader_set(sh_fancy_lighting);\n\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");  // Also drawn using sh_fancy_lighting"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The call to <span class=\"inline3_func\">shader_set</span> should be accompanied with a call to <span class=\"inline3_func\">shader_reset</span>.</p>",
-          "text": "The call to shader_set should be accompanied with a call to shader_reset."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    shader_set(sh_fancy_lighting);<br>\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);<br>\n    shader_reset();<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"World 1\");\n  </p>",
-          "text": "/// Draw Event\n\n    shader_set(sh_fancy_lighting);\n\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");"
-        }
-      ]
+      "description": "This error is shown when a call to the function shader_reset is missing after drawing using a custom shader (set with shader_set). When the shader isn't set back to the default shader after drawing using a custom shader, everything that's drawn after that is also drawn using that shader.",
+      "badExample": "/// Draw Event\n\n    shader_set(sh_fancy_lighting);\n\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");  // Also drawn using sh_fancy_lighting",
+      "goodExample": "/// Draw Event\n\n    shader_set(sh_fancy_lighting);\n\n    vertex_submit(vb_my_world_model, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");",
+      "correction": "The call to shader_set should be accompanied with a call to shader_reset."
     },
     {
       "id": "GM2004",
       "title": "This for statement does not use its index and can be written as a repeat statement instead.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that the&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/for.htm\">for</a></span> statement has a loop counter that is never used, e.g. to index an array. When the number of iterations is known in advance and doesn't depend on a condition the for loop doesn't need a counter and can be replaced by a&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/repeat.htm\">repeat</a></span> statement.</p>",
-          "text": "This message indicates that the for statement has a loop counter that is never used, e.g. to index an array. When the number of iterations is known in advance and doesn't depend on a condition the for loop doesn't need a counter and can be replaced by a repeat statement."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">randomise();<br>\n    var _num_elements = 20;<br>\n    array = [];<br>\n    <br>\n    for(var i = 0;i &lt; _num_elements;i++)<br>\n    {<br>\n    &nbsp; &nbsp; array_push(array, irandom(100));<br>\n    }\n  </p>",
-          "text": "randomise();\n\n    var _num_elements = 20;\n\n    array = [];\n\n\n\n    for(var i = 0;i < _num_elements;i++)\n\n    {\n\n        array_push(array, irandom(100));\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The for loop in the example code above doesn't use its index. In this specific situation, the function used (<span class=\"inline2\">array_push()</span>) automatically appends to the end of the array so the index doesn't have to be provided explicitly.</p>",
-          "text": "The for loop in the example code above doesn't use its index. In this specific situation, the function used (array_push()) automatically appends to the end of the array so the index doesn't have to be provided explicitly."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">randomise();<br>\n    var _num_elements = 20;<br>\n    array = [];<br>\n    <br>\n    repeat(_num_elements)<br>\n    {<br>\n    &nbsp; &nbsp; array_push(array, irandom(100));<br>\n    }\n  </p>",
-          "text": "randomise();\n\n    var _num_elements = 20;\n\n    array = [];\n\n\n\n    repeat(_num_elements)\n\n    {\n\n        array_push(array, irandom(100));\n\n    }"
-        }
-      ]
+      "description": "This message indicates that the for statement has a loop counter that is never used, e.g. to index an array. When the number of iterations is known in advance and doesn't depend on a condition the for loop doesn't need a counter and can be replaced by a repeat statement.",
+      "badExample": "randomise();\n\n    var _num_elements = 20;\n\n    array = [];\n\n\n\n    for(var i = 0;i < _num_elements;i++)\n\n    {\n\n        array_push(array, irandom(100));\n\n    }",
+      "goodExample": "randomise();\n\n    var _num_elements = 20;\n\n    array = [];\n\n\n\n    repeat(_num_elements)\n\n    {\n\n        array_push(array, irandom(100));\n\n    }",
+      "correction": "The for loop in the example code above doesn't use its index. In this specific situation, the function used (array_push()) automatically appends to the end of the array so the index doesn't have to be provided explicitly."
     },
     {
       "id": "GM2005",
       "title": "Not all code paths call surface_reset_target() before end of script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This error indicates that you changed the draw target with a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Surfaces/surface_set_target.htm\">surface_set_target</a></span> but haven't set it back with a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Surfaces/surface_reset_target.htm\">surface_reset_target</a></span> in all situations.</p>",
-          "text": "This error indicates that you changed the draw target with a call to surface_set_target but haven't set it back with a call to surface_reset_target in all situations."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>See:&nbsp;<a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Surfaces/Surfaces.htm\">Surfaces</a></p>",
-          "text": "See: Surfaces"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    if (!surface_exists(sf_canvas))<br>\n    {<br>\n    &nbsp; &nbsp; sf_canvas = surface_create(512, 512);<br>\n    }<br>\n    <br>\n    surface_set_target(sf_canvas);<br>\n    draw_clear_alpha(c_white, 0);<br>\n    draw_rectangle(4, 4, 40, 40);\n  </p>",
-          "text": "/// Draw Event\n\n    if (!surface_exists(sf_canvas))\n\n    {\n\n        sf_canvas = surface_create(512, 512);\n\n    }\n\n\n\n    surface_set_target(sf_canvas);\n\n    draw_clear_alpha(c_white, 0);\n\n    draw_rectangle(4, 4, 40, 40);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example code above the drawing target is still set to <span class=\"inline2\">sf_canvas</span> after the block of code has executed. Further draw commands will also draw to this surface. A call to <span class=\"inline3_func\">surface_reset_target()</span> is needed at the end to reset the drawing target.</p>",
-          "text": "In the example code above the drawing target is still set to sf_canvas after the block of code has executed. Further draw commands will also draw to this surface. A call to surface_reset_target() is needed at the end to reset the drawing target."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    if (!surface_exists(sf_canvas))<br>\n    {<br>\n    &nbsp; &nbsp; sf_canvas = surface_create(512, 512);<br>\n    }<br>\n    <br>\n    surface_set_target(sf_canvas);<br>\n    draw_clear_alpha(c_white, 0);<br>\n    draw_rectangle(4, 4, 40, 40);<br>\n    surface_reset_target();\n  </p>",
-          "text": "/// Draw Event\n\n    if (!surface_exists(sf_canvas))\n\n    {\n\n        sf_canvas = surface_create(512, 512);\n\n    }\n\n\n\n    surface_set_target(sf_canvas);\n\n    draw_clear_alpha(c_white, 0);\n\n    draw_rectangle(4, 4, 40, 40);\n\n    surface_reset_target();"
-        }
-      ]
+      "description": "This error indicates that you changed the draw target with a call to surface_set_target but haven't set it back with a call to surface_reset_target in all situations.\n\nSee: Surfaces",
+      "badExample": "/// Draw Event\n\n    if (!surface_exists(sf_canvas))\n\n    {\n\n        sf_canvas = surface_create(512, 512);\n\n    }\n\n\n\n    surface_set_target(sf_canvas);\n\n    draw_clear_alpha(c_white, 0);\n\n    draw_rectangle(4, 4, 40, 40);",
+      "goodExample": "/// Draw Event\n\n    if (!surface_exists(sf_canvas))\n\n    {\n\n        sf_canvas = surface_create(512, 512);\n\n    }\n\n\n\n    surface_set_target(sf_canvas);\n\n    draw_clear_alpha(c_white, 0);\n\n    draw_rectangle(4, 4, 40, 40);\n\n    surface_reset_target();",
+      "correction": "In the example code above the drawing target is still set to sf_canvas after the block of code has executed. Further draw commands will also draw to this surface. A call to surface_reset_target() is needed at the end to reset the drawing target."
     },
     {
       "id": "GM2007",
       "title": "var expression should be terminated with a ';' (semicolon.)",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that a semicolon <span class=\"inline2\">;</span> is missing at the end of a <span class=\"inline2\">var</span> statement. Local variables can be declared without immediately assigning them a value, but this declaration needs to be terminated with a semicolon.</p>",
-          "text": "This message indicates that a semicolon ; is missing at the end of a var statement. Local variables can be declared without immediately assigning them a value, but this declaration needs to be terminated with a semicolon."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var a</p>",
-          "text": "var a"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A semicolon needs to be added at the end of the statement to fix this.</p>",
-          "text": "A semicolon needs to be added at the end of the statement to fix this."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var a;</p>",
-          "text": "var a;"
-        }
-      ]
+      "description": "This message indicates that a semicolon ; is missing at the end of a var statement. Local variables can be declared without immediately assigning them a value, but this declaration needs to be terminated with a semicolon.",
+      "badExample": "var a",
+      "goodExample": "var a;",
+      "correction": "A semicolon needs to be added at the end of the statement to fix this."
     },
     {
       "id": "GM2008",
       "title": "Opening another vertex batch before closing a previous vertex batch.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you start another vertex batch with a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_begin.htm\">vertex_begin</a></span> before having called&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_end.htm\">vertex_end</a></span> for the current batch. Every call to <span class=\"inline3_func\">vertex_begin()</span> must be followed by a call to <span class=\"inline3_func\">vertex_end()</span> before a next call to <span class=\"inline3_func\">vertex_begin()</span>.</p>",
-          "text": "This message is shown when you start another vertex batch with a call to vertex_begin before having called vertex_end for the current batch. Every call to vertex_begin() must be followed by a call to vertex_end() before a next call to vertex_begin()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vertex_begin(vb, format);<br>\n    <br>\n    // vertex_position_3d(...)<br>\n    // vertex_color(...)<br>\n    // vertex_texcoord(...)<br>\n    // etc.<br>\n    vertex_begin(vb, format); &nbsp; &nbsp;// Error!<br>\n    <br>\n    // vertex_position_3d(...)<br>\n    // vertex_color(...)<br>\n    // vertex_texcoord(...)<br>\n    // etc.<br>\n    vertex_end(vb);\n  </p>",
-          "text": "vertex_begin(vb, format);\n\n\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_begin(vb, format);    // Error!\n\n\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example above two calls to <span class=\"inline3_func\">vertex_begin()</span> follow each other without a call to <span class=\"inline3_func\">vertex_end()</span> between them. Adding a call to <span class=\"inline3_func\">vertex_end()</span> in between fixes the issue.</p>",
-          "text": "In the example above two calls to vertex_begin() follow each other without a call to vertex_end() between them. Adding a call to vertex_end() in between fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vertex_begin(vb, format);<br>\n    // vertex_position_3d(...)<br>\n    // vertex_color(...)<br>\n    // vertex_texcoord(...)<br>\n    // etc.<br>\n    vertex_end(vb); &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;// End the current one first!<br>\n    <br>\n    vertex_begin(vb, format); &nbsp; &nbsp;// Only then start a new one!<br>\n    // vertex_position_3d(...)<br>\n    // vertex_color(...)<br>\n    // vertex_texcoord(...)<br>\n    // etc.<br>\n    vertex_end(vb);\n  </p>",
-          "text": "vertex_begin(vb, format);\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);              // End the current one first!\n\n\n\n    vertex_begin(vb, format);    // Only then start a new one!\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);"
-        }
-      ]
+      "description": "This message is shown when you start another vertex batch with a call to vertex_begin before having called vertex_end for the current batch. Every call to vertex_begin() must be followed by a call to vertex_end() before a next call to vertex_begin().",
+      "badExample": "vertex_begin(vb, format);\n\n\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_begin(vb, format);    // Error!\n\n\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);",
+      "goodExample": "vertex_begin(vb, format);\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);              // End the current one first!\n\n\n\n    vertex_begin(vb, format);    // Only then start a new one!\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);",
+      "correction": "In the example above two calls to vertex_begin() follow each other without a call to vertex_end() between them. Adding a call to vertex_end() in between fixes the issue."
     },
     {
       "id": "GM2009",
       "title": "Closing a vertex batch without opening a vertex batch.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you close a vertex batch with a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_end.htm\">vertex_end</a></span> before starting the batch with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_begin.htm\">vertex_begin</a></span>.&nbsp;You first need to start the vertex batch with a call to <span class=\"inline3_func\">vertex_begin()</span>, then add vertex data according to the vertex format for the desired number of vertices and finally close the batch with a call to <span class=\"inline3_func\">vertex_end()</span>.</p>",
-          "text": "This message is shown when you close a vertex batch with a call to vertex_end before starting the batch with a call to vertex_begin. You first need to start the vertex batch with a call to vertex_begin(), then add vertex data according to the vertex format for the desired number of vertices and finally close the batch with a call to vertex_end()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vertex_end(vb);</p>",
-          "text": "vertex_end(vb);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example code above a vertex batch is closed using <span class=\"inline3_func\">vertex_end()</span> without ever being opened. The fix is to add a call to <span class=\"inline3_func\">vertex_begin()</span> and add data for the vertices before the call to <span class=\"inline3_func\">vertex_end()</span>.</p>",
-          "text": "In the example code above a vertex batch is closed using vertex_end() without ever being opened. The fix is to add a call to vertex_begin() and add data for the vertices before the call to vertex_end()."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vertex_begin(vb, format);<br>\n    // vertex_position_3d(...)<br>\n    // vertex_color(...)<br>\n    // vertex_texcoord(...)<br>\n    // etc.<br>\n    vertex_end(vb);</p>",
-          "text": "vertex_begin(vb, format);\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);"
-        }
-      ]
+      "description": "This message is shown when you close a vertex batch with a call to vertex_end before starting the batch with a call to vertex_begin. You first need to start the vertex batch with a call to vertex_begin(), then add vertex data according to the vertex format for the desired number of vertices and finally close the batch with a call to vertex_end().",
+      "badExample": "vertex_end(vb);",
+      "goodExample": "vertex_begin(vb, format);\n\n    // vertex_position_3d(...)\n\n    // vertex_color(...)\n\n    // vertex_texcoord(...)\n\n    // etc.\n\n    vertex_end(vb);",
+      "correction": "In the example code above a vertex batch is closed using vertex_end() without ever being opened. The fix is to add a call to vertex_begin() and add data for the vertices before the call to vertex_end()."
     },
     {
       "id": "GM2010",
       "title": "The function '{0}' cannot be called outside of a vertex_begin()/vertex_end() block.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you're attempting to call a function that writes vertex data outside of <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_begin.htm\">vertex_begin</a></span>&nbsp;/ <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_end.htm\">vertex_end</a></span>. Vertex data can only be added after first calling <span class=\"inline3_func\">vertex_begin()</span> and before calling <span class=\"inline3_func\">vertex_end()</span>.</p>",
-          "text": "This message is shown when you're attempting to call a function that writes vertex data outside of vertex_begin / vertex_end. Vertex data can only be added after first calling vertex_begin() and before calling vertex_end()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    format = vertex_format_end();<br>\n    vb = vertex_create_buffer();<br>\n    <br>\n    vertex_begin(vb, format);<br>\n    vertex_end(vb);<br>\n    vertex_position_3d(vb, x, y, 0);<br>\n    vertex_position_3d(vb, x + 100, y, 0);<br>\n    vertex_position_3d(vb, x, y + 100, 0);\n  </p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();\n\n    vb = vertex_create_buffer();\n\n\n\n    vertex_begin(vb, format);\n\n    vertex_end(vb);\n\n    vertex_position_3d(vb, x, y, 0);\n\n    vertex_position_3d(vb, x + 100, y, 0);\n\n    vertex_position_3d(vb, x, y + 100, 0);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, the function calls to write positions to the vertex buffer come after <span class=\"inline3_func\">vertex_end()</span>. To fix this they need to be moved between <span class=\"inline3_func\">vertex_begin()</span> and <span class=\"inline3_func\">vertex_end()</span>.</p>",
-          "text": "In the code example above, the function calls to write positions to the vertex buffer come after vertex_end(). To fix this they need to be moved between vertex_begin() and vertex_end()."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    format = vertex_format_end();<br>\n    vb = vertex_create_buffer();<br>\n    <br>\n    vertex_begin(vb, format);<br>\n    vertex_position_3d(vb, x, y, 0);<br>\n    vertex_position_3d(vb, x + 100, y, 0);<br>\n    vertex_position_3d(vb, x, y + 100, 0);<br>\n    vertex_end(vb);\n  </p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();\n\n    vb = vertex_create_buffer();\n\n\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, x, y, 0);\n\n    vertex_position_3d(vb, x + 100, y, 0);\n\n    vertex_position_3d(vb, x, y + 100, 0);\n\n    vertex_end(vb);"
-        }
-      ]
+      "description": "This message is shown when you're attempting to call a function that writes vertex data outside of vertex_begin / vertex_end. Vertex data can only be added after first calling vertex_begin() and before calling vertex_end().",
+      "badExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();\n\n    vb = vertex_create_buffer();\n\n\n\n    vertex_begin(vb, format);\n\n    vertex_end(vb);\n\n    vertex_position_3d(vb, x, y, 0);\n\n    vertex_position_3d(vb, x + 100, y, 0);\n\n    vertex_position_3d(vb, x, y + 100, 0);",
+      "goodExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();\n\n    vb = vertex_create_buffer();\n\n\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, x, y, 0);\n\n    vertex_position_3d(vb, x + 100, y, 0);\n\n    vertex_position_3d(vb, x, y + 100, 0);\n\n    vertex_end(vb);",
+      "correction": "In the code example above, the function calls to write positions to the vertex buffer come after vertex_end(). To fix this they need to be moved between vertex_begin() and vertex_end()."
     },
     {
       "id": "GM2011",
       "title": "Not all code paths call vertex_end() before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you started writing vertex data to a vertex buffer but haven't properly finished writing the data with a closing call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_end.htm\">vertex_end</a></span>. Every call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_begin.htm\">vertex_begin</a></span> should be accompanied by a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_end.htm\">vertex_end</a></span>. To write data to a vertex buffer you should do the following:</p>",
-          "text": "This message indicates that you started writing vertex data to a vertex buffer but haven't properly finished writing the data with a closing call to vertex_end. Every call to vertex_begin should be accompanied by a call to vertex_end. To write data to a vertex buffer you should do the following:"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vb = vertex_create_buffer();<br>\n    vertex_begin(vb, format);<br>\n    vertex_position_3d(vb, 0, 0, 0);<br>\n    vertex_colour(vb, c_white, 1);<br>\n    // Etc.<br>\n    <br>\n    /// Draw Event<br>\n    vertex_submit(vb, pr_pointlist, -1);\n  </p>",
-          "text": "/// Create Event\n\n    vb = vertex_create_buffer();\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, 0, 0, 0);\n\n    vertex_colour(vb, c_white, 1);\n\n    // Etc.\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_pointlist, -1);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, the vertex buffer isn't properly finished because a call to <span class=\"inline3_func\">vertex_end()</span> is missing. This needs to be added to fix the issue.</p>",
-          "text": "In the code example above, the vertex buffer isn't properly finished because a call to vertex_end() is missing. This needs to be added to fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vb = vertex_create_buffer();<br>\n    vertex_begin(vb, format);<br>\n    vertex_position_3d(vb, 0, 0, 0);<br>\n    vertex_colour(vb, c_white, 1);<br>\n    // Etc.<br>\n    vertex_end(vb);<br>\n    <br>\n    /// Draw Event<br>\n    vertex_submit(vb, pr_pointlist, -1);\n  </p>",
-          "text": "/// Create Event\n\n    vb = vertex_create_buffer();\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, 0, 0, 0);\n\n    vertex_colour(vb, c_white, 1);\n\n    // Etc.\n\n    vertex_end(vb);\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_pointlist, -1);"
-        }
-      ]
+      "description": "This message indicates that you started writing vertex data to a vertex buffer but haven't properly finished writing the data with a closing call to vertex_end. Every call to vertex_begin should be accompanied by a call to vertex_end. To write data to a vertex buffer you should do the following:",
+      "badExample": "/// Create Event\n\n    vb = vertex_create_buffer();\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, 0, 0, 0);\n\n    vertex_colour(vb, c_white, 1);\n\n    // Etc.\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_pointlist, -1);",
+      "goodExample": "/// Create Event\n\n    vb = vertex_create_buffer();\n\n    vertex_begin(vb, format);\n\n    vertex_position_3d(vb, 0, 0, 0);\n\n    vertex_colour(vb, c_white, 1);\n\n    // Etc.\n\n    vertex_end(vb);\n\n\n\n    /// Draw Event\n\n    vertex_submit(vb, pr_pointlist, -1);",
+      "correction": "In the code example above, the vertex buffer isn't properly finished because a call to vertex_end() is missing. This needs to be added to fix the issue."
     },
     {
       "id": "GM2012",
       "title": "Opening another vertex format before closing a previous vertex format.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you begin a new vertex format with&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_begin.htm\">vertex_format_begin</a></span> before finishing the previous one with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_end.htm\">vertex_format_end</a></span>. A vertex format must always be closed before starting a new one.</p>",
-          "text": "This message is shown when you begin a new vertex format with vertex_format_begin before finishing the previous one with a call to vertex_format_end. A vertex format must always be closed before starting a new one."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    format1 = vertex_format_end();<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_texcoord();<br>\n    format2 = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format1 = vertex_format_end();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_texcoord();\n\n    format2 = vertex_format_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example code above, one vertex format definition is nested inside another one. As a result, a vertex format is being defined while another one's definition hasn't finished. To fix this, all vertex formats should be defined one after the other:</p>",
-          "text": "In the example code above, one vertex format definition is nested inside another one. As a result, a vertex format is being defined while another one's definition hasn't finished. To fix this, all vertex formats should be defined one after the other:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    format1 = vertex_format_end();<br>\n    <br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_texcoord();<br>\n    format2 = vertex_format_end();\n  </p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format1 = vertex_format_end();\n\n\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_texcoord();\n\n    format2 = vertex_format_end();"
-        }
-      ]
+      "description": "This message is shown when you begin a new vertex format with vertex_format_begin before finishing the previous one with a call to vertex_format_end. A vertex format must always be closed before starting a new one.",
+      "badExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format1 = vertex_format_end();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_texcoord();\n\n    format2 = vertex_format_end();",
+      "goodExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format1 = vertex_format_end();\n\n\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_texcoord();\n\n    format2 = vertex_format_end();",
+      "correction": "In the example code above, one vertex format definition is nested inside another one. As a result, a vertex format is being defined while another one's definition hasn't finished. To fix this, all vertex formats should be defined one after the other:"
     },
     {
       "id": "GM2013",
       "title": "Closing a vertex format without opening a vertex format.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you close a vertex format with&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_end.htm\">vertex_format_end</a></span> without first having called <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_begin.htm\">vertex_format_begin</a></span>.</p>",
-          "text": "This message is shown when you close a vertex format with vertex_format_end without first having called vertex_format_begin."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    format = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    format = vertex_format_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The code example above closes the vertex format without ever having started it with a call to <span class=\"inline3_func\">vertex_format_begin()</span>. The vertex format should be opened with a call to this function and at least one vertex attribute should be added to it using one of the <span class=\"inline2\">vertex_format_add_*</span> functions.</p>",
-          "text": "The code example above closes the vertex format without ever having started it with a call to vertex_format_begin(). The vertex format should be opened with a call to this function and at least one vertex attribute should be added to it using one of the vertex_format_add_* functions."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    format = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();"
-        }
-      ]
+      "description": "This message is shown when you close a vertex format with vertex_format_end without first having called vertex_format_begin.",
+      "badExample": "/// Create Event\n\n    format = vertex_format_end();",
+      "goodExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    format = vertex_format_end();",
+      "correction": "The code example above closes the vertex format without ever having started it with a call to vertex_format_begin(). The vertex format should be opened with a call to this function and at least one vertex attribute should be added to it using one of the vertex_format_add_* functions."
     },
     {
       "id": "GM2014",
       "title": "The function '{0}' cannot be called outside of a vertex_format_begin()/vertex_format_end() block.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>The <span class=\"inline2\">vertex_format_add_*</span> functions can only be called between a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_begin.htm\">vertex_format_begin</a></span> and <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_end.htm\">vertex_format_end</a></span>. The function <span class=\"inline3_func\">vertex_format_begin()</span> starts the vertex format, calls to <span class=\"inline3_func\">vertex_format_add_*</span> define the vertex format's attributes and the function <span class=\"inline3_func\">vertex_format_end()</span> ends the definition of the vertex format and returns it.</p>",
-          "text": "The vertex_format_add_* functions can only be called between a call to vertex_format_begin and vertex_format_end. The function vertex_format_begin() starts the vertex format, calls to vertex_format_add_* define the vertex format's attributes and the function vertex_format_end() ends the definition of the vertex format and returns it."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_colour();<br>\n    vertex_format_add_texcoord();<br>\n    vertex_format_begin();<br>\n    format = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    vertex_format_begin();\n\n    format = vertex_format_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, the <span class=\"inline3_func\">vertex_format_add_*</span> functions are called before the call to <span class=\"inline3_func\">vertex_format_begin()</span> that begins the actual definition of a vertex format. These functions always go between <span class=\"inline3_func\">vertex_format_begin()</span> and <span class=\"inline3_func\">vertex_format_end()</span>. Moving the call to <span class=\"inline3_func\">vertex_format_begin()</span> before the first <span class=\"inline2\">vertex_format_add_*</span> call fixes the issue.</p>",
-          "text": "In the code example above, the vertex_format_add_* functions are called before the call to vertex_format_begin() that begins the actual definition of a vertex format. These functions always go between vertex_format_begin() and vertex_format_end(). Moving the call to vertex_format_begin() before the first vertex_format_add_* call fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_colour();<br>\n    vertex_format_add_texcoord();<br>\n    format = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    format = vertex_format_end();"
-        }
-      ]
+      "description": "The vertex_format_add_* functions can only be called between a call to vertex_format_begin and vertex_format_end. The function vertex_format_begin() starts the vertex format, calls to vertex_format_add_* define the vertex format's attributes and the function vertex_format_end() ends the definition of the vertex format and returns it.",
+      "badExample": "/// Create Event\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    vertex_format_begin();\n\n    format = vertex_format_end();",
+      "goodExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    format = vertex_format_end();",
+      "correction": "In the code example above, the vertex_format_add_* functions are called before the call to vertex_format_begin() that begins the actual definition of a vertex format. These functions always go between vertex_format_begin() and vertex_format_end(). Moving the call to vertex_format_begin() before the first vertex_format_add_* call fixes the issue."
     },
     {
       "id": "GM2015",
       "title": "Not all code paths call vertex_format_end() before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you started the definition of a vertex format with&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_begin.htm\">vertex_format_begin</a></span> but haven't finished it with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/vertex_format_end.htm\">vertex_format_end</a></span>. The call to <span class=\"inline3_func\">vertex_format_end()</span> returns the actual vertex format.</p>",
-          "text": "This message is shown when you started the definition of a vertex format with vertex_format_begin but haven't finished it with a call to vertex_format_end. The call to vertex_format_end() returns the actual vertex format."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_colour();<br>\n    vertex_format_add_texcoord();</p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A vertex format definition isn't complete without a call to <span class=\"inline3_func\">vertex_format_end()</span> that returns the format. This needs to be added to fix the issue.</p>",
-          "text": "A vertex format definition isn't complete without a call to vertex_format_end() that returns the format. This needs to be added to fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    vertex_format_begin();<br>\n    vertex_format_add_position_3d();<br>\n    vertex_format_add_colour();<br>\n    vertex_format_add_texcoord();<br>\n    format = vertex_format_end();</p>",
-          "text": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    format = vertex_format_end();"
-        }
-      ]
+      "description": "This message is shown when you started the definition of a vertex format with vertex_format_begin but haven't finished it with a call to vertex_format_end. The call to vertex_format_end() returns the actual vertex format.",
+      "badExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();",
+      "goodExample": "/// Create Event\n\n    vertex_format_begin();\n\n    vertex_format_add_position_3d();\n\n    vertex_format_add_colour();\n\n    vertex_format_add_texcoord();\n\n    format = vertex_format_end();",
+      "correction": "A vertex format definition isn't complete without a call to vertex_format_end() that returns the format. This needs to be added to fix the issue."
     },
     {
       "id": "GM2016",
       "title": "Instance variable '{0}' declared outside of Create event, declare with 'var' or move to Create event.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you declare an <a href=\"../../GameMaker_Language/GML_Overview/Variables/Instance_Variables.htm\" title=\"Instance Variables\">instance variable</a> outside of the Create event. Instance variables should always be created in the Create event to guarantee that you'll be able to access them in all other events.</p>",
-          "text": "This message is shown when you declare an instance variable outside of the Create event. Instance variables should always be created in the Create event to guarantee that you'll be able to access them in all other events."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>When you don't define instance variables in the Create event, you might at one point run into a situation where that variable doesn't exist yet. For example, when you first define the instance variable in the Step event and only use it in the Step event, this won't cause problems. Though when you later decide to add a Begin Step event to the object and attempt to access the variable there, an error will be thrown when your game runs. This is because Begin Step events run before Step events and the first Step event hasn't run yet when the first Begin Step event runs.</p>",
-          "text": "When you don't define instance variables in the Create event, you might at one point run into a situation where that variable doesn't exist yet. For example, when you first define the instance variable in the Step event and only use it in the Step event, this won't cause problems. Though when you later decide to add a Begin Step event to the object and attempt to access the variable there, an error will be thrown when your game runs. This is because Begin Step events run before Step events and the first Step event hasn't run yet when the first Begin Step event runs."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    ammo_initialised = false;<br>\n    <br>\n    /// Begin Step Event<br>\n    <br>\n    /// Step Event<br>\n    if (!ammo_initialised)<br>\n    {<br>\n    &nbsp; &nbsp; ammo = 0;<br>\n    &nbsp; &nbsp; ammo_initialised = true;<br>\n    }<br>\n    var _ins_ammo = instance_place(x, y, obj_ammo);<br>\n    if (_ins_ammo != noone)<br>\n    {<br>\n    &nbsp; &nbsp; // Collect ammo<br>\n    &nbsp; &nbsp; ammo++;<br>\n    &nbsp; &nbsp; instance_destroy(_ins_ammo);<br>\n    }\n  </p>",
-          "text": "/// Create Event\n\n    ammo_initialised = false;\n\n\n\n    /// Begin Step Event\n\n\n\n    /// Step Event\n\n    if (!ammo_initialised)\n\n    {\n\n        ammo = 0;\n\n        ammo_initialised = true;\n\n    }\n\n    var _ins_ammo = instance_place(x, y, obj_ammo);\n\n    if (_ins_ammo != noone)\n\n    {\n\n        // Collect ammo\n\n        ammo++;\n\n        instance_destroy(_ins_ammo);\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>This issue is fixed by moving the declaration of the variable to the object's Create event.</p>",
-          "text": "This issue is fixed by moving the declaration of the variable to the object's Create event."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    ammo = 0;<br>\n    <br>\n    /// Begin Step Event<br>\n    // Do something with ammo here<br>\n    <br>\n    /// Step Event<br>\n    var _ins_ammo = instance_place(x, y, obj_ammo);<br>\n    if (_ins_ammo != noone)<br>\n    {<br>\n    &nbsp; &nbsp; // Collect ammo<br>\n    &nbsp; &nbsp; ammo++;<br>\n    &nbsp; &nbsp; instance_destroy(_ins_ammo);<br>\n    }\n  </p>",
-          "text": "/// Create Event\n\n    ammo = 0;\n\n\n\n    /// Begin Step Event\n\n    // Do something with ammo here\n\n\n\n    /// Step Event\n\n    var _ins_ammo = instance_place(x, y, obj_ammo);\n\n    if (_ins_ammo != noone)\n\n    {\n\n        // Collect ammo\n\n        ammo++;\n\n        instance_destroy(_ins_ammo);\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you declare an instance variable outside of the Create event. Instance variables should always be created in the Create event to guarantee that you'll be able to access them in all other events.\n\nWhen you don't define instance variables in the Create event, you might at one point run into a situation where that variable doesn't exist yet. For example, when you first define the instance variable in the Step event and only use it in the Step event, this won't cause problems. Though when you later decide to add a Begin Step event to the object and attempt to access the variable there, an error will be thrown when your game runs. This is because Begin Step events run before Step events and the first Step event hasn't run yet when the first Begin Step event runs.",
+      "badExample": "/// Create Event\n\n    ammo_initialised = false;\n\n\n\n    /// Begin Step Event\n\n\n\n    /// Step Event\n\n    if (!ammo_initialised)\n\n    {\n\n        ammo = 0;\n\n        ammo_initialised = true;\n\n    }\n\n    var _ins_ammo = instance_place(x, y, obj_ammo);\n\n    if (_ins_ammo != noone)\n\n    {\n\n        // Collect ammo\n\n        ammo++;\n\n        instance_destroy(_ins_ammo);\n\n    }",
+      "goodExample": "/// Create Event\n\n    ammo = 0;\n\n\n\n    /// Begin Step Event\n\n    // Do something with ammo here\n\n\n\n    /// Step Event\n\n    var _ins_ammo = instance_place(x, y, obj_ammo);\n\n    if (_ins_ammo != noone)\n\n    {\n\n        // Collect ammo\n\n        ammo++;\n\n        instance_destroy(_ins_ammo);\n\n    }",
+      "correction": "This issue is fixed by moving the declaration of the variable to the object's Create event."
     },
     {
       "id": "GM2017",
       "title": "Inconsistent naming. Recommended name is '{0}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when Feather encounters a name in your code that's not named according to the naming rules as defined under Feather Settings &gt; Naming Rules. The names can be asset names, names of variables in a particular scope (local, instance, etc.) as well as function, constructor, enum and macro names.</p>",
-          "text": "This message is shown when Feather encounters a name in your code that's not named according to the naming rules as defined under Feather Settings > Naming Rules. The names can be asset names, names of variables in a particular scope (local, instance, etc.) as well as function, constructor, enum and macro names."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Note that Feather will check against your own naming rules when you customise them in the <a data-xref=\"{title}\" href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm\">Feather Preferences</a>.</p>",
-          "text": "Note that Feather will check against your own naming rules when you customise them in the Feather Preferences."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;s = sprSprite;<br>\n    enum size<br>\n    {<br>\n    &nbsp; &nbsp; small,<br>\n    &nbsp; &nbsp; medium,<br>\n    &nbsp; &nbsp; large<br>\n    }<br>\n    <br>\n    function Show()<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"Here it is!\");<br>\n    }\n  </p>",
-          "text": "var s = sprSprite;\n\n    enum size\n\n    {\n\n        small,\n\n        medium,\n\n        large\n\n    }\n\n\n\n    function Show()\n\n    {\n\n        show_debug_message(\"Here it is!\");\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The code in the example above contains a few names that aren't named according to Feather's default naming rules. To make them consistent with these rules, the code should be changed to the following:</p>",
-          "text": "The code in the example above contains a few names that aren't named according to Feather's default naming rules. To make them consistent with these rules, the code should be changed to the following:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_s = spr_sprite;<br>\n    enum SIZE<br>\n    {<br>\n    &nbsp; &nbsp; SMALL,<br>\n    &nbsp; &nbsp; MEDIUM,<br>\n    &nbsp; &nbsp; LARGE<br>\n    }<br>\n    <br>\n    function show()<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"Here it is!\");<br>\n    }\n  </p>",
-          "text": "var _s = spr_sprite;\n\n    enum SIZE\n\n    {\n\n        SMALL,\n\n        MEDIUM,\n\n        LARGE\n\n    }\n\n\n\n    function show()\n\n    {\n\n        show_debug_message(\"Here it is!\");\n\n    }"
-        }
-      ]
+      "description": "This message is shown when Feather encounters a name in your code that's not named according to the naming rules as defined under Feather Settings > Naming Rules. The names can be asset names, names of variables in a particular scope (local, instance, etc.) as well as function, constructor, enum and macro names.\n\nNote that Feather will check against your own naming rules when you customise them in the Feather Preferences.",
+      "badExample": "var s = sprSprite;\n\n    enum size\n\n    {\n\n        small,\n\n        medium,\n\n        large\n\n    }\n\n\n\n    function Show()\n\n    {\n\n        show_debug_message(\"Here it is!\");\n\n    }",
+      "goodExample": "var _s = spr_sprite;\n\n    enum SIZE\n\n    {\n\n        SMALL,\n\n        MEDIUM,\n\n        LARGE\n\n    }\n\n\n\n    function show()\n\n    {\n\n        show_debug_message(\"Here it is!\");\n\n    }",
+      "correction": "The code in the example above contains a few names that aren't named according to Feather's default naming rules. To make them consistent with these rules, the code should be changed to the following:"
     },
     {
       "id": "GM2019",
       "title": "Not all code paths call draw_set_valign(fa_top) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This warning message indicates that you changed the vertical text alignment to a value different from the default (<span class=\"inline2\">fa_top</span>) but haven't changed it back afterwards.</p>",
-          "text": "This warning message indicates that you changed the vertical text alignment to a value different from the default (fa_top) but haven't changed it back afterwards."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw GUI Begin Event<br>\n    draw_set_valign(fa_bottom);<br>\n    draw_text(5, room_height-5, \"In the bottom-left corner\");<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"In the top-left corner\");\n  </p>",
-          "text": "/// Draw GUI Begin Event\n\n    draw_set_valign(fa_bottom);\n\n    draw_text(5, room_height-5, \"In the bottom-left corner\");\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the above code example, the vertical text alignment is set to bottom-aligned and some text is drawn in the Draw GUI Begin event. The text alignment isn't reset to <span class=\"inline2\">fa_top</span>, however, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn bottom-aligned at a position in the top-left corner of the window. Resetting the vertical text alignment back to <span class=\"inline2\">fa_top</span> fixes the issue.</p>",
-          "text": "In the above code example, the vertical text alignment is set to bottom-aligned and some text is drawn in the Draw GUI Begin event. The text alignment isn't reset to fa_top, however, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn bottom-aligned at a position in the top-left corner of the window. Resetting the vertical text alignment back to fa_top fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw GUI Begin Event<br>\n    draw_set_valign(fa_bottom);<br>\n    draw_text(5, room_height-5, \"In the bottom-left corner\");<br>\n    draw_set_valign(fa_top);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"In the top-left corner\");\n  </p>",
-          "text": "/// Draw GUI Begin Event\n\n    draw_set_valign(fa_bottom);\n\n    draw_text(5, room_height-5, \"In the bottom-left corner\");\n\n    draw_set_valign(fa_top);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");"
-        }
-      ]
+      "description": "This warning message indicates that you changed the vertical text alignment to a value different from the default (fa_top) but haven't changed it back afterwards.",
+      "badExample": "/// Draw GUI Begin Event\n\n    draw_set_valign(fa_bottom);\n\n    draw_text(5, room_height-5, \"In the bottom-left corner\");\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");",
+      "goodExample": "/// Draw GUI Begin Event\n\n    draw_set_valign(fa_bottom);\n\n    draw_text(5, room_height-5, \"In the bottom-left corner\");\n\n    draw_set_valign(fa_top);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");",
+      "correction": "In the above code example, the vertical text alignment is set to bottom-aligned and some text is drawn in the Draw GUI Begin event. The text alignment isn't reset to fa_top, however, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn bottom-aligned at a position in the top-left corner of the window. Resetting the vertical text alignment back to fa_top fixes the issue."
     },
     {
       "id": "GM2020",
       "title": "all cannot be referenced in this way.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you attempt to reference the keyword&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Instance Keywords/all.htm\">all</a></span> in the dot operator. The keyword <span class=\"inline2\">all</span> can be used in a&nbsp;<span class=\"inline2\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Overview/Language_Features/with.htm\">with</a></span> statement to indicate that it should loop through all instances, but it cannot be used with the dot operator to change a variable in all instances at the same time.</p>",
-          "text": "This message is shown when you attempt to reference the keyword all in the dot operator. The keyword all can be used in a with statement to indicate that it should loop through all instances, but it cannot be used with the dot operator to change a variable in all instances at the same time."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">all.x = 200;</p>",
-          "text": "all.x = 200;"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fix for this issue is to use the keyword <span class=\"inline2\">all</span> in a <span class=\"inline2\">with</span> statement.</p>",
-          "text": "The fix for this issue is to use the keyword all in a with statement."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">with (all)<br>\n    {<br>\n    &nbsp; &nbsp; x = 200;<br>\n    }</p>",
-          "text": "with (all)\n\n    {\n\n        x = 200;\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you attempt to reference the keyword all in the dot operator. The keyword all can be used in a with statement to indicate that it should loop through all instances, but it cannot be used with the dot operator to change a variable in all instances at the same time.",
+      "badExample": "all.x = 200;",
+      "goodExample": "with (all)\n\n    {\n\n        x = 200;\n\n    }",
+      "correction": "The fix for this issue is to use the keyword all in a with statement."
     },
     {
       "id": "GM2022",
       "title": "Return value of a pure function is not being used.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've&nbsp;called a&nbsp;<a class=\"glossterm\" data-glossterm=\"pure\" href=\"#\">pure</a> function, which doesn't change anything and only returns a value, without using its return value. The return value can be used by assigning it to a variable, using it in an expression or by passing it as a parameter in a function call.</p>",
-          "text": "This message indicates that you've called a pure function, which doesn't change anything and only returns a value, without using its return value. The return value can be used by assigning it to a variable, using it in an expression or by passing it as a parameter in a function call."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">variable_get_hash(\"member\");<br>\n    choose(\"a\", \"b\", \"c\");<br>\n    make_colour_rgb(255, 255, 0);</p>",
-          "text": "variable_get_hash(\"member\");\n\n    choose(\"a\", \"b\", \"c\");\n\n    make_colour_rgb(255, 255, 0);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The return value needs be used in the code in order to fix the issue.</p>",
-          "text": "The return value needs be used in the code in order to fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_hash = variable_get_hash(\"member\");<br>\n    if (choose(\"a\", \"b\", \"c\") == \"a\") { show_debug_message(\"Good choice!\"); }<br>\n    draw_set_colour(make_colour_rgb(255, 255, 0));</p>",
-          "text": "var _hash = variable_get_hash(\"member\");\n\n    if (choose(\"a\", \"b\", \"c\") == \"a\") { show_debug_message(\"Good choice!\"); }\n\n    draw_set_colour(make_colour_rgb(255, 255, 0));"
-        }
-      ]
+      "description": "This message indicates that you've called a pure function, which doesn't change anything and only returns a value, without using its return value. The return value can be used by assigning it to a variable, using it in an expression or by passing it as a parameter in a function call.",
+      "badExample": "variable_get_hash(\"member\");\n\n    choose(\"a\", \"b\", \"c\");\n\n    make_colour_rgb(255, 255, 0);",
+      "goodExample": "var _hash = variable_get_hash(\"member\");\n\n    if (choose(\"a\", \"b\", \"c\") == \"a\") { show_debug_message(\"Good choice!\"); }\n\n    draw_set_colour(make_colour_rgb(255, 255, 0));",
+      "correction": "The return value needs be used in the code in order to fix the issue."
     },
     {
       "id": "GM2023",
       "title": "Evaluation order of function calls in argument list not guaranteed between platforms.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when there are multiple function calls in the argument list when calling a function. When a function is called, the arguments are not necessarily initialised in the order they're defined in the argument list. As a consequence, when the arguments contain function calls, those function calls may not execute in the order you'd expect. In some specific cases, such as when a function reads data sequentially, this can give unexpected results.</p>",
-          "text": "This message is shown when there are multiple function calls in the argument list when calling a function. When a function is called, the arguments are not necessarily initialised in the order they're defined in the argument list. As a consequence, when the arguments contain function calls, those function calls may not execute in the order you'd expect. In some specific cases, such as when a function reads data sequentially, this can give unexpected results."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">vertex_position_3d(vb, buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32));<br>\n    /// z will be x, y will be y, x will be z<br>\n    /// since the buffer_read's are called in order last to first</p>",
-          "text": "vertex_position_3d(vb, buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32));\n\n    /// z will be x, y will be y, x will be z\n\n    /// since the buffer_read's are called in order last to first"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To make sure the assignments are done in the correct order you call the functions and assign the result of each of them to a temporary variable before calling the actual function. Then call the actual function and pass the temporary variables as the arguments.</p>",
-          "text": "To make sure the assignments are done in the correct order you call the functions and assign the result of each of them to a temporary variable before calling the actual function. Then call the actual function and pass the temporary variables as the arguments."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var&nbsp;_x = buffer_read(buff, buffer_f32);<br>\n    var&nbsp;_y = buffer_read(buff, buffer_f32);<br>\n    var&nbsp;_z = buffer_read(buff, buffer_f32);<br>\n    vertex_position_3d(vb, _x, _y, _z);</p>",
-          "text": "var _x = buffer_read(buff, buffer_f32);\n\n    var _y = buffer_read(buff, buffer_f32);\n\n    var _z = buffer_read(buff, buffer_f32);\n\n    vertex_position_3d(vb, _x, _y, _z);"
-        }
-      ]
+      "description": "This message is shown when there are multiple function calls in the argument list when calling a function. When a function is called, the arguments are not necessarily initialised in the order they're defined in the argument list. As a consequence, when the arguments contain function calls, those function calls may not execute in the order you'd expect. In some specific cases, such as when a function reads data sequentially, this can give unexpected results.",
+      "badExample": "vertex_position_3d(vb, buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32), buffer_read(buff, buffer_f32));\n\n    /// z will be x, y will be y, x will be z\n\n    /// since the buffer_read's are called in order last to first",
+      "goodExample": "var _x = buffer_read(buff, buffer_f32);\n\n    var _y = buffer_read(buff, buffer_f32);\n\n    var _z = buffer_read(buff, buffer_f32);\n\n    vertex_position_3d(vb, _x, _y, _z);",
+      "correction": "To make sure the assignments are done in the correct order you call the functions and assign the result of each of them to a temporary variable before calling the actual function. Then call the actual function and pass the temporary variables as the arguments."
     },
     {
       "id": "GM2025",
       "title": "Reference to non-existent event '{0}'.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>Shown when a <a href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_user.htm\">user event</a> is called but that user event does not exist in the object.</p>",
-          "text": "Shown when a user event is called but that user event does not exist in the object."
-        }
-      ]
+      "description": "Shown when a user event is called but that user event does not exist in the object.",
+      "badExample": null,
+      "goodExample": null,
+      "correction": null
     },
     {
       "id": "GM2026",
       "title": "Not all code paths call draw_set_halign(fa_left) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you changed the horizontal text alignment to a value different from the default (<span class=\"inline2\">fa_left</span>) but haven't changed it back afterwards.</p>",
-          "text": "This message indicates that you changed the horizontal text alignment to a value different from the default (fa_left) but haven't changed it back afterwards."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw GUI Begin Event<br>\n    draw_set_halign(fa_right);<br>\n    draw_text(room_width-5, 5, \"In the top-right corner\");<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"In the top-left corner\");\n  </p>",
-          "text": "/// Draw GUI Begin Event\n\n    draw_set_halign(fa_right);\n\n    draw_text(room_width-5, 5, \"In the top-right corner\");\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example code above, the horizontal text alignment is set to right-aligned and some text is drawn in the Draw GUI Begin event. However, the text alignment isn't reset to <span class=\"inline2\">fa_left</span>, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn right-aligned at a position in the top-left corner of the window. Resetting the horizontal text alignment back to <span class=\"inline2\">fa_left</span> fixes the issue.</p>",
-          "text": "In the example code above, the horizontal text alignment is set to right-aligned and some text is drawn in the Draw GUI Begin event. However, the text alignment isn't reset to fa_left, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn right-aligned at a position in the top-left corner of the window. Resetting the horizontal text alignment back to fa_left fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw GUI Begin Event<br>\n    draw_set_halign(fa_right);<br>\n    draw_text(room_width-5, 5, \"In the top-right corner\");<br>\n    draw_set_halign(fa_left);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"In the top-left corner\");\n  </p>",
-          "text": "/// Draw GUI Begin Event\n\n    draw_set_halign(fa_right);\n\n    draw_text(room_width-5, 5, \"In the top-right corner\");\n\n    draw_set_halign(fa_left);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");"
-        }
-      ]
+      "description": "This message indicates that you changed the horizontal text alignment to a value different from the default (fa_left) but haven't changed it back afterwards.",
+      "badExample": "/// Draw GUI Begin Event\n\n    draw_set_halign(fa_right);\n\n    draw_text(room_width-5, 5, \"In the top-right corner\");\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");",
+      "goodExample": "/// Draw GUI Begin Event\n\n    draw_set_halign(fa_right);\n\n    draw_text(room_width-5, 5, \"In the top-right corner\");\n\n    draw_set_halign(fa_left);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"In the top-left corner\");",
+      "correction": "In the example code above, the horizontal text alignment is set to right-aligned and some text is drawn in the Draw GUI Begin event. However, the text alignment isn't reset to fa_left, which causes text in the Draw GUI Event that follows it to be drawn mostly offscreen. This is because it is drawn right-aligned at a position in the top-left corner of the window. Resetting the horizontal text alignment back to fa_left fixes the issue."
     },
     {
       "id": "GM2027",
       "title": "Opening another primitive before closing a previous primitive.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you open another primitive using&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_begin.htm\">draw_primitive_begin</a></span> without closing the current primitive with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_end.htm\">draw_primitive_end</a></span>.</p>",
-          "text": "This message is shown when you open another primitive using draw_primitive_begin without closing the current primitive with a call to draw_primitive_end."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A primitive is always drawn with a call to <span class=\"inline3_func\">draw_primitive_begin()</span>, followed by multiple calls to one of the <span class=\"inline2\">draw_vertex*</span> functions and finally a call to <span class=\"inline3_func\">draw_primitive_end()</span>.</p>",
-          "text": "A primitive is always drawn with a call to draw_primitive_begin(), followed by multiple calls to one of the draw_vertex* functions and finally a call to draw_primitive_end()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_primitive_begin(pr_linestrip);<br>\n    draw_vertex(0, 0);<br>\n    draw_vertex(10, 0);<br>\n    draw_vertex(0, 10);<br>\n    draw_primitive_begin(pr_linestrip);<br>\n    draw_vertex(10, 0);<br>\n    draw_vertex(20, 0);<br>\n    draw_vertex(10, 10);<br>\n    draw_primitive_end();</p>",
-          "text": "/// Draw Event\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(0, 0);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(0, 10);\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(20, 0);\n\n    draw_vertex(10, 10);\n\n    draw_primitive_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The first primitive is missing a <span class=\"inline3_func\">draw_primitive_end()</span> call after the calls to <span class=\"inline3_func\">draw_vertex()</span>. Adding it fixes the issue.</p>",
-          "text": "The first primitive is missing a draw_primitive_end() call after the calls to draw_vertex(). Adding it fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_primitive_begin(pr_linestrip);<br>\n    draw_vertex(0, 0);<br>\n    draw_vertex(10, 0);<br>\n    draw_vertex(0, 10);<br>\n    draw_primitive_end();<br>\n    <br>\n    draw_primitive_begin(pr_linestrip);<br>\n    draw_vertex(10, 0);<br>\n    draw_vertex(20, 0);<br>\n    draw_vertex(10, 10);<br>\n    draw_primitive_end();\n  </p>",
-          "text": "/// Draw Event\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(0, 0);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(0, 10);\n\n    draw_primitive_end();\n\n\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(20, 0);\n\n    draw_vertex(10, 10);\n\n    draw_primitive_end();"
-        }
-      ]
+      "description": "This message is shown when you open another primitive using draw_primitive_begin without closing the current primitive with a call to draw_primitive_end.\n\nA primitive is always drawn with a call to draw_primitive_begin(), followed by multiple calls to one of the draw_vertex* functions and finally a call to draw_primitive_end().",
+      "badExample": "/// Draw Event\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(0, 0);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(0, 10);\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(20, 0);\n\n    draw_vertex(10, 10);\n\n    draw_primitive_end();",
+      "goodExample": "/// Draw Event\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(0, 0);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(0, 10);\n\n    draw_primitive_end();\n\n\n\n    draw_primitive_begin(pr_linestrip);\n\n    draw_vertex(10, 0);\n\n    draw_vertex(20, 0);\n\n    draw_vertex(10, 10);\n\n    draw_primitive_end();",
+      "correction": "The first primitive is missing a draw_primitive_end() call after the calls to draw_vertex(). Adding it fixes the issue."
     },
     {
       "id": "GM2028",
       "title": "Closing a primitive without opening a primitive.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you made a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_end.htm\">draw_primitive_end</a></span> to close a primitive, but haven't opened a primitive first with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_begin.htm\">draw_primitive_begin</a></span>.</p>",
-          "text": "This message indicates that you made a call to draw_primitive_end to close a primitive, but haven't opened a primitive first with a call to draw_primitive_begin."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_primitive_end(); &nbsp;// Which primitive to close?</p>",
-          "text": "/// Draw Event\n\n    draw_primitive_end();  // Which primitive to close?"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Calling <span class=\"inline3_func\">draw_primitive_begin()</span> before <span class=\"inline3_func\">draw_primitive_end()</span> fixes this issue.</p>",
-          "text": "Calling draw_primitive_begin() before draw_primitive_end() fixes this issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_primitive_begin(pr_linelist);<br>\n    <br>\n    // draw_vertex, draw_vertex_colour, etc.<br>\n    <br>\n    draw_primitive_end();\n  </p>",
-          "text": "/// Draw Event\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    // draw_vertex, draw_vertex_colour, etc.\n\n\n\n    draw_primitive_end();"
-        }
-      ]
+      "description": "This message indicates that you made a call to draw_primitive_end to close a primitive, but haven't opened a primitive first with a call to draw_primitive_begin.",
+      "badExample": "/// Draw Event\n\n    draw_primitive_end();  // Which primitive to close?",
+      "goodExample": "/// Draw Event\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    // draw_vertex, draw_vertex_colour, etc.\n\n\n\n    draw_primitive_end();",
+      "correction": "Calling draw_primitive_begin() before draw_primitive_end() fixes this issue."
     },
     {
       "id": "GM2029",
       "title": "The function '{0}' cannot be called outside of a draw_primitive_begin()/draw_primitive_end() block.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you use one of the <span class=\"inline2\">draw_vertex*</span> functions outside of&nbsp; <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_begin.htm\">draw_primitive_begin</a></span>&nbsp;/ <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_end.htm\">draw_primitive_end</a></span>. These functions add vertices when drawing a primitive and only do something when called between <span class=\"inline3_func\">draw_primitive_begin()</span> and <span class=\"inline3_func\">draw_primitive_end()</span>.</p>",
-          "text": "This message is shown when you use one of the draw_vertex* functions outside of draw_primitive_begin / draw_primitive_end. These functions add vertices when drawing a primitive and only do something when called between draw_primitive_begin() and draw_primitive_end()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_vertex(room_width/4, room_height/4);<br>\n    draw_vertex(room_width/2, room_height/4);<br>\n    draw_vertex(room_width/4, room_height/2);<br>\n    draw_primitive_begin(pr_trianglelist);<br>\n    draw_primitive_end();</p>",
-          "text": "/// Draw Event\n\n    draw_vertex(room_width/4, room_height/4);\n\n    draw_vertex(room_width/2, room_height/4);\n\n    draw_vertex(room_width/4, room_height/2);\n\n    draw_primitive_begin(pr_trianglelist);\n\n    draw_primitive_end();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example, the calls to <span class=\"inline3_func\">draw_vertex()</span> need to be moved between the calls to <span class=\"inline3_func\">draw_primitive_begin()</span> and <span class=\"inline3_func\">draw_primitive_end()</span>.</p>",
-          "text": "In the code example, the calls to draw_vertex() need to be moved between the calls to draw_primitive_begin() and draw_primitive_end()."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_primitive_begin(pr_trianglelist);<br>\n    draw_vertex(room_width/4, room_height/4);<br>\n    draw_vertex(room_width/2, room_height/4);<br>\n    draw_vertex(room_width/4, room_height/2);<br>\n    draw_primitive_end();</p>",
-          "text": "/// Draw Event\n\n    draw_primitive_begin(pr_trianglelist);\n\n    draw_vertex(room_width/4, room_height/4);\n\n    draw_vertex(room_width/2, room_height/4);\n\n    draw_vertex(room_width/4, room_height/2);\n\n    draw_primitive_end();"
-        }
-      ]
+      "description": "This message is shown when you use one of the draw_vertex* functions outside of draw_primitive_begin / draw_primitive_end. These functions add vertices when drawing a primitive and only do something when called between draw_primitive_begin() and draw_primitive_end().",
+      "badExample": "/// Draw Event\n\n    draw_vertex(room_width/4, room_height/4);\n\n    draw_vertex(room_width/2, room_height/4);\n\n    draw_vertex(room_width/4, room_height/2);\n\n    draw_primitive_begin(pr_trianglelist);\n\n    draw_primitive_end();",
+      "goodExample": "/// Draw Event\n\n    draw_primitive_begin(pr_trianglelist);\n\n    draw_vertex(room_width/4, room_height/4);\n\n    draw_vertex(room_width/2, room_height/4);\n\n    draw_vertex(room_width/4, room_height/2);\n\n    draw_primitive_end();",
+      "correction": "In the code example, the calls to draw_vertex() need to be moved between the calls to draw_primitive_begin() and draw_primitive_end()."
     },
     {
       "id": "GM2030",
       "title": "Not all code paths call draw_primitive_end() before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_end.htm\">draw_primitive_end</a></span> is missing in at least one place in your code. This can happen when you draw, for example, different vertices based on an if-else condition and you added the call to <span class=\"inline3_func\">draw_primitive_end()</span> to the if case, but not to the else case.</p>",
-          "text": "This message indicates that a call to draw_primitive_end is missing in at least one place in your code. This can happen when you draw, for example, different vertices based on an if-else condition and you added the call to draw_primitive_end() to the if case, but not to the else case."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    var _condition = (irandom(100) &lt; 50);<br>\n    draw_primitive_begin(pr_linelist);<br>\n    <br>\n    if (_condition)<br>\n    {<br>\n    &nbsp; &nbsp; // draw_vertex, draw_vertex_colour, etc.<br>\n    &nbsp; &nbsp; draw_primitive_end();<br>\n    }<br>\n    else<br>\n    {<br>\n    &nbsp; &nbsp; // draw_vertex, draw_vertex_colour, etc.<br>\n    }\n  </p>",
-          "text": "/// Draw Event\n\n    var _condition = (irandom(100) < 50);\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    if (_condition)\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n        draw_primitive_end();\n\n    }\n\n    else\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the example above one of two possible code paths is followed, where each draws a different shape. The if case ends with a call to <span class=\"inline3_func\">draw_primitive_end()</span>, though the else case is missing that call. Adding it to the else case is one possible fix, though the clean and more robust way to fix the issue is to move it outside of the if-else statement.</p>",
-          "text": "In the example above one of two possible code paths is followed, where each draws a different shape. The if case ends with a call to draw_primitive_end(), though the else case is missing that call. Adding it to the else case is one possible fix, though the clean and more robust way to fix the issue is to move it outside of the if-else statement."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    var _condition = (irandom(100) &lt; 50);<br>\n    draw_primitive_begin(pr_linelist);<br>\n    <br>\n    if (_condition)<br>\n    {<br>\n    &nbsp; &nbsp; // draw_vertex, draw_vertex_colour, etc.<br>\n    }<br>\n    else<br>\n    {<br>\n    &nbsp; &nbsp; // draw_vertex, draw_vertex_colour, etc.<br>\n    }<br>\n    <br>\n    draw_primitive_end(); &nbsp;// Call no longer depends on if-else condition!\n  </p>",
-          "text": "/// Draw Event\n\n    var _condition = (irandom(100) < 50);\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    if (_condition)\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }\n\n    else\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }\n\n\n\n    draw_primitive_end();  // Call no longer depends on if-else condition!"
-        }
-      ]
+      "description": "This message indicates that a call to draw_primitive_end is missing in at least one place in your code. This can happen when you draw, for example, different vertices based on an if-else condition and you added the call to draw_primitive_end() to the if case, but not to the else case.",
+      "badExample": "/// Draw Event\n\n    var _condition = (irandom(100) < 50);\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    if (_condition)\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n        draw_primitive_end();\n\n    }\n\n    else\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }",
+      "goodExample": "/// Draw Event\n\n    var _condition = (irandom(100) < 50);\n\n    draw_primitive_begin(pr_linelist);\n\n\n\n    if (_condition)\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }\n\n    else\n\n    {\n\n        // draw_vertex, draw_vertex_colour, etc.\n\n    }\n\n\n\n    draw_primitive_end();  // Call no longer depends on if-else condition!",
+      "correction": "In the example above one of two possible code paths is followed, where each draws a different shape. The if case ends with a call to draw_primitive_end(), though the else case is missing that call. Adding it to the else case is one possible fix, though the clean and more robust way to fix the issue is to move it outside of the if-else statement."
     },
     {
       "id": "GM2031",
       "title": "Opening another File Find before closing a previous File Find.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you start another File Find with&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_first.htm\">file_find_first</a></span> without closing the previous one with <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_close.htm\">file_find_close</a></span>. You can only perform one File Find at a time and one needs to be closed before another can be opened.</p>",
-          "text": "This message is shown when you start another File Find with file_find_first without closing the previous one with file_find_close. You can only perform one File Find at a time and one needs to be closed before another can be opened."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _look_for_description = true;<br>\n    var&nbsp;_file = file_find_first(\"/game_data/*.bin\", fa_none);<br>\n    if (_look_for_description)<br>\n    {<br>\n    &nbsp; &nbsp; _file2 = file_find_first(\"/game_data/*.json\", fa_none);<br>\n    }<br>\n    <br>\n    file_find_close();\n  </p>",
-          "text": "var _look_for_description = true;\n\n    var _file = file_find_first(\"/game_data/*.bin\", fa_none);\n\n    if (_look_for_description)\n\n    {\n\n        _file2 = file_find_first(\"/game_data/*.json\", fa_none);\n\n    }\n\n\n\n    file_find_close();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above a second file find is started with <span class=\"inline3_func\">file_find_first()</span>&nbsp;before the current file find is properly closed if a variable <span class=\"inline2\">_look_for_description</span> is set to <span class=\"inline2\">true</span>. To properly fix the issue the first file find needs to be closed before the <span class=\"inline2\">if</span> statement is checked and the second file find needs to be closed inside the <span class=\"inline2\">true</span> case of the <span class=\"inline2\">if</span>&nbsp;statement (at the same level as the call to <span class=\"inline3_func\">file_find_first()</span>).</p>",
-          "text": "In the code example above a second file find is started with file_find_first() before the current file find is properly closed if a variable _look_for_description is set to true. To properly fix the issue the first file find needs to be closed before the if statement is checked and the second file find needs to be closed inside the true case of the if statement (at the same level as the call to file_find_first())."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">var _look_for_description = true;<br>\n    var&nbsp;_file = file_find_first(\"/game_data/*.bin\", fa_none);<br>\n    file_find_close();<br>\n    if (_look_for_description)<br>\n    {<br>\n    &nbsp; &nbsp; _file2 = file_find_first(\"/game_data/*.json\", fa_none);<br>\n    &nbsp; &nbsp; file_find_close();<br>\n    }</p>",
-          "text": "var _look_for_description = true;\n\n    var _file = file_find_first(\"/game_data/*.bin\", fa_none);\n\n    file_find_close();\n\n    if (_look_for_description)\n\n    {\n\n        _file2 = file_find_first(\"/game_data/*.json\", fa_none);\n\n        file_find_close();\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you start another File Find with file_find_first without closing the previous one with file_find_close. You can only perform one File Find at a time and one needs to be closed before another can be opened.",
+      "badExample": "var _look_for_description = true;\n\n    var _file = file_find_first(\"/game_data/*.bin\", fa_none);\n\n    if (_look_for_description)\n\n    {\n\n        _file2 = file_find_first(\"/game_data/*.json\", fa_none);\n\n    }\n\n\n\n    file_find_close();",
+      "goodExample": "var _look_for_description = true;\n\n    var _file = file_find_first(\"/game_data/*.bin\", fa_none);\n\n    file_find_close();\n\n    if (_look_for_description)\n\n    {\n\n        _file2 = file_find_first(\"/game_data/*.json\", fa_none);\n\n        file_find_close();\n\n    }",
+      "correction": "In the code example above a second file find is started with file_find_first() before the current file find is properly closed if a variable _look_for_description is set to true. To properly fix the issue the first file find needs to be closed before the if statement is checked and the second file find needs to be closed inside the true case of the if statement (at the same level as the call to file_find_first())."
     },
     {
       "id": "GM2032",
       "title": "Closing a File Find without opening a File Find.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you call&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_close.htm\">file_find_close</a></span> when no File Find is currently open (i.e. no call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_first.htm\">file_find_first</a></span> was made).</p>",
-          "text": "This message is shown when you call file_find_close when no File Find is currently open (i.e. no call to file_find_first was made)."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">file_find_close();</p>",
-          "text": "file_find_close();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>A call to <span class=\"inline3_func\">file_find_first()</span> should be added if the intention is to do a File Find.</p>",
-          "text": "A call to file_find_first() should be added if the intention is to do a File Find."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">file_find_first(\"*.json\", fa_none);<br>\n    file_find_close();</p>",
-          "text": "file_find_first(\"*.json\", fa_none);\n\n    file_find_close();"
-        }
-      ]
+      "description": "This message is shown when you call file_find_close when no File Find is currently open (i.e. no call to file_find_first was made).",
+      "badExample": "file_find_close();",
+      "goodExample": "file_find_first(\"*.json\", fa_none);\n\n    file_find_close();",
+      "correction": "A call to file_find_first() should be added if the intention is to do a File Find."
     },
     {
       "id": "GM2033",
       "title": "The function '{0}' cannot be called outside of a file_find_first()/file_find_close() block.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that the given function can only go between a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_first.htm\">file_find_first</a></span> and a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_close.htm\">file_find_close</a></span>.</p>",
-          "text": "This message indicates that the given function can only go between a call to file_find_first and a call to file_find_close."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">fnames = [];<br>\n    var _fname = file_find_first(\"*.txt\", fa_none);<br>\n    <br>\n    while(_fname != \"\")<br>\n    {<br>\n    &nbsp; &nbsp; array_push(fnames, _fname);<br>\n    &nbsp; &nbsp; _fname = file_find_next();<br>\n    }<br>\n    <br>\n    file_find_close();<br>\n    file_find_next();\n  </p>",
-          "text": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n\n\n    file_find_close();\n\n    file_find_next();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The second <span class=\"inline3_func\">file_find_next()</span> is called outside of the calls to <span class=\"inline3_func\">file_find_first()</span> and <span class=\"inline3_func\">file_find_close()</span>. It needs to be removed to fix the issue.</p>",
-          "text": "The second file_find_next() is called outside of the calls to file_find_first() and file_find_close(). It needs to be removed to fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">fnames = [];<br>\n    var _fname = file_find_first(\"*.txt\", fa_none);<br>\n    <br>\n    while(_fname != \"\")<br>\n    {<br>\n    &nbsp; &nbsp; array_push(fnames, _fname);<br>\n    &nbsp; &nbsp; _fname = file_find_next();<br>\n    }<br>\n    <br>\n    file_find_close();\n  </p>",
-          "text": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n\n\n    file_find_close();"
-        }
-      ]
+      "description": "This message indicates that the given function can only go between a call to file_find_first and a call to file_find_close.",
+      "badExample": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n\n\n    file_find_close();\n\n    file_find_next();",
+      "goodExample": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n\n\n    file_find_close();",
+      "correction": "The second file_find_next() is called outside of the calls to file_find_first() and file_find_close(). It needs to be removed to fix the issue."
     },
     {
       "id": "GM2034",
       "title": "Not all code paths call file_find_close() before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/File_Handling/File_System/file_find_close.htm\">file_find_close</a></span> may not be encountered. Ideally, the call to <span class=\"inline3_func\">file_find_close()</span> should occur in the same scope as the call to <span class=\"inline3_func\">file_find_first()</span>.</p>",
-          "text": "This message indicates that a call to file_find_close may not be encountered. Ideally, the call to file_find_close() should occur in the same scope as the call to file_find_first()."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">fnames = [];<br>\n    var _fname = file_find_first(\"*.txt\", fa_none);<br>\n    while(_fname != \"\")<br>\n    {<br>\n    &nbsp; &nbsp; array_push(fnames, _fname);<br>\n    &nbsp; &nbsp; _fname = file_find_next();<br>\n    }</p>",
-          "text": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example, a call to <span class=\"inline3_func\">file_find_close()</span> is missing. This needs to be added to fix the issue.</p>",
-          "text": "In the code example, a call to file_find_close() is missing. This needs to be added to fix the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">fnames = [];<br>\n    var _fname = file_find_first(\"*.txt\", fa_none);<br>\n    while(_fname != \"\")<br>\n    {<br>\n    &nbsp; &nbsp; array_push(fnames, _fname);<br>\n    &nbsp; &nbsp; _fname = file_find_next();<br>\n    }<br>\n    file_find_close();</p>",
-          "text": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n    file_find_close();"
-        }
-      ]
+      "description": "This message indicates that a call to file_find_close may not be encountered. Ideally, the call to file_find_close() should occur in the same scope as the call to file_find_first().",
+      "badExample": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }",
+      "goodExample": "fnames = [];\n\n    var _fname = file_find_first(\"*.txt\", fa_none);\n\n    while(_fname != \"\")\n\n    {\n\n        array_push(fnames, _fname);\n\n        _fname = file_find_next();\n\n    }\n\n    file_find_close();",
+      "correction": "In the code example, a call to file_find_close() is missing. This needs to be added to fix the issue."
     },
     {
       "id": "GM2035",
       "title": "Not all code paths call gpu_pop_state() before end of script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that there are situations where&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_pop_state.htm\">gpu_pop_state</a></span> isn't called, depending on your game's logic. This can occur when you have logic in your code where, for example, the <span class=\"inline2\">if</span> case contains a call to <span class=\"inline3_func\">gpu_pop_state</span>&nbsp;but the <span class=\"inline2\">else</span> case doesn't. Depending on whether the expression inside the if statement evaluates to <span class=\"inline2\">true</span> or <span class=\"inline2\">false</span> the function may not get called.</p>",
-          "text": "This message indicates that there are situations where gpu_pop_state isn't called, depending on your game's logic. This can occur when you have logic in your code where, for example, the if case contains a call to gpu_pop_state but the else case doesn't. Depending on whether the expression inside the if statement evaluates to true or false the function may not get called."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw End Event<br>\n    gpu_push_state();<br>\n    gpu_set_blendmode(bm_add);<br>\n    if (show_name)<br>\n    {<br>\n    &nbsp; &nbsp; draw_text(x, y, name);<br>\n    &nbsp; &nbsp; gpu_pop_state();<br>\n    }<br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, $\"Instances: {instance_count}\");</p>",
-          "text": "/// Draw End Event\n\n    gpu_push_state();\n\n    gpu_set_blendmode(bm_add);\n\n    if (show_name)\n\n    {\n\n        draw_text(x, y, name);\n\n        gpu_pop_state();\n\n    }\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Instances: {instance_count}\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example, the GPU's current state is pushed onto the stack and the blend mode is then changed to <span class=\"inline2\">bm_add</span>. The GPU's state is then set back to the previous one, but only if an instance variable is <span class=\"inline2\">true</span>. This has consequences for the subsequent Draw GUI Event. The call to <span class=\"inline3_func\">gpu_pop_state</span> needs to be moved out of the <span class=\"inline2\">if</span> statement so it always executes.</p>",
-          "text": "In the code example, the GPU's current state is pushed onto the stack and the blend mode is then changed to bm_add. The GPU's state is then set back to the previous one, but only if an instance variable is true. This has consequences for the subsequent Draw GUI Event. The call to gpu_pop_state needs to be moved out of the if statement so it always executes."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw End Event<br>\n    gpu_push_state();<br>\n    gpu_set_blendmode(bm_add);<br>\n    if (show_name)<br>\n    {<br>\n    &nbsp; &nbsp; draw_text(x, y, name);<br>\n    }<br>\n    gpu_pop_state();<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, $\"Instances: {instance_count}\"); &nbsp;// All good!\n  </p>",
-          "text": "/// Draw End Event\n\n    gpu_push_state();\n\n    gpu_set_blendmode(bm_add);\n\n    if (show_name)\n\n    {\n\n        draw_text(x, y, name);\n\n    }\n\n    gpu_pop_state();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Instances: {instance_count}\");  // All good!"
-        }
-      ]
+      "description": "This message indicates that there are situations where gpu_pop_state isn't called, depending on your game's logic. This can occur when you have logic in your code where, for example, the if case contains a call to gpu_pop_state but the else case doesn't. Depending on whether the expression inside the if statement evaluates to true or false the function may not get called.",
+      "badExample": "/// Draw End Event\n\n    gpu_push_state();\n\n    gpu_set_blendmode(bm_add);\n\n    if (show_name)\n\n    {\n\n        draw_text(x, y, name);\n\n        gpu_pop_state();\n\n    }\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Instances: {instance_count}\");",
+      "goodExample": "/// Draw End Event\n\n    gpu_push_state();\n\n    gpu_set_blendmode(bm_add);\n\n    if (show_name)\n\n    {\n\n        draw_text(x, y, name);\n\n    }\n\n    gpu_pop_state();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, $\"Instances: {instance_count}\");  // All good!",
+      "correction": "In the code example, the GPU's current state is pushed onto the stack and the blend mode is then changed to bm_add. The GPU's state is then set back to the previous one, but only if an instance variable is true. This has consequences for the subsequent Draw GUI Event. The call to gpu_pop_state needs to be moved out of the if statement so it always executes."
     },
     {
       "id": "GM2039",
       "title": "Call to execute a global script resource like a function is deprecated.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you call a script asset as a function. A script asset is not meant to be executed directly as a function. While the behaviour is still included in <span data-keyref=\"GameMaker Name\">GameMaker</span>, it is only there to support legacy code.</p>",
-          "text": "This message is shown when you call a script asset as a function. A script asset is not meant to be executed directly as a function. While the behaviour is still included in GameMaker, it is only there to support legacy code."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// my_function<br>\n    show_debug_message(\"my_function calling!\");&nbsp; // Function call. Debug message is shown already!<br>\n    <br>\n    /// Create Event<br>\n    my_function();&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;// Debug message is shown again!\n  </p>",
-          "text": "/// my_function\n\n    show_debug_message(\"my_function calling!\");  // Function call. Debug message is shown already!\n\n\n\n    /// Create Event\n\n    my_function();                               // Debug message is shown again!"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>If a script asset contains code that should be its own function, this code should be moved inside a new function definition inside the script. The new function gets the name of the script asset and the script asset can be renamed to a descriptive name that describes well what it contains (a group of functions, a collection of (global) variables, a collection of macros, etc.).</p>",
-          "text": "If a script asset contains code that should be its own function, this code should be moved inside a new function definition inside the script. The new function gets the name of the script asset and the script asset can be renamed to a descriptive name that describes well what it contains (a group of functions, a collection of (global) variables, a collection of macros, etc.)."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Functions (Script Asset)<br>\n    function my_function()<br>\n    {<br>\n    &nbsp; &nbsp; show_debug_message(\"my_function calling!\");&nbsp; // Function call as part of function definition. Nothing is shown (yet)!<br>\n    }<br>\n    <br>\n    /// Create Event<br>\n    my_function();&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;// Actual function call, debug message is shown (only) at the intented time!\n  </p>",
-          "text": "/// Functions (Script Asset)\n\n    function my_function()\n\n    {\n\n        show_debug_message(\"my_function calling!\");  // Function call as part of function definition. Nothing is shown (yet)!\n\n    }\n\n\n\n    /// Create Event\n\n    my_function();                                   // Actual function call, debug message is shown (only) at the intented time!"
-        }
-      ]
+      "description": "This message is shown when you call a script asset as a function. A script asset is not meant to be executed directly as a function. While the behaviour is still included in GameMaker, it is only there to support legacy code.",
+      "badExample": "/// my_function\n\n    show_debug_message(\"my_function calling!\");  // Function call. Debug message is shown already!\n\n\n\n    /// Create Event\n\n    my_function();                               // Debug message is shown again!",
+      "goodExample": "/// Functions (Script Asset)\n\n    function my_function()\n\n    {\n\n        show_debug_message(\"my_function calling!\");  // Function call as part of function definition. Nothing is shown (yet)!\n\n    }\n\n\n\n    /// Create Event\n\n    my_function();                                   // Actual function call, debug message is shown (only) at the intented time!",
+      "correction": "If a script asset contains code that should be its own function, this code should be moved inside a new function definition inside the script. The new function gets the name of the script asset and the script asset can be renamed to a descriptive name that describes well what it contains (a group of functions, a collection of (global) variables, a collection of macros, etc.)."
     },
     {
       "id": "GM2040",
       "title": "Call to event_inherited() in object with no parent event.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you call the function&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_inherited.htm\">event_inherited</a></span> in an object that either has no parent object or that has no ancestor in its parent-child hierarchy that defines the event.</p>",
-          "text": "This message is shown when you call the function event_inherited in an object that either has no parent object or that has no ancestor in its parent-child hierarchy that defines the event."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// obj_parent<br>\n    // No Room Start event<br>\n    <br>\n    /// obj_child.Room_Start<br>\n    event_inherited();\n  </p>",
-          "text": "/// obj_parent\n\n    // No Room Start event\n\n\n\n    /// obj_child.Room_Start\n\n    event_inherited();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example, an object <span class=\"inline2\">obj_child</span> has an object <span class=\"inline2\">obj_parent</span> as its parent object. The parent object doesn't define a Room Start event yet the child object does and calls <span class=\"inline3_func\">event_inherited()</span>. The call to <span class=\"inline3_func\">event_inherited()</span> can be removed, or it can be commented out in case the event might get added later in the parent object.</p>",
-          "text": "In the code example, an object obj_child has an object obj_parent as its parent object. The parent object doesn't define a Room Start event yet the child object does and calls event_inherited(). The call to event_inherited() can be removed, or it can be commented out in case the event might get added later in the parent object."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// obj_parent<br>\n    // No Room Start event<br>\n    <br>\n    /// obj_child.Room_Start<br>\n    event_inherited();\n  </p>",
-          "text": "/// obj_parent\n\n    // No Room Start event\n\n\n\n    /// obj_child.Room_Start\n\n    event_inherited();"
-        }
-      ]
+      "description": "This message is shown when you call the function event_inherited in an object that either has no parent object or that has no ancestor in its parent-child hierarchy that defines the event.",
+      "badExample": "/// obj_parent\n\n    // No Room Start event\n\n\n\n    /// obj_child.Room_Start\n\n    event_inherited();",
+      "goodExample": "/// obj_parent\n\n    // No Room Start event\n\n\n\n    /// obj_child.Room_Start\n\n    event_inherited();",
+      "correction": "In the code example, an object obj_child has an object obj_parent as its parent object. The parent object doesn't define a Room Start event yet the child object does and calls event_inherited(). The call to event_inherited() can be removed, or it can be commented out in case the event might get added later in the parent object."
     },
     {
       "id": "GM2042",
       "title": "Inconsistent stack depth for gpu_push_state()/gpu_pop_state() blocks. All branches should call these functions an equal number of times.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_push_state.htm\">gpu_push_state</a></span> is called a different number of times than <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_pop_state.htm\">gpu_pop_state</a></span>. Every call to <span class=\"inline3_func\">gpu_push_state</span>&nbsp;must be accompanied by a call to <span class=\"inline3_func\">gpu_pop_state</span>.</p>",
-          "text": "This message indicates that gpu_push_state is called a different number of times than gpu_pop_state. Every call to gpu_push_state must be accompanied by a call to gpu_pop_state."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    // Situation 1<br>\n    gpu_push_state();<br>\n    gpu_push_state();<br>\n    // draw something<br>\n    gpu_pop_state();<br>\n    <br>\n    // Situation 2<br>\n    gpu_push_state();<br>\n    // draw_something<br>\n    gpu_pop_state();<br>\n    gpu_pop_state();\n  </p>",
-          "text": "/// Draw Event\n\n    // Situation 1\n\n    gpu_push_state();\n\n    gpu_push_state();\n\n    // draw something\n\n    gpu_pop_state();\n\n\n\n    // Situation 2\n\n    gpu_push_state();\n\n    // draw_something\n\n    gpu_pop_state();\n\n    gpu_pop_state();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Every call to <span class=\"inline3_func\">gpu_push_state</span>&nbsp;in the code above must have a corresponding call to <span class=\"inline3_func\">gpu_pop_state</span>. Assuming that two stack pushes were meant in the first case and a single stack push in the second case, the code can be fixed as follows:</p>",
-          "text": "Every call to gpu_push_state in the code above must have a corresponding call to gpu_pop_state. Assuming that two stack pushes were meant in the first case and a single stack push in the second case, the code can be fixed as follows:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    // Situation 1<br>\n    gpu_push_state();<br>\n    gpu_push_state();<br>\n    // draw something<br>\n    gpu_pop_state();<br>\n    gpu_pop_state();<br>\n    <br>\n    // Situation 2<br>\n    gpu_push_state();<br>\n    // draw_something<br>\n    gpu_pop_state();\n  </p>",
-          "text": "/// Draw Event\n\n    // Situation 1\n\n    gpu_push_state();\n\n    gpu_push_state();\n\n    // draw something\n\n    gpu_pop_state();\n\n    gpu_pop_state();\n\n\n\n    // Situation 2\n\n    gpu_push_state();\n\n    // draw_something\n\n    gpu_pop_state();"
-        }
-      ]
+      "description": "This message indicates that gpu_push_state is called a different number of times than gpu_pop_state. Every call to gpu_push_state must be accompanied by a call to gpu_pop_state.",
+      "badExample": "/// Draw Event\n\n    // Situation 1\n\n    gpu_push_state();\n\n    gpu_push_state();\n\n    // draw something\n\n    gpu_pop_state();\n\n\n\n    // Situation 2\n\n    gpu_push_state();\n\n    // draw_something\n\n    gpu_pop_state();\n\n    gpu_pop_state();",
+      "goodExample": "/// Draw Event\n\n    // Situation 1\n\n    gpu_push_state();\n\n    gpu_push_state();\n\n    // draw something\n\n    gpu_pop_state();\n\n    gpu_pop_state();\n\n\n\n    // Situation 2\n\n    gpu_push_state();\n\n    // draw_something\n\n    gpu_pop_state();",
+      "correction": "Every call to gpu_push_state in the code above must have a corresponding call to gpu_pop_state. Assuming that two stack pushes were meant in the first case and a single stack push in the second case, the code can be fixed as follows:"
     },
     {
       "id": "GM2043",
       "title": "Attempting to access the local variable '{0}' outside of the scope it was defined in.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This warning is shown when you access a local variable either before it's defined or after it's gone out of scope.</p>",
-          "text": "This warning is shown when you access a local variable either before it's defined or after it's gone out of scope."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Attempt to access before it's defined<br>\n    // Didn't come across variable definition yet<br>\n    i = 0;<br>\n    var i = 34;<br>\n    <br>\n    // Attempting to access after the variable's gone out of scope<br>\n    if&nbsp;(something_occurred)<br>\n    {<br>\n    &nbsp; &nbsp; // Variable is defined inside curly braces,<br>\n    &nbsp; &nbsp; // remains \"in scope\" between these curly braces<br>\n    &nbsp; &nbsp; var&nbsp;_msg&nbsp;=&nbsp;\"Something happened!\";<br>\n    }<br>\n    <br>\n    // Variable went out of scope after the closing curly brace<br>\n    _msg = \"test\";\n  </p>",
-          "text": "// Attempt to access before it's defined\n\n    // Didn't come across variable definition yet\n\n    i = 0;\n\n    var i = 34;\n\n\n\n    // Attempting to access after the variable's gone out of scope\n\n    if (something_occurred)\n\n    {\n\n        // Variable is defined inside curly braces,\n\n        // remains \"in scope\" between these curly braces\n\n        var _msg = \"Something happened!\";\n\n    }\n\n\n\n    // Variable went out of scope after the closing curly brace\n\n    _msg = \"test\";"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>You should make sure to always define local variables before accessing them. In case of the <span class=\"inline2\">if</span> statement the variable can simply be declared before the <span class=\"inline2\">if</span>&nbsp;so it stays in scope the entire time and can also be accessed from within the <span class=\"inline2\">if</span> statement.</p>",
-          "text": "You should make sure to always define local variables before accessing them. In case of the if statement the variable can simply be declared before the if so it stays in scope the entire time and can also be accessed from within the if statement."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Fix for access before it's defined<br>\n    var i = 0;<br>\n    i = 34;<br>\n    <br>\n    // Fix for access after the variable's gone out of scope<br>\n    var _msg;<br>\n    if&nbsp;(something_occurred)<br>\n    {<br>\n    &nbsp; &nbsp; // Variable can be accessed and modified from within if<br>\n    &nbsp; &nbsp; _msg&nbsp;=&nbsp;\"Something happened!\";<br>\n    }<br>\n    <br>\n    // Variable is still in scope now<br>\n    _msg = \"test\";\n  </p>",
-          "text": "// Fix for access before it's defined\n\n    var i = 0;\n\n    i = 34;\n\n\n\n    // Fix for access after the variable's gone out of scope\n\n    var _msg;\n\n    if (something_occurred)\n\n    {\n\n        // Variable can be accessed and modified from within if\n\n        _msg = \"Something happened!\";\n\n    }\n\n\n\n    // Variable is still in scope now\n\n    _msg = \"test\";"
-        }
-      ]
+      "description": "This warning is shown when you access a local variable either before it's defined or after it's gone out of scope.",
+      "badExample": "// Attempt to access before it's defined\n\n    // Didn't come across variable definition yet\n\n    i = 0;\n\n    var i = 34;\n\n\n\n    // Attempting to access after the variable's gone out of scope\n\n    if (something_occurred)\n\n    {\n\n        // Variable is defined inside curly braces,\n\n        // remains \"in scope\" between these curly braces\n\n        var _msg = \"Something happened!\";\n\n    }\n\n\n\n    // Variable went out of scope after the closing curly brace\n\n    _msg = \"test\";",
+      "goodExample": "// Fix for access before it's defined\n\n    var i = 0;\n\n    i = 34;\n\n\n\n    // Fix for access after the variable's gone out of scope\n\n    var _msg;\n\n    if (something_occurred)\n\n    {\n\n        // Variable can be accessed and modified from within if\n\n        _msg = \"Something happened!\";\n\n    }\n\n\n\n    // Variable is still in scope now\n\n    _msg = \"test\";",
+      "correction": "You should make sure to always define local variables before accessing them. In case of the if statement the variable can simply be declared before the if so it stays in scope the entire time and can also be accessed from within the if statement."
     },
     {
       "id": "GM2044",
       "title": "Local variable '{0}' is already declared.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you declare a local variable with the same name as a local variable that already exists.</p>",
-          "text": "This message is shown when you declare a local variable with the same name as a local variable that already exists."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Situation 1: declared again<br>\n    var i = 0;<br>\n    var _num_elements = 20;<br>\n    array = array_create(_num_elements);<br>\n    repeat(_num_elements)<br>\n    {<br>\n    &nbsp; &nbsp; array[i--] = irandom(100);<br>\n    }<br>\n    var i = 0;<br>\n    <br>\n    // Situation 2: redeclared in a nested loop<br>\n    for(var i = 0;i &lt; 50;i++)<br>\n    {<br>\n    &nbsp; &nbsp; for(var i = 0;i &lt; 50;i++)<br>\n    &nbsp; &nbsp; {<br>\n    &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<br>\n    &nbsp; &nbsp; }<br>\n    }\n  </p>",
-          "text": "// Situation 1: declared again\n\n    var i = 0;\n\n    var _num_elements = 20;\n\n    array = array_create(_num_elements);\n\n    repeat(_num_elements)\n\n    {\n\n        array[i--] = irandom(100);\n\n    }\n\n    var i = 0;\n\n\n\n    // Situation 2: redeclared in a nested loop\n\n    for(var i = 0;i < 50;i++)\n\n    {\n\n        for(var i = 0;i < 50;i++)\n\n        {\n\n\n\n        }\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the above example two situations are shown. In the first situation the local variable is declared and used in a <span class=\"inline2\">repeat</span> loop. After that, it is redeclared. In this case, it suffices to keep only the first declaration and change the other one to an assignment since the variable already exists at that point. In the second situation the same variable name is accidentally used for both loop counters in a nested for loop. This will cause the variable to increment not only in the outer loop but also in the inner loop. To fix this, the inner loop counter variable should be renamed.</p>",
-          "text": "In the above example two situations are shown. In the first situation the local variable is declared and used in a repeat loop. After that, it is redeclared. In this case, it suffices to keep only the first declaration and change the other one to an assignment since the variable already exists at that point. In the second situation the same variable name is accidentally used for both loop counters in a nested for loop. This will cause the variable to increment not only in the outer loop but also in the inner loop. To fix this, the inner loop counter variable should be renamed."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">// Situation 1: declared again<br>\n    var i = 0;<br>\n    var _num_elements = 20;<br>\n    array = array_create(_num_elements);<br>\n    repeat(_num_elements)<br>\n    {<br>\n    &nbsp; &nbsp; array[i--] = irandom(100);<br>\n    }<br>\n    i = 0;<br>\n    <br>\n    // Situation 2: redeclared in a nested loop<br>\n    for(var i = 0;i &lt; 50;i++)<br>\n    {<br>\n    &nbsp; &nbsp; for(var j = 0;j &lt; 50;j++)<br>\n    &nbsp; &nbsp; {<br>\n    &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<br>\n    &nbsp; &nbsp; }<br>\n    }\n  </p>",
-          "text": "// Situation 1: declared again\n\n    var i = 0;\n\n    var _num_elements = 20;\n\n    array = array_create(_num_elements);\n\n    repeat(_num_elements)\n\n    {\n\n        array[i--] = irandom(100);\n\n    }\n\n    i = 0;\n\n\n\n    // Situation 2: redeclared in a nested loop\n\n    for(var i = 0;i < 50;i++)\n\n    {\n\n        for(var j = 0;j < 50;j++)\n\n        {\n\n\n\n        }\n\n    }"
-        }
-      ]
+      "description": "This message is shown when you declare a local variable with the same name as a local variable that already exists.",
+      "badExample": "// Situation 1: declared again\n\n    var i = 0;\n\n    var _num_elements = 20;\n\n    array = array_create(_num_elements);\n\n    repeat(_num_elements)\n\n    {\n\n        array[i--] = irandom(100);\n\n    }\n\n    var i = 0;\n\n\n\n    // Situation 2: redeclared in a nested loop\n\n    for(var i = 0;i < 50;i++)\n\n    {\n\n        for(var i = 0;i < 50;i++)\n\n        {\n\n\n\n        }\n\n    }",
+      "goodExample": "// Situation 1: declared again\n\n    var i = 0;\n\n    var _num_elements = 20;\n\n    array = array_create(_num_elements);\n\n    repeat(_num_elements)\n\n    {\n\n        array[i--] = irandom(100);\n\n    }\n\n    i = 0;\n\n\n\n    // Situation 2: redeclared in a nested loop\n\n    for(var i = 0;i < 50;i++)\n\n    {\n\n        for(var j = 0;j < 50;j++)\n\n        {\n\n\n\n        }\n\n    }",
+      "correction": "In the above example two situations are shown. In the first situation the local variable is declared and used in a repeat loop. After that, it is redeclared. In this case, it suffices to keep only the first declaration and change the other one to an assignment since the variable already exists at that point. In the second situation the same variable name is accidentally used for both loop counters in a nested for loop. This will cause the variable to increment not only in the outer loop but also in the inner loop. To fix this, the inner loop counter variable should be renamed."
     },
     {
       "id": "GM2046",
       "title": "Inconsistent stack depth for surface_set_target()/surface_reset_target() blocks. All branches should call these functions the same number of times.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've set the draw target to a surface more times than you've reset it back to the previous target. Every change to the draw target must be accompanied by a change back to the previous draw target. If you miss a call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Surfaces/surface_reset_target.htm\">surface_reset_target</a></span> this may cause certain things to be drawn to a different surface.</p>",
-          "text": "This message indicates that you've set the draw target to a surface more times than you've reset it back to the previous target. Every change to the draw target must be accompanied by a change back to the previous draw target. If you miss a call to surface_reset_target this may cause certain things to be drawn to a different surface."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    sf = -1;<br>\n    <br>\n    /// Draw Event<br>\n    if (!surface_exists(sf))<br>\n    {<br>\n    &nbsp; &nbsp; sf = surface_create(128, 128);<br>\n    }<br>\n    surface_set_target(sf);<br>\n    draw_clear_alpha(c_blue, 1);<br>\n    draw_circle(50, 50, 20, false);<br>\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));\n  </p>",
-          "text": "/// Create Event\n\n    sf = -1;\n\n\n\n    /// Draw Event\n\n    if (!surface_exists(sf))\n\n    {\n\n        sf = surface_create(128, 128);\n\n    }\n\n    surface_set_target(sf);\n\n    draw_clear_alpha(c_blue, 1);\n\n    draw_circle(50, 50, 20, false);\n\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, a surface is created and drawn to in the Draw event. The surface is set as the drawing target but the drawing target isn't reset properly. A vertex buffer is then submitted with the surface texture used as the texture. However, the drawing target is still set to the surface itself and the vertex buffer will be rendered to the surface.</p>",
-          "text": "In the code example above, a surface is created and drawn to in the Draw event. The surface is set as the drawing target but the drawing target isn't reset properly. A vertex buffer is then submitted with the surface texture used as the texture. However, the drawing target is still set to the surface itself and the vertex buffer will be rendered to the surface."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Adding a call to <span class=\"inline3_func\">surface_reset_target()</span> after drawing to the surface fixes the issue.</p>",
-          "text": "Adding a call to surface_reset_target() after drawing to the surface fixes the issue."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    sf = -1;<br>\n    <br>\n    /// Draw Event<br>\n    if (!surface_exists(sf))<br>\n    {<br>\n    &nbsp; &nbsp; sf = surface_create(128, 128);<br>\n    }<br>\n    surface_set_target(sf);<br>\n    draw_clear_alpha(c_blue, 1);<br>\n    draw_circle(50, 50, 20, false);<br>\n    surface_reset_target();<br>\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));\n  </p>",
-          "text": "/// Create Event\n\n    sf = -1;\n\n\n\n    /// Draw Event\n\n    if (!surface_exists(sf))\n\n    {\n\n        sf = surface_create(128, 128);\n\n    }\n\n    surface_set_target(sf);\n\n    draw_clear_alpha(c_blue, 1);\n\n    draw_circle(50, 50, 20, false);\n\n    surface_reset_target();\n\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));"
-        }
-      ]
+      "description": "This message indicates that you've set the draw target to a surface more times than you've reset it back to the previous target. Every change to the draw target must be accompanied by a change back to the previous draw target. If you miss a call to surface_reset_target this may cause certain things to be drawn to a different surface.",
+      "badExample": "/// Create Event\n\n    sf = -1;\n\n\n\n    /// Draw Event\n\n    if (!surface_exists(sf))\n\n    {\n\n        sf = surface_create(128, 128);\n\n    }\n\n    surface_set_target(sf);\n\n    draw_clear_alpha(c_blue, 1);\n\n    draw_circle(50, 50, 20, false);\n\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));",
+      "goodExample": "/// Create Event\n\n    sf = -1;\n\n\n\n    /// Draw Event\n\n    if (!surface_exists(sf))\n\n    {\n\n        sf = surface_create(128, 128);\n\n    }\n\n    surface_set_target(sf);\n\n    draw_clear_alpha(c_blue, 1);\n\n    draw_circle(50, 50, 20, false);\n\n    surface_reset_target();\n\n    vertex_submit(vb, pr_trianglelist, surface_get_texture(sf));",
+      "correction": "In the code example above, a surface is created and drawn to in the Draw event. The surface is set as the drawing target but the drawing target isn't reset properly. A vertex buffer is then submitted with the surface texture used as the texture. However, the drawing target is still set to the surface itself and the vertex buffer will be rendered to the surface.\n\nAdding a call to surface_reset_target() after drawing to the surface fixes the issue."
     },
     {
       "id": "GM2047",
       "title": "Unreachable code.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when a part of your code cannot be reached in any way because the logic always prevents it from happening. For example, when the expression inside an <span class=\"inline2\">if</span> statement always evaluates to <span class=\"inline2\">false</span>, the code inside that <span class=\"inline2\">if</span> statement will never be executed.</p>",
-          "text": "This message is shown when a part of your code cannot be reached in any way because the logic always prevents it from happening. For example, when the expression inside an if statement always evaluates to false, the code inside that if statement will never be executed."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">if (false)<br>\n    {<br>\n    &nbsp; &nbsp; // Unreachable code<br>\n    }</p>",
-          "text": "if (false)\n\n    {\n\n        // Unreachable code\n\n    }"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To fix this you should change the expression so that there are cases where it can evaluate to <span class=\"inline2\">true</span> and the code inside the <span class=\"inline2\">if</span> case executes.</p>",
-          "text": "To fix this you should change the expression so that there are cases where it can evaluate to true and the code inside the if case executes."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">if (choose(true, false))<br>\n    {<br>\n    &nbsp; &nbsp; // Code executed if 'true'<br>\n    }</p>",
-          "text": "if (choose(true, false))\n\n    {\n\n        // Code executed if 'true'\n\n    }"
-        }
-      ]
+      "description": "This message is shown when a part of your code cannot be reached in any way because the logic always prevents it from happening. For example, when the expression inside an if statement always evaluates to false, the code inside that if statement will never be executed.",
+      "badExample": "if (false)\n\n    {\n\n        // Unreachable code\n\n    }",
+      "goodExample": "if (choose(true, false))\n\n    {\n\n        // Code executed if 'true'\n\n    }",
+      "correction": "To fix this you should change the expression so that there are cases where it can evaluate to true and the code inside the if case executes."
     },
     {
       "id": "GM2048",
       "title": "Not all code paths call gpu_set_blendenable(true) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that <span class=\"inline2\">gpu_set_blendenable(true)</span> isn't called in all possible cases after you disable blending with <span class=\"inline2\">gpu_set_blendenable(false)</span>. This can occur when you have logic in your code where, for example, the <span class=\"inline2\">if</span> case contains a call to <span class=\"inline2\">gpu_set_blendenable(true)</span> but the <span class=\"inline2\">else</span> case doesn't. Depending on whether the expression inside the <span class=\"inline2\">if</span> statement evaluates to <span class=\"inline2\">true</span> or <span class=\"inline2\">false</span>, the function may not get called and blending won't be enabled again for subsequent drawing.</p>",
-          "text": "This message indicates that gpu_set_blendenable(true) isn't called in all possible cases after you disable blending with gpu_set_blendenable(false). This can occur when you have logic in your code where, for example, the if case contains a call to gpu_set_blendenable(true) but the else case doesn't. Depending on whether the expression inside the if statement evaluates to true or false, the function may not get called and blending won't be enabled again for subsequent drawing."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_blendenable(false);<br>\n    vertex_submit(vb, pr_trianglelist, tex);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"Hello!\"); &nbsp;// Text isn't drawn correctly\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_blendenable(false);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"Hello!\");  // Text isn't drawn correctly"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To fix this issue you need to re-enable alpha blending with another call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_blendenable.htm\">gpu_set_blendenable</a></span>.</p>",
-          "text": "To fix this issue you need to re-enable alpha blending with another call to gpu_set_blendenable."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_blendenable(false);<br>\n    vertex_submit(vb, pr_trianglelist, tex);<br>\n    gpu_set_blendenable(true);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"Hello!\"); &nbsp;// Text is drawn correctly again\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_blendenable(false);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_blendenable(true);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"Hello!\");  // Text is drawn correctly again"
-        }
-      ]
+      "description": "This message indicates that gpu_set_blendenable(true) isn't called in all possible cases after you disable blending with gpu_set_blendenable(false). This can occur when you have logic in your code where, for example, the if case contains a call to gpu_set_blendenable(true) but the else case doesn't. Depending on whether the expression inside the if statement evaluates to true or false, the function may not get called and blending won't be enabled again for subsequent drawing.",
+      "badExample": "/// Draw Event\n\n    gpu_set_blendenable(false);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"Hello!\");  // Text isn't drawn correctly",
+      "goodExample": "/// Draw Event\n\n    gpu_set_blendenable(false);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_blendenable(true);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"Hello!\");  // Text is drawn correctly again",
+      "correction": "To fix this issue you need to re-enable alpha blending with another call to gpu_set_blendenable."
     },
     {
       "id": "GM2049",
       "title": "Not all code paths call gpu_set_zfunc(cmpfunc_lessequal) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the function for z-testing but haven't set it back to the default <span class=\"inline2\">cmpfunc_lessequal</span> again. When depth testing is enabled with a call to <span class=\"inline2\">gpu_set_ztestenable(true)</span>, by default a pixel that's written to the depth buffer is considered closer when its z value is less or equal (<span class=\"inline2\">cmpfunc_lessequal</span>) than the current depth value for that pixel.</p>",
-          "text": "This message indicates that you've changed the function for z-testing but haven't set it back to the default cmpfunc_lessequal again. When depth testing is enabled with a call to gpu_set_ztestenable(true), by default a pixel that's written to the depth buffer is considered closer when its z value is less or equal (cmpfunc_lessequal) than the current depth value for that pixel."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_ztestenable(true);<br>\n    gpu_set_zfunc(cmpfunc_greater);<br>\n    vertex_submit(vb, pr_trianglelist, tex);<br>\n    gpu_set_ztestenable(false);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_ztestenable(true);\n\n    gpu_set_zfunc(cmpfunc_greater);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_ztestenable(false);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The comparison function used for z-testing needs to be properly reset to <span class=\"inline2\">cmpfunc_lessequal</span> in another call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_zfunc.htm\">gpu_set_zfunc</a></span>.</p>",
-          "text": "The comparison function used for z-testing needs to be properly reset to cmpfunc_lessequal in another call to gpu_set_zfunc."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_ztestenable(true);<br>\n    gpu_set_zfunc(cmpfunc_greater);<br>\n    vertex_submit(vb, pr_trianglelist, tex);<br>\n    gpu_set_zfunc(cmpfunc_lessequal);<br>\n    gpu_set_ztestenable(false);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_ztestenable(true);\n\n    gpu_set_zfunc(cmpfunc_greater);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_zfunc(cmpfunc_lessequal);\n\n    gpu_set_ztestenable(false);"
-        }
-      ]
+      "description": "This message indicates that you've changed the function for z-testing but haven't set it back to the default cmpfunc_lessequal again. When depth testing is enabled with a call to gpu_set_ztestenable(true), by default a pixel that's written to the depth buffer is considered closer when its z value is less or equal (cmpfunc_lessequal) than the current depth value for that pixel.",
+      "badExample": "/// Draw Event\n\n    gpu_set_ztestenable(true);\n\n    gpu_set_zfunc(cmpfunc_greater);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_ztestenable(false);",
+      "goodExample": "/// Draw Event\n\n    gpu_set_ztestenable(true);\n\n    gpu_set_zfunc(cmpfunc_greater);\n\n    vertex_submit(vb, pr_trianglelist, tex);\n\n    gpu_set_zfunc(cmpfunc_lessequal);\n\n    gpu_set_ztestenable(false);",
+      "correction": "The comparison function used for z-testing needs to be properly reset to cmpfunc_lessequal in another call to gpu_set_zfunc."
     },
     {
       "id": "GM2050",
       "title": "Not all code paths call gpu_set_fog(false, c_black, 0, 1) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the GPU fog settings with a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_fog.htm\">gpu_set_fog</a></span>, but haven't reset them to the default fog settings afterwards. GPU fog is disabled by default.</p>",
-          "text": "This message indicates that you've changed the GPU fog settings with a call to gpu_set_fog, but haven't reset them to the default fog settings afterwards. GPU fog is disabled by default."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_fog(true, c_aqua, 0, 1000);<br>\n    draw_self();</p>",
-          "text": "/// Draw Event\n\n    gpu_set_fog(true, c_aqua, 0, 1000);\n\n    draw_self();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The fog needs to be disabled after drawing with fog enabled in order not to affect subsequent draw commands.</p>",
-          "text": "The fog needs to be disabled after drawing with fog enabled in order not to affect subsequent draw commands."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_fog(true, c_aqua, 0, 1000);<br>\n    draw_self();<br>\n    gpu_set_fog(false, c_black, 0, 1);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_fog(true, c_aqua, 0, 1000);\n\n    draw_self();\n\n    gpu_set_fog(false, c_black, 0, 1);"
-        }
-      ]
+      "description": "This message indicates that you've changed the GPU fog settings with a call to gpu_set_fog, but haven't reset them to the default fog settings afterwards. GPU fog is disabled by default.",
+      "badExample": "/// Draw Event\n\n    gpu_set_fog(true, c_aqua, 0, 1000);\n\n    draw_self();",
+      "goodExample": "/// Draw Event\n\n    gpu_set_fog(true, c_aqua, 0, 1000);\n\n    draw_self();\n\n    gpu_set_fog(false, c_black, 0, 1);",
+      "correction": "The fog needs to be disabled after drawing with fog enabled in order not to affect subsequent draw commands."
     },
     {
       "id": "GM2051",
       "title": "Not all code paths call gpu_set_cullmode(cull_noculling) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the cullmode using a call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_cullmode.htm\">gpu_set_cullmode</a></span>, but haven't reset it to <span class=\"inline2\">cull_noculling</span> afterwards. When culling is enabled, the GPU will not draw the backside of triangles based on the winding order of the vertices, which is either clockwise or counter-clockwise.</p>",
-          "text": "This message indicates that you've changed the cullmode using a call to gpu_set_cullmode, but haven't reset it to cull_noculling afterwards. When culling is enabled, the GPU will not draw the backside of triangles based on the winding order of the vertices, which is either clockwise or counter-clockwise."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_cullmode(cull_clockwise);<br>\n    shader_set(sh_lighting);<br>\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);<br>\n    shader_reset();<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"World 1\");\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_cullmode(cull_clockwise);\n\n    shader_set(sh_lighting);\n\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In order to fix this issue the cullmode needs to be properly reset to <span class=\"inline2\">cull_noculling</span> or to the value that it had before.</p>",
-          "text": "In order to fix this issue the cullmode needs to be properly reset to cull_noculling or to the value that it had before."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_cullmode(cull_clockwise);<br>\n    // OR<br>\n    // var _cm = gpu_get_cullmode();<br>\n    // gpu_set_cullmode(cull_clockwise);<br>\n    <br>\n    shader_set(sh_lighting);<br>\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);<br>\n    shader_reset();<br>\n    <br>\n    gpu_set_cullmode(cull_noculling);<br>\n    // OR<br>\n    // gpu_set_cullmode(_cm);<br>\n    <br>\n    /// Draw GUI Event<br>\n    draw_text(5, 5, \"World 1\");\n  </p>",
-          "text": "/// Draw Event\n\n    gpu_set_cullmode(cull_clockwise);\n\n    // OR\n\n    // var _cm = gpu_get_cullmode();\n\n    // gpu_set_cullmode(cull_clockwise);\n\n\n\n    shader_set(sh_lighting);\n\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    gpu_set_cullmode(cull_noculling);\n\n    // OR\n\n    // gpu_set_cullmode(_cm);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");"
-        }
-      ]
+      "description": "This message indicates that you've changed the cullmode using a call to gpu_set_cullmode, but haven't reset it to cull_noculling afterwards. When culling is enabled, the GPU will not draw the backside of triangles based on the winding order of the vertices, which is either clockwise or counter-clockwise.",
+      "badExample": "/// Draw Event\n\n    gpu_set_cullmode(cull_clockwise);\n\n    shader_set(sh_lighting);\n\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");",
+      "goodExample": "/// Draw Event\n\n    gpu_set_cullmode(cull_clockwise);\n\n    // OR\n\n    // var _cm = gpu_get_cullmode();\n\n    // gpu_set_cullmode(cull_clockwise);\n\n\n\n    shader_set(sh_lighting);\n\n    vertex_submit(vb_static_geometry, pr_trianglelist, -1);\n\n    shader_reset();\n\n\n\n    gpu_set_cullmode(cull_noculling);\n\n    // OR\n\n    // gpu_set_cullmode(_cm);\n\n\n\n    /// Draw GUI Event\n\n    draw_text(5, 5, \"World 1\");",
+      "correction": "In order to fix this issue the cullmode needs to be properly reset to cull_noculling or to the value that it had before."
     },
     {
       "id": "GM2052",
       "title": "Not all code paths call gpu_set_colourwriteenable(true, true, true, true) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've disabled writing to at least one colour channel but haven't re-enabled writing to all colour channels afterwards.</p>",
-          "text": "This message indicates that you've disabled writing to at least one colour channel but haven't re-enabled writing to all colour channels afterwards."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_colourwriteenable(true, true, true, false);<br>\n    draw_sprite(sprite_index, 0, x, y);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_colourwriteenable(true, true, true, false);\n\n    draw_sprite(sprite_index, 0, x, y);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above writing to the alpha channel is disabled for all draw calls that follow the call to <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_colourwriteenable.htm\">gpu_set_colourwriteenable</a></span>. No call to <span class=\"inline2\">gpu_set_colourwriteenable()</span>&nbsp;is made to reset this, however. Because of this, subsequent draw commands will also not write to the alpha channel. Another call to <span class=\"inline2\">gpu_set_colourwriteenable()</span> is needed to fix this, which restores writing to all colour channels.</p>",
-          "text": "In the code example above writing to the alpha channel is disabled for all draw calls that follow the call to gpu_set_colourwriteenable. No call to gpu_set_colourwriteenable() is made to reset this, however. Because of this, subsequent draw commands will also not write to the alpha channel. Another call to gpu_set_colourwriteenable() is needed to fix this, which restores writing to all colour channels."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_colourwriteenable(true, true, true, false);<br>\n    draw_sprite(sprite_index, 0, x, y);<br>\n    gpu_set_colourwriteenable(true, true, true, true);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_colourwriteenable(true, true, true, false);\n\n    draw_sprite(sprite_index, 0, x, y);\n\n    gpu_set_colourwriteenable(true, true, true, true);"
-        }
-      ]
+      "description": "This message indicates that you've disabled writing to at least one colour channel but haven't re-enabled writing to all colour channels afterwards.",
+      "badExample": "/// Draw Event\n\n    gpu_set_colourwriteenable(true, true, true, false);\n\n    draw_sprite(sprite_index, 0, x, y);",
+      "goodExample": "/// Draw Event\n\n    gpu_set_colourwriteenable(true, true, true, false);\n\n    draw_sprite(sprite_index, 0, x, y);\n\n    gpu_set_colourwriteenable(true, true, true, true);",
+      "correction": "In the code example above writing to the alpha channel is disabled for all draw calls that follow the call to gpu_set_colourwriteenable. No call to gpu_set_colourwriteenable() is made to reset this, however. Because of this, subsequent draw commands will also not write to the alpha channel. Another call to gpu_set_colourwriteenable() is needed to fix this, which restores writing to all colour channels."
     },
     {
       "id": "GM2053",
       "title": "Not all code paths call gpu_set_alphatestenable(false) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've enabled alpha testing but haven't disabled it again afterwards.</p>",
-          "text": "This message indicates that you've enabled alpha testing but haven't disabled it again afterwards."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_alphatestenable(true);<br>\n    draw_self();</p>",
-          "text": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    draw_self();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To fix this you should disable alpha testing after drawing everything that needs to be drawn with alpha testing enabled.</p>",
-          "text": "To fix this you should disable alpha testing after drawing everything that needs to be drawn with alpha testing enabled."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_alphatestenable(true);<br>\n    draw_self();<br>\n    gpu_set_alphatestenable(false);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    draw_self();\n\n    gpu_set_alphatestenable(false);"
-        }
-      ]
+      "description": "This message indicates that you've enabled alpha testing but haven't disabled it again afterwards.",
+      "badExample": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    draw_self();",
+      "goodExample": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    draw_self();\n\n    gpu_set_alphatestenable(false);",
+      "correction": "To fix this you should disable alpha testing after drawing everything that needs to be drawn with alpha testing enabled."
     },
     {
       "id": "GM2054",
       "title": "Not all code paths call gpu_set_alphatestref(0) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the alpha test ref value from the default value of 0 (using&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_alphatestref.htm\">gpu_set_alphatestref</a></span>) but haven't changed it back to 0 afterwards.</p>",
-          "text": "This message indicates that you've changed the alpha test ref value from the default value of 0 (using gpu_set_alphatestref) but haven't changed it back to 0 afterwards."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Note that the alpha test ref value is only used when alpha testing is enabled using <span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_alphatestenable.htm\">gpu_set_alphatestenable</a></span>.</p>",
-          "text": "Note that the alpha test ref value is only used when alpha testing is enabled using gpu_set_alphatestenable."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_alphatestenable(true);<br>\n    gpu_set_alphatestref(127);<br>\n    draw_sprite(sprite_index, 0, x, y);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    gpu_set_alphatestref(127);\n\n    draw_sprite(sprite_index, 0, x, y);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The alpha test ref value should be reset back to 0 to prevent subsequent draw commands from being affected.</p>",
-          "text": "The alpha test ref value should be reset back to 0 to prevent subsequent draw commands from being affected."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    gpu_set_alphatestenable(true);<br>\n    gpu_set_alphatestref(127);<br>\n    draw_sprite(sprite_index, 0, x, y);<br>\n    gpu_set_alphatestref(0);<br>\n    gpu_set_alphatestenable(false);</p>",
-          "text": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    gpu_set_alphatestref(127);\n\n    draw_sprite(sprite_index, 0, x, y);\n\n    gpu_set_alphatestref(0);\n\n    gpu_set_alphatestenable(false);"
-        }
-      ]
+      "description": "This message indicates that you've changed the alpha test ref value from the default value of 0 (using gpu_set_alphatestref) but haven't changed it back to 0 afterwards.\n\nNote that the alpha test ref value is only used when alpha testing is enabled using gpu_set_alphatestenable.",
+      "badExample": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    gpu_set_alphatestref(127);\n\n    draw_sprite(sprite_index, 0, x, y);",
+      "goodExample": "/// Draw Event\n\n    gpu_set_alphatestenable(true);\n\n    gpu_set_alphatestref(127);\n\n    draw_sprite(sprite_index, 0, x, y);\n\n    gpu_set_alphatestref(0);\n\n    gpu_set_alphatestenable(false);",
+      "correction": "The alpha test ref value should be reset back to 0 to prevent subsequent draw commands from being affected."
     },
     {
       "id": "GM2055",
       "title": "Not all code paths call gpu_set_texfilter(false) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the texture filter setting to true but haven't changed it back to false afterwards. By default, texture filtering is set to disabled for all texture samplers.</p>",
-          "text": "This message indicates that you've changed the texture filter setting to true but haven't changed it back to false afterwards. By default, texture filtering is set to disabled for all texture samplers."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    tex = sprite_get_texture(spr_texpage, 0);<br>\n    <br>\n    /// Draw Event<br>\n    gpu_set_texfilter(true);<br>\n    vertex_submit(vb_world, pr_trianglelist, tex);\n  </p>",
-          "text": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texfilter(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>After the call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_texfilter.htm\">gpu_set_texfilter</a></span> and all draw commands that follow it you need to reset texture filtering to <span class=\"inline2\">false</span>, the default setting.</p>",
-          "text": "After the call to gpu_set_texfilter and all draw commands that follow it you need to reset texture filtering to false, the default setting."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    tex = sprite_get_texture(spr_texpage, 0);<br>\n    <br>\n    /// Draw Event<br>\n    gpu_set_texfilter(true);<br>\n    vertex_submit(vb_world, pr_trianglelist, tex);<br>\n    gpu_set_texfilter(false);\n  </p>",
-          "text": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texfilter(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);\n\n    gpu_set_texfilter(false);"
-        }
-      ]
+      "description": "This message indicates that you've changed the texture filter setting to true but haven't changed it back to false afterwards. By default, texture filtering is set to disabled for all texture samplers.",
+      "badExample": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texfilter(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);",
+      "goodExample": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texfilter(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);\n\n    gpu_set_texfilter(false);",
+      "correction": "After the call to gpu_set_texfilter and all draw commands that follow it you need to reset texture filtering to false, the default setting."
     },
     {
       "id": "GM2056",
       "title": "Not all code paths call gpu_set_texrepeat(false) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the texture repeat setting to <span class=\"inline2\">true</span> but haven't changed it back to <span class=\"inline2\">false</span> afterwards. By default, texture repeating is set to disabled for all texture samplers.</p>",
-          "text": "This message indicates that you've changed the texture repeat setting to true but haven't changed it back to false afterwards. By default, texture repeating is set to disabled for all texture samplers."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    tex = sprite_get_texture(spr_texpage, 0);<br>\n    <br>\n    /// Draw Event<br>\n    gpu_set_texrepeat(true);<br>\n    vertex_submit(vb_world, pr_trianglelist, tex);\n  </p>",
-          "text": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texrepeat(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>After the call to&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/GPU_Control/gpu_set_texrepeat.htm\">gpu_set_texrepeat</a></span> and all draw commands that follow it you should reset the texture repeat to <span class=\"inline2\">false</span>, the default setting.</p>",
-          "text": "After the call to gpu_set_texrepeat and all draw commands that follow it you should reset the texture repeat to false, the default setting."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    tex = sprite_get_texture(spr_texpage, 0);<br>\n    <br>\n    /// Draw Event<br>\n    gpu_set_texrepeat(true);<br>\n    vertex_submit(vb_world, pr_trianglelist, tex);<br>\n    gpu_set_texrepeat(false);\n  </p>",
-          "text": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texrepeat(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);\n\n    gpu_set_texrepeat(false);"
-        }
-      ]
+      "description": "This message indicates that you've changed the texture repeat setting to true but haven't changed it back to false afterwards. By default, texture repeating is set to disabled for all texture samplers.",
+      "badExample": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texrepeat(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);",
+      "goodExample": "/// Create Event\n\n    tex = sprite_get_texture(spr_texpage, 0);\n\n\n\n    /// Draw Event\n\n    gpu_set_texrepeat(true);\n\n    vertex_submit(vb_world, pr_trianglelist, tex);\n\n    gpu_set_texrepeat(false);",
+      "correction": "After the call to gpu_set_texrepeat and all draw commands that follow it you should reset the texture repeat to false, the default setting."
     },
     {
       "id": "GM2061",
       "title": "Opportunity to use nullish coalesce operator.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>Shows when you are trying to check if an expression is <span class=\"inline2\">undefined</span>, and then applying a different value in that case:</p>",
-          "text": "Shows when you are trying to check if an expression is undefined, and then applying a different value in that case:"
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">array = modify_array(array);<br>\n    if (array == undefined) array = [];</p>",
-          "text": "array = modify_array(array);\n\n    if (array == undefined) array = [];"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>For this, the <a href=\"../../GameMaker_Language/GML_Overview/Expressions_And_Operators.htm\">nullish operator</a> can be used:</p>",
-          "text": "For this, the nullish operator can be used:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">array = modify_array(array) ?? [];</p>",
-          "text": "array = modify_array(array) ?? [];"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>To keep a variable unchanged if the RHS expression is <span class=\"inline2\">undefined</span>, use this:</p>",
-          "text": "To keep a variable unchanged if the RHS expression is undefined, use this:"
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">array ??= modify_array(array);</p>",
-          "text": "array ??= modify_array(array);"
-        }
-      ]
+      "description": "Shows when you are trying to check if an expression is undefined, and then applying a different value in that case:",
+      "badExample": "array = modify_array(array);\n\n    if (array == undefined) array = [];",
+      "goodExample": "array = modify_array(array) ?? [];\n\narray ??= modify_array(array);",
+      "correction": "For this, the nullish operator can be used:\n\nTo keep a variable unchanged if the RHS expression is undefined, use this:"
     },
     {
       "id": "GM2062",
       "title": "Not all code paths call draw_set_colour(c_white) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the draw colour to a colour that's different from <span class=\"inline2\">c_white</span> but haven't changed it back to <span class=\"inline2\">c_white</span> afterwards.</p>",
-          "text": "This message indicates that you've changed the draw colour to a colour that's different from c_white but haven't changed it back to c_white afterwards."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The draw colour is the colour that's used to blend the sprite with. A colour of <span class=\"inline2\">c_white</span> essentially multiplies all of the sprite's pixels' colours by 1, resulting in no change.</p>",
-          "text": "The draw colour is the colour that's used to blend the sprite with. A colour of c_white essentially multiplies all of the sprite's pixels' colours by 1, resulting in no change."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_set_colour(c_red);<br>\n    draw_text(5, 5, \"Hello!\");</p>",
-          "text": "/// Draw Event\n\n    draw_set_colour(c_red);\n\n    draw_text(5, 5, \"Hello!\");"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, the draw colour used for drawing is set to <span class=\"inline2\">c_red</span> but isn't set back to <span class=\"inline2\">c_white</span> afterwards. This causes all subsequent draw commands to draw with that same draw colour.</p>",
-          "text": "In the code example above, the draw colour used for drawing is set to c_red but isn't set back to c_white afterwards. This causes all subsequent draw commands to draw with that same draw colour."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_set_colour(c_red);<br>\n    draw_text(5, 5, \"Hello!\");<br>\n    draw_set_colour(c_white);</p>",
-          "text": "/// Draw Event\n\n    draw_set_colour(c_red);\n\n    draw_text(5, 5, \"Hello!\");\n\n    draw_set_colour(c_white);"
-        }
-      ]
+      "description": "This message indicates that you've changed the draw colour to a colour that's different from c_white but haven't changed it back to c_white afterwards.\n\nThe draw colour is the colour that's used to blend the sprite with. A colour of c_white essentially multiplies all of the sprite's pixels' colours by 1, resulting in no change.",
+      "badExample": "/// Draw Event\n\n    draw_set_colour(c_red);\n\n    draw_text(5, 5, \"Hello!\");",
+      "goodExample": "/// Draw Event\n\n    draw_set_colour(c_red);\n\n    draw_text(5, 5, \"Hello!\");\n\n    draw_set_colour(c_white);",
+      "correction": "In the code example above, the draw colour used for drawing is set to c_red but isn't set back to c_white afterwards. This causes all subsequent draw commands to draw with that same draw colour."
     },
     {
       "id": "GM2063",
       "title": "Not all code paths call draw_set_alpha(1) before the end of the script.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message indicates that you've changed the draw alpha to a value different from 1 using&nbsp;<span class=\"inline3_func\"><a data-xref=\"{title}\" href=\"../../GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/draw_set_alpha.htm\">draw_set_alpha</a></span> but haven't changed it back to 1.</p>",
-          "text": "This message indicates that you've changed the draw alpha to a value different from 1 using draw_set_alpha but haven't changed it back to 1."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>The alpha value is the value that's used for blending each pixel of the sprite (the source) with the destination pixel.</p>",
-          "text": "The alpha value is the value that's used for blending each pixel of the sprite (the source) with the destination pixel."
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_set_alpha(0.5);<br>\n    draw_self();</p>",
-          "text": "/// Draw Event\n\n    draw_set_alpha(0.5);\n\n    draw_self();"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the code example above, the alpha value used for drawing is set to 0.5 but isn't set back to 1 afterwards. This causes all subsequent draw commands to draw with that same alpha value.</p>",
-          "text": "In the code example above, the alpha value used for drawing is set to 0.5 but isn't set back to 1 afterwards. This causes all subsequent draw commands to draw with that same alpha value."
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Draw Event<br>\n    draw_set_alpha(0.5);<br>\n    draw_self();<br>\n    draw_set_alpha(1);</p>",
-          "text": "/// Draw Event\n\n    draw_set_alpha(0.5);\n\n    draw_self();\n\n    draw_set_alpha(1);"
-        }
-      ]
+      "description": "This message indicates that you've changed the draw alpha to a value different from 1 using draw_set_alpha but haven't changed it back to 1.\n\nThe alpha value is the value that's used for blending each pixel of the sprite (the source) with the destination pixel.",
+      "badExample": "/// Draw Event\n\n    draw_set_alpha(0.5);\n\n    draw_self();",
+      "goodExample": "/// Draw Event\n\n    draw_set_alpha(0.5);\n\n    draw_self();\n\n    draw_set_alpha(1);",
+      "correction": "In the code example above, the alpha value used for drawing is set to 0.5 but isn't set back to 1 afterwards. This causes all subsequent draw commands to draw with that same alpha value."
     },
     {
       "id": "GM2064",
       "title": "Variable '{0}' does not exist in object's Variable Definitions.",
-      "blocks": [
-        {
-          "type": "paragraph",
-          "html": "<p>This message is shown when you create a new instance of an object using one of the <span class=\"inline2\">instance_create_*</span> functions and attempt to access variables that aren't defined in the object's <a href=\"../Object_Properties/Object_Variables.htm\" title=\"Object Variables\">Variable Definitions</a> when assigning to the optional variable struct.</p>",
-          "text": "This message is shown when you create a new instance of an object using one of the instance_create_* functions and attempt to access variables that aren't defined in the object's Variable Definitions when assigning to the optional variable struct."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>In the variable struct you can access variables from any scope, though in instance scope the only variables that exist at this point are the ones defined in the Variable Definitions.</p>",
-          "text": "In the variable struct you can access variables from any scope, though in instance scope the only variables that exist at this point are the ones defined in the Variable Definitions."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Important: object variables don't belong to the object but are initialised in every new instance created from that object. The first point in your code where you can access these variables is the var struct.</p>",
-          "text": "Important: object variables don't belong to the object but are initialised in every new instance created from that object. The first point in your code where you can access these variables is the var struct."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p><img class=\"center\" src=\"../../assets/Images/The_IDE/Code Editor/Feather_Rules/var_def_none.png\"></p>",
-          "text": ""
-        },
-        {
-          "type": "heading",
-          "html": "<h4>Example</h4>",
-          "text": "Example",
-          "level": 4
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {<br>\n    &nbsp; &nbsp; intro_message: message<br>\n    });<br>\n    <br>\n    // The message variable does not exist\n  </p>",
-          "text": "/// Create Event\n\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {\n\n        intro_message: message\n\n    });\n\n\n\n    // The message variable does not exist"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>Variables can only be accessed when they've first been defined. In the example above, the object doesn't have any variables defined but an attempt is made to access an instance variable named <span class=\"inline2\">message</span>. In order to fix this, the variable has to be defined in the object variables.</p>",
-          "text": "Variables can only be accessed when they've first been defined. In the example above, the object doesn't have any variables defined but an attempt is made to access an instance variable named message. In order to fix this, the variable has to be defined in the object variables."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p><img class=\"center\" src=\"../../assets/Images/The_IDE/Code Editor/Feather_Rules/var_def_message.png\"></p>",
-          "text": ""
-        },
-        {
-          "type": "code",
-          "html": "<p class=\"code\">/// Create Event<br>\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {<br>\n    &nbsp; &nbsp; intro_message: message<br>\n    });</p>",
-          "text": "/// Create Event\n\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {\n\n        intro_message: message\n\n    });"
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>&nbsp;</p>",
-          "text": ""
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>&nbsp;</p>",
-          "text": ""
-        }
-      ]
+      "description": "This message is shown when you create a new instance of an object using one of the instance_create_* functions and attempt to access variables that aren't defined in the object's Variable Definitions when assigning to the optional variable struct.\n\nIn the variable struct you can access variables from any scope, though in instance scope the only variables that exist at this point are the ones defined in the Variable Definitions.\n\nImportant: object variables don't belong to the object but are initialised in every new instance created from that object. The first point in your code where you can access these variables is the var struct.",
+      "badExample": "/// Create Event\n\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {\n\n        intro_message: message\n\n    });\n\n\n\n    // The message variable does not exist",
+      "goodExample": "/// Create Event\n\n    ins_companion = instance_create_layer(x, y, layer, obj_companion, {\n\n        intro_message: message\n\n    });",
+      "correction": "Variables can only be accessed when they've first been defined. In the example above, the object doesn't have any variables defined but an attempt is made to access an instance variable named message. In order to fix this, the variable has to be defined in the object variables."
     }
   ],
   "directives": [
@@ -3643,17 +868,14 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>A Feather directive has the following syntax:&nbsp;</p>",
           "text": "A Feather directive has the following syntax:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather command&nbsp;parameters [in PATH]</p>",
           "text": "// Feather command parameters [in PATH]"
         },
         {
           "type": "paragraph",
-          "html": "<p>It is a regular script comment that starts with <span class=\"inline2\">Feather</span>, followed by the command and its parameters. Optionally, it may take a path to a script,&nbsp;object or group in&nbsp;<a data-xref=\"{title}\" href=\"../../Introduction/The_Asset_Browser.htm\">The Asset Browser</a>&nbsp;to which the directive is applied.</p>",
           "text": "It is a regular script comment that starts with Feather, followed by the command and its parameters. Optionally, it may take a path to a script, object or group in The Asset Browser to which the directive is applied."
         }
       ]
@@ -3664,72 +886,58 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>Specific <a href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm#s3\">feather rules</a> can be ignored using the directive <span class=\"inline2\">Feather ignore</span>&nbsp;or <span class=\"inline2\">Feather disable</span>:&nbsp;</p>",
           "text": "Specific feather rules can be ignored using the directive Feather ignore or Feather disable:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather ignore&nbsp; GM1010<br>\n    // Feather disable GM1010</p>",
           "text": "// Feather ignore  GM1010\n\n    // Feather disable GM1010"
         },
         {
           "type": "paragraph",
-          "html": "<p>For example, consider the following piece of code:&nbsp;</p>",
           "text": "For example, consider the following piece of code:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather ignore GM1010<br>\n    result = 5 + \"5\";</p>",
           "text": "// Feather ignore GM1010\n\n    result = 5 + \"5\";"
         },
         {
           "type": "paragraph",
-          "html": "<p>With&nbsp;<strong>Strict Type mode</strong>&nbsp;enabled, Feather normally shows a <span class=\"inline2\">\"GM1010 - Cannot perform '+' operation between types 'real' and 'string'</span> message. With the directive above, Feather will ignore messages of this type, in that particular script.</p>",
           "text": "With Strict Type mode enabled, Feather normally shows a \"GM1010 - Cannot perform '+' operation between types 'real' and 'string' message. With the directive above, Feather will ignore messages of this type, in that particular script."
         },
         {
           "type": "paragraph",
-          "html": "<p>The directive only affects lines after the comment itself, so any statements before the comment will still show warnings.</p>",
           "text": "The directive only affects lines after the comment itself, so any statements before the comment will still show warnings."
         },
         {
           "type": "html",
-          "html": "<h3>Ignoring Once</h3>",
           "text": "Ignoring Once"
         },
         {
           "type": "paragraph",
-          "html": "<p>The GM message can be ignored&nbsp;only&nbsp;once by adding&nbsp;<span class=\"inline2\">once</span>:</p>",
           "text": "The GM message can be ignored only once by adding once:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather ignore&nbsp;once GM1010</p>",
           "text": "// Feather ignore once GM1010"
         },
         {
           "type": "paragraph",
-          "html": "<p>This command makes Feather ignore&nbsp;the first&nbsp;occurrence&nbsp;of this type of message but not the&nbsp;ones that come after that:&nbsp;</p>",
           "text": "This command makes Feather ignore the first occurrence of this type of message but not the ones that come after that:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather ignore&nbsp;once GM1010<br>\n    result = 5 + \"5\";&nbsp; &nbsp; // ignored<br>\n    result = 6 + \"6\";&nbsp; &nbsp; // error</p>",
           "text": "// Feather ignore once GM1010\n\n    result = 5 + \"5\";    // ignored\n\n    result = 6 + \"6\";    // error"
         },
         {
           "type": "html",
-          "html": "<h3>Restoring</h3>",
           "text": "Restoring"
         },
         {
           "type": "paragraph",
-          "html": "<p>Finally, you can re-enable the GM message using <span class=\"inline2\">restore</span> / <span class=\"inline2\">enable</span>:&nbsp;</p>",
           "text": "Finally, you can re-enable the GM message using restore / enable:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather restore GM1010<br>\n    // Feather enable&nbsp; GM1010</p>",
           "text": "// Feather restore GM1010\n\n    // Feather enable  GM1010"
         }
       ]
@@ -3740,17 +948,14 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>This directive sets the profile for the script:&nbsp;</p>",
           "text": "This directive sets the profile for the script:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">// Feather use syntax-errors<br>\n    // Feather use type-errors<br>\n    // Feather use all<br>\n    // Feather use none</p>",
           "text": "// Feather use syntax-errors\n\n    // Feather use type-errors\n\n    // Feather use all\n\n    // Feather use none"
         },
         {
           "type": "note",
-          "html": "<p class=\"note\"><code><span data-conref=\"../../assets/snippets/Tag_note.hts\"> </span>&nbsp;</code>This Feather directive corresponds to the&nbsp;<a data-xref=\"{text}\" href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm#message_severity_profile\">Profile</a>&nbsp;preference in the&nbsp;<a href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm\">Feather Preferences</a>.</p>",
           "text": "This Feather directive corresponds to the Profile preference in the Feather Preferences."
         }
       ]
@@ -3761,17 +966,14 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>This directive sets the type validation mode to use from either <em>strict</em> or <em>relaxed:&nbsp;</em></p>",
           "text": "This directive sets the type validation mode to use from either strict or relaxed:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">/// Feather use strict<br>\n    /// Feather use relaxed</p>",
           "text": "/// Feather use strict\n\n    /// Feather use relaxed"
         },
         {
           "type": "note",
-          "html": "<p class=\"note\"><span data-conref=\"../../assets/snippets/Tag_note.hts\"> </span>&nbsp;This Feather directive corresponds to the <strong>Strict Type mode</strong>&nbsp;preference in the <a href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm\">Feather Preferences</a>.</p>",
           "text": "This Feather directive corresponds to the Strict Type mode preference in the Feather Preferences."
         }
       ]
@@ -3782,17 +984,14 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>You can also set the profile and type validation mode in a single line:&nbsp;</p>",
           "text": "You can also set the profile and type validation mode in a single line:"
         },
         {
           "type": "code",
-          "html": "<p class=\"code\">/// Feather use all, strict</p>",
           "text": "/// Feather use all, strict"
         },
         {
           "type": "paragraph",
-          "html": "<p>The above comment will make Feather look for <strong>All</strong> errors <em>and</em> use <strong>Strict Type mode</strong>.</p>",
           "text": "The above comment will make Feather look for All errors and use Strict Type mode."
         }
       ]
@@ -3803,58 +1002,44 @@
       "blocks": [
         {
           "type": "paragraph",
-          "html": "<p>Optionally you can provide a path using the <span class=\"inline2\">in</span> directive to apply a Feather directive to a specific script,&nbsp;object or group&nbsp;in <a data-xref=\"{title}\" href=\"../../Introduction/The_Asset_Browser.htm\">The Asset Browser</a>. This can be placed in&nbsp;the main script&nbsp;of an external library&nbsp;of functions, though you can place it in any&nbsp;other script, e.g. a blank \"FeatherConfig\" script.</p>",
           "text": "Optionally you can provide a path using the in directive to apply a Feather directive to a specific script, object or group in The Asset Browser. This can be placed in the main script of an external library of functions, though you can place it in any other script, e.g. a blank \"FeatherConfig\" script."
         },
         {
           "type": "note",
-          "html": "<p class=\"note\"><span data-conref=\"../../assets/snippets/Tag_note.hts\"> </span>&nbsp;Having numerous rules using paths may cause performance issues, the exception being paths set specifically to <span class=\"inline2\">*</span> alone.</p>",
           "text": "Having numerous rules using paths may cause performance issues, the exception being paths set specifically to * alone."
         },
         {
           "type": "paragraph",
-          "html": "<p>You can use the following special symbols in your paths:&nbsp;</p>",
           "text": "You can use the following special symbols in your paths:"
         },
         {
           "type": "list",
-          "html": "<ul class=\"colour\">\n    <li><span class=\"inline2\">/</span>&nbsp;- When used in the beginning of a path, points to the root&nbsp;of the Asset Browser</li>\n    <li><span class=\"inline2\">.</span>&nbsp;- When used in the beginning of a path, points to the current script's folder</li>\n    <li><span class=\"inline2\">*</span> is a wildcard that matches everything inside the preceding directory</li>\n  </ul>",
-          "text": "/ - When used in the beginning of a path, points to the root of the Asset Browser\n    . - When used in the beginning of a path, points to the current script's folder\n    * is a wildcard that matches everything inside the preceding directory"
+          "text": "/ - When used in the beginning of a path, points to the root of the Asset Browser\n    . - When used in the beginning of a path, points to the current script's folder\n    * is a wildcard that matches everything inside the preceding directory",
+          "items": [
+            "/ - When used in the beginning of a path, points to the root of the Asset Browser",
+            ". - When used in the beginning of a path, points to the current script's folder",
+            "* is a wildcard that matches everything inside the preceding directory"
+          ]
         },
         {
           "type": "paragraph",
-          "html": "<p>This way&nbsp;you can&nbsp;define paths to assets in the Asset Browser, for example:</p>",
           "text": "This way you can define paths to assets in the Asset Browser, for example:"
         },
         {
           "type": "table",
-          "html": "<table border=\"1\" cellpadding=\"1\" cellspacing=\"1\">\n    <thead>\n      <tr>\n        <th>Path</th>\n        <th>Applies To</th>\n      </tr>\n    </thead>\n    <tbody>\n      <tr>\n        <td>/Scripts/*</td>\n        <td>All assets in /Scripts</td>\n      </tr>\n      <tr>\n        <td>/*</td>\n        <td>All assets</td>\n      </tr>\n      <tr>\n        <td>./*</td>\n        <td>All assets in the current folder and subfolders</td>\n      </tr>\n      <tr>\n        <td>/Foo/Bar/obj_manager</td>\n        <td>obj_manager in the /Foo/Bar folder</td>\n      </tr>\n    </tbody>\n  </table>",
           "text": "Path Applies To /Scripts/* All assets in /Scripts /* All assets ./* All assets in the current folder and subfolders /Foo/Bar/obj_manager obj_manager in the /Foo/Bar folder"
         },
         {
           "type": "paragraph",
-          "html": "<p>Examples:&nbsp;</p>",
           "text": "Examples:"
         },
         {
           "type": "table",
-          "html": "<table border=\"1\" cellpadding=\"1\" cellspacing=\"1\">\n    <thead>\n      <tr>\n        <th>Directive</th>\n        <th>Effect</th>\n      </tr>\n    </thead>\n    <tbody>\n      <tr>\n        <td><span class=\"inline\">// Feather ignore GM2017 in *</span></td>\n        <td>Ignores all Naming Rule violations in the whole project</td>\n      </tr>\n      <tr>\n        <td><span class=\"inline\">// Feather ignore GM1064 in ./*</span></td>\n        <td>Ignores GM1064 in the current folder and all subfolders</td>\n      </tr>\n      <tr>\n        <td><span class=\"inline\">// Feather use type-errors in /Objects/System/*</span></td>\n        <td>Sets the profile to type-errors in specifically the Objects/System folder</td>\n      </tr>\n      <tr>\n        <td><span class=\"inline\">// Feather use all in /Objects/System/obj_controller</span></td>\n        <td>Sets the profile to all in obj_controller</td>\n      </tr>\n    </tbody>\n  </table>",
           "text": "Directive Effect // Feather ignore GM2017 in * Ignores all Naming Rule violations in the whole project // Feather ignore GM1064 in ./* Ignores GM1064 in the current folder and all subfolders // Feather use type-errors in /Objects/System/* Sets the profile to type-errors in specifically the Objects/System folder // Feather use all in /Objects/System/obj_controller Sets the profile to all in obj_controller"
         },
         {
           "type": "note",
-          "html": "<p class=\"note\"><span data-conref=\"../../assets/snippets/Tag_warning.hts\"> </span>&nbsp;No consistent result is guaranteed&nbsp;if you have two directives that enable and disable a Feather message on the same path.</p>",
           "text": "No consistent result is guaranteed if you have two directives that enable and disable a Feather message on the same path."
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>&nbsp;</p>",
-          "text": ""
-        },
-        {
-          "type": "paragraph",
-          "html": "<p>&nbsp;</p>",
-          "text": ""
         }
       ]
     }
@@ -3881,33 +1066,23 @@
     "rawBlocks": [
       {
         "type": "paragraph",
-        "html": "<p><img class=\"center\" src=\"../../assets/Images/Setup_And_Version/Preferences/Feather/FeatherPrefs_NamingRules.png\">This section allows you to set naming rules for assets, variables and various other parts of <span data-keyref=\"GML_Code\">GML Code</span>. Any newly created assets in the Asset Browser will follow the naming rules set here.</p>",
         "text": "This section allows you to set naming rules for assets, variables and various other parts of GML Code. Any newly created assets in the Asset Browser will follow the naming rules set here."
       },
       {
         "type": "paragraph",
-        "html": "<p>The GM2017 rule under \"Message Severity\" must be enabled for naming rules to take effect. By default, it's disabled (set to \"Ignore\").</p>",
         "text": "The GM2017 rule under \"Message Severity\" must be enabled for naming rules to take effect. By default, it's disabled (set to \"Ignore\")."
       },
       {
         "type": "paragraph",
-        "html": "<p>The settings in this section are as follows:</p>",
         "text": "The settings in this section are as follows:"
       },
       {
         "type": "list",
-        "html": "<ul class=\"colour\">\n    <li><strong>Identifier Blocklist</strong>: This is a space-separated list of identifiers that will be ignored for all naming rules.<br>\n      <br>\n      For example, say you have a rule to use <span class=\"inline2\">obj_</span> as a prefix for objects, but you want your objects <span class=\"inline2\">manager</span> and <span class=\"inline2\">network</span> to remain as-is and not use the <span class=\"inline2\">obj_</span> prefix.<br>\n      <br>\n      In that case, you would write <span class=\"inline2\">manager network</span> into the <strong>Identifier Blocklist</strong> field. Feather will ignore those objects <em>and</em> any other identifiers (variables, enums, parameters, etc.) with the same names.\n    </li>\n    <li><strong>&lt;identifier&gt; Naming Rule</strong>: You can set naming rules for each type of identifier in the list, such as assets, macros, enums, function parameters, variables, etc.<br>\n      <br>\n      Each naming rule drop-down has the following options:\n      <ul>\n        <li><strong>Naming Style</strong>: Choose the naming style for the identifier. Your options are:\n          <ul>\n            <li><strong>Unconstrained</strong>: No formatting is forced on this type of identifier.</li>\n            <li><strong>UpperCamelCase</strong>: <em>MyHealth, ObjGrappleHook</em></li>\n            <li><strong>lowerCamelCase</strong>: <em>myHealth, objGrappleHook</em></li>\n            <li><strong>ALL_UPPER</strong>: <em>MY_HEALTH, OBJ_GRAPPLE_HOOK</em></li>\n            <li><strong>all_lower</strong>: <em>my_health, obj_grapple_hook</em></li>\n          </ul>\n        </li>\n        <li><strong>Prefix</strong>: Text that should appear before the identifier name, which may be <span class=\"inline2\">obj_</span> for objects, <span class=\"inline2\">_</span> for local variables, etc. depending on your preferences.</li>\n        <li><strong>Suffix</strong>: Text that should appear after the identifier name.</li>\n        <li><strong>Preserve trailing and leading underscores</strong>: If enabled, preserves underscores around your asset's name even after suggestions.<br>\n          <br>\n          With this, you can use asset names such as <span class=\"inline2\">__objCamera</span>, keeping any leading and trailing underscores where they are.\n        </li>\n      </ul>\n    </li>\n  </ul>",
-        "text": "Identifier Blocklist: This is a space-separated list of identifiers that will be ignored for all naming rules.\n\n\n\n      For example, say you have a rule to use obj_ as a prefix for objects, but you want your objects manager and network to remain as-is and not use the obj_ prefix.\n\n\n\n      In that case, you would write manager network into the Identifier Blocklist field. Feather will ignore those objects and any other identifiers (variables, enums, parameters, etc.) with the same names.\n\n    <identifier> Naming Rule: You can set naming rules for each type of identifier in the list, such as assets, macros, enums, function parameters, variables, etc.\n\n\n\n      Each naming rule drop-down has the following options:\n\n        Naming Style: Choose the naming style for the identifier. Your options are:\n\n            Unconstrained: No formatting is forced on this type of identifier.\n            UpperCamelCase: MyHealth, ObjGrappleHook\n            lowerCamelCase: myHealth, objGrappleHook\n            ALL_UPPER: MY_HEALTH, OBJ_GRAPPLE_HOOK\n            all_lower: my_health, obj_grapple_hook\n\n\n        Prefix: Text that should appear before the identifier name, which may be obj_ for objects, _ for local variables, etc. depending on your preferences.\n        Suffix: Text that should appear after the identifier name.\n        Preserve trailing and leading underscores: If enabled, preserves underscores around your asset's name even after suggestions.\n\n\n\n          With this, you can use asset names such as __objCamera, keeping any leading and trailing underscores where they are."
-      },
-      {
-        "type": "paragraph",
-        "html": "<p>&nbsp;</p>",
-        "text": ""
-      },
-      {
-        "type": "paragraph",
-        "html": "<p>&nbsp;</p>",
-        "text": ""
+        "text": "Identifier Blocklist: This is a space-separated list of identifiers that will be ignored for all naming rules.\n\n\n\n      For example, say you have a rule to use obj_ as a prefix for objects, but you want your objects manager and network to remain as-is and not use the obj_ prefix.\n\n\n\n      In that case, you would write manager network into the Identifier Blocklist field. Feather will ignore those objects and any other identifiers (variables, enums, parameters, etc.) with the same names.\n\n    <identifier> Naming Rule: You can set naming rules for each type of identifier in the list, such as assets, macros, enums, function parameters, variables, etc.\n\n\n\n      Each naming rule drop-down has the following options:\n\n        Naming Style: Choose the naming style for the identifier. Your options are:\n\n            Unconstrained: No formatting is forced on this type of identifier.\n            UpperCamelCase: MyHealth, ObjGrappleHook\n            lowerCamelCase: myHealth, objGrappleHook\n            ALL_UPPER: MY_HEALTH, OBJ_GRAPPLE_HOOK\n            all_lower: my_health, obj_grapple_hook\n\n\n        Prefix: Text that should appear before the identifier name, which may be obj_ for objects, _ for local variables, etc. depending on your preferences.\n        Suffix: Text that should appear after the identifier name.\n        Preserve trailing and leading underscores: If enabled, preserves underscores around your asset's name even after suggestions.\n\n\n\n          With this, you can use asset names such as __objCamera, keeping any leading and trailing underscores where they are.",
+        "items": [
+          "Identifier Blocklist: This is a space-separated list of identifiers that will be ignored for all naming rules. For example, say you have a rule to use obj_ as a prefix for objects, but you want your objects manager and network to remain as-is and not use the obj_ prefix. In that case, you would write manager network into the Identifier Blocklist field. Feather will ignore those objects and any other identifiers (variables, enums, parameters, etc.) with the same names.",
+          "<identifier> Naming Rule: You can set naming rules for each type of identifier in the list, such as assets, macros, enums, function parameters, variables, etc. Each naming rule drop-down has the following options: Naming Style: Choose the naming style for the identifier. Your options are: Unconstrained: No formatting is forced on this type of identifier. UpperCamelCase: MyHealth, ObjGrappleHook lowerCamelCase: myHealth, objGrappleHook ALL_UPPER: MY_HEALTH, OBJ_GRAPPLE_HOOK all_lower: my_health, obj_grapple_hook Prefix: Text that should appear before the identifier name, which may be obj_ for objects, _ for local variables, etc. depending on your preferences. Suffix: Text that should appear after the identifier name. Preserve trailing and leading underscores: If enabled, preserves underscores around your asset's name even after suggestions. With this, you can use asset names such as __objCamera, keeping any leading and trailing underscores where they are."
+        ]
       }
     ]
   },
@@ -3915,22 +1090,18 @@
     "introBlocks": [
       {
         "type": "paragraph",
-        "html": "<p><a href=\"../../Setting_Up_And_Version_Information/IDE_Preferences/Feather_Settings.htm\">Feather</a> uses data types to provide smart syntax-checking when writing code, ensuring you don't use the wrong data type for a variable or function parameter.</p>",
         "text": "Feather uses data types to provide smart syntax-checking when writing code, ensuring you don't use the wrong data type for a variable or function parameter."
       },
       {
         "type": "paragraph",
-        "html": "<p>It also allows you to specify the data types for the parameters and return values of your own&nbsp;<a href=\"../../GameMaker_Language/GML_Overview/Script_Functions.htm\">script functions</a>, using <a href=\"JSDoc_Script_Comments.htm\">JSDoc comments</a>.</p>",
         "text": "It also allows you to specify the data types for the parameters and return values of your own script functions, using JSDoc comments."
       },
       {
         "type": "paragraph",
-        "html": "<p>The <span class=\"inline\">@param</span> and <span class=\"inline\">@return</span>&nbsp;JSDoc tags allow you specify any one of the following types:</p>",
         "text": "The @param and @return JSDoc tags allow you specify any one of the following types:"
       },
       {
         "type": "note",
-        "html": "<p class=\"note\"><span class=\"note\">NOTE</span>&nbsp;JSDoc&nbsp;base types are case-insensitive, so <span class=\"inline2\">string</span> and <span class=\"inline2\">String</span> are the same, however specifiers (after the <span class=\"inline2\">.</span>) are case-sensitive, meaning <span class=\"inline2\">Id.DsList</span> is valid (referring to a&nbsp;<span data-keyref=\"Type_ID_DS_List\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Lists/ds_list_create.htm\" target=\"_blank\">DS List</a></span>) but <span class=\"inline2\">Id.dslist</span> is not.</p>",
         "text": "NOTE JSDoc base types are case-insensitive, so string and String are the same, however specifiers (after the .) are case-sensitive, meaning Id.DsList is valid (referring to a DS List) but Id.dslist is not."
       }
     ],
@@ -3940,7 +1111,6 @@
         "specifierExamples": [
           "N/A"
         ],
-        "specifierHtml": "<em>N/A</em>",
         "description": "A real number"
       },
       {
@@ -3948,7 +1118,6 @@
         "specifierExamples": [
           "N/A"
         ],
-        "specifierHtml": "<em>N/A</em>",
         "description": "A boolean"
       },
       {
@@ -3956,7 +1125,6 @@
         "specifierExamples": [
           "N/A"
         ],
-        "specifierHtml": "<em>N/A</em>",
         "description": "A string"
       },
       {
@@ -3965,7 +1133,6 @@
           "Default - Array",
           "..."
         ],
-        "specifierHtml": "<em>Default</em> -&nbsp;<span data-keyref=\"Type_Array\"><a href=\"../../GameMaker_Language/GML_Overview/Arrays.htm\" target=\"_blank\">Array</a></span><br>\n          ...",
         "description": "An array, may include specifiers"
       },
       {
@@ -3974,7 +1141,6 @@
           "Default - Pointer",
           "..."
         ],
-        "specifierHtml": "<em>Default</em> -&nbsp;<span data-keyref=\"Type_Pointer\"><a href=\"../../GameMaker_Language/GML_Overview/Data_Types.htm\" target=\"_blank\">Pointer</a></span><br>\n          ...",
         "description": "A pointer, may include specifiers"
       },
       {
@@ -3983,7 +1149,6 @@
           "Default - Function",
           "..."
         ],
-        "specifierHtml": "<em>Default</em> -&nbsp;<span data-keyref=\"Type_Function\"><a href=\"../../GameMaker_Language/GML_Overview/Script_Functions.htm\" target=\"_blank\">Function</a></span><br>\n          ...",
         "description": "A function, may include specifiers"
       },
       {
@@ -3992,7 +1157,6 @@
           "Default - Struct",
           "..."
         ],
-        "specifierHtml": "<em>Default</em> -&nbsp;<span data-keyref=\"Type_Struct\"><a href=\"../../GameMaker_Language/GML_Overview/Structs.htm\" target=\"_blank\">Struct</a></span><br>\n          ...",
         "description": "A struct, may include specifiers (such as constructors)"
       },
       {
@@ -4007,7 +1171,6 @@
           ".DsQueue - DS Queue",
           "..."
         ],
-        "specifierHtml": ".Instance -&nbsp;<span data-keyref=\"Type_ID_Instance\"><a href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Instances/Instance_Variables/id.htm\" target=\"_blank\">Object Instance</a></span><br>\n          .DsList -&nbsp;<span data-keyref=\"Type_ID_DS_List\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Lists/ds_list_create.htm\" target=\"_blank\">DS List</a></span><br>\n          .DsMap -&nbsp;<span data-keyref=\"Type_ID_DS_Map\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Maps/ds_map_create.htm\" target=\"_blank\">DS Map</a></span><br>\n          .DsGrid -&nbsp;<span data-keyref=\"Type_ID_DS_Grid\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Grids/ds_grid_create.htm\" target=\"_blank\">DS Grid</a></span><br>\n          .DsStack -&nbsp;<span data-keyref=\"Type_ID_DS_Stack\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Stacks/ds_stack_create.htm\" target=\"_blank\">DS Stack</a></span><br>\n          .DsPriority -&nbsp;<span data-keyref=\"Type_ID_DS_Priority\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Priority_Queues/ds_priority_create.htm\" target=\"_blank\">DS Priority</a></span><br>\n          .DsQueue -&nbsp;<span data-keyref=\"Type_ID_DS_Queue\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Queues/ds_queue_create.htm\" target=\"_blank\">DS Queue</a></span><em><br>\n            ...</em>",
         "description": "An ID, requires specifiers"
       },
       {
@@ -4028,7 +1191,6 @@
           ".GMTileSet - Tile Set Asset",
           "..."
         ],
-        "specifierHtml": ".GMAnimCurve -&nbsp;<span data-keyref=\"Type_Asset_Animation_Curve\"><a href=\"../Animation_Curves.htm\" target=\"_blank\">Animation Curve Asset</a></span><br>\n          .GMObject -&nbsp;<span data-keyref=\"Type_Asset_Object\"><a href=\"../Objects.htm\" target=\"_blank\">Object Asset</a></span><br>\n          .GMAudioGroup -&nbsp;<span data-keyref=\"Type_ID_Audio_Group\"><a href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Audio/Audio_Groups/Audio_Groups.htm\" target=\"_blank\">Audio Group ID</a></span><br>\n          .GMFont -&nbsp;<span data-keyref=\"Type_Asset_Font\"><a href=\"../Fonts.htm\" target=\"_blank\">Font Asset</a></span><br>\n          .GMPath -&nbsp;<span data-keyref=\"Type_Asset_Path\"><a href=\"../Paths.htm\" target=\"_blank\">Path Asset</a></span><br>\n          .GMScript -&nbsp;<span data-keyref=\"Type_Asset_Script\"><a href=\"../Scripts.htm\" target=\"_blank\">Script Asset</a></span><br>\n          .GMShader -&nbsp;<span data-keyref=\"Type_Asset_Shader\"><a href=\"../Shaders.htm\" target=\"_blank\">Shader Asset</a></span><br>\n          .GMSound -&nbsp;<span data-keyref=\"Type_Asset_Sound\"><a href=\"../Sounds.htm\" target=\"_blank\">Sound Asset</a></span><br>\n          .GMTimeline -&nbsp;<span data-keyref=\"Type_Asset_Timeline\"><a href=\"../Timelines.htm\" target=\"_blank\">Timeline Asset</a></span><br>\n          .GMRoom -&nbsp;<span data-keyref=\"Type_Asset_Room\"><a href=\"../Rooms.htm\" target=\"_blank\">Room Asset</a></span>&nbsp;<br>\n          .GMSequence -&nbsp;<span data-keyref=\"Type_Asset_Sequence\"><a href=\"../Sequences.htm\" target=\"_blank\">Sequence Asset</a></span><br>\n          .GMSprite -&nbsp;<span data-keyref=\"Type_Asset_Sprite\"><a href=\"../Sprites.htm\" target=\"_blank\">Sprite Asset</a></span><br>\n          .GMTileSet -&nbsp;<span data-keyref=\"Type_Asset_Tile_Set\"><a href=\"../Tile_Sets.htm\" target=\"_blank\">Tile Set Asset</a></span><em><br>\n            ...</em>",
         "description": "An asset, requires specifiers"
       },
       {
@@ -4043,7 +1205,6 @@
           ".PrimitiveType - Primitive Type Constant",
           "..."
         ],
-        "specifierHtml": ".Colour -&nbsp;<span data-keyref=\"Type_Constant_Colour\"><a href=\"../../GameMaker_Language/GML_Reference/Drawing/Colour_And_Alpha/Colour_And_Alpha.htm\" target=\"_blank\">Colour</a></span><br>\n          .HAlign - <span data-keyref=\"Type_Constant_Draw_HAlign\"><a href=\"../../GameMaker_Language/GML_Reference/Drawing/Text/draw_set_halign.htm\" target=\"_blank\">Horizontal Alignment Constant</a></span><br>\n          .VAlign -&nbsp;<span data-keyref=\"Type_Constant_Draw_VAlign\"><a href=\"../../GameMaker_Language/GML_Reference/Drawing/Text/draw_set_valign.htm\" target=\"_blank\">Vertical Alignment Constant</a></span><br>\n          .Cursor -&nbsp;<span data-keyref=\"Type_Constant_Cursor\"><a href=\"../../GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_get_cursor.htm\" target=\"_blank\">Cursor Constant</a></span><br>\n          .EventType -&nbsp;<span data-keyref=\"Type_Constant_Event_Type\"><a href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_perform.htm\" target=\"_blank\">Event Type Constant</a></span><br>\n          .EventNumber -&nbsp;<span data-keyref=\"Type_Constant_Event_Number\"><a href=\"../../GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_perform.htm\" target=\"_blank\">Event Number Constant</a></span><br>\n          .PrimitiveType -&nbsp;<span data-keyref=\"Type_Constant_Draw_Primitive_Type\"><a href=\"../../GameMaker_Language/GML_Reference/Drawing/Primitives/draw_primitive_begin.htm\" target=\"_blank\">Primitive Type Constant</a></span><br>\n          ...",
         "description": "A constant, requires specifiers"
       },
       {
@@ -4051,19 +1212,16 @@
         "specifierExamples": [
           "N/A"
         ],
-        "specifierHtml": "<em>N/A</em>",
         "description": "Any data type"
       }
     ],
     "noteBlocks": [
       {
         "type": "note",
-        "html": "<p class=\"note\"><span class=\"note\">NOTE</span>&nbsp;JSDoc&nbsp;base types are case-insensitive, so <span class=\"inline2\">string</span> and <span class=\"inline2\">String</span> are the same, however specifiers (after the <span class=\"inline2\">.</span>) are case-sensitive, meaning <span class=\"inline2\">Id.DsList</span> is valid (referring to a&nbsp;<span data-keyref=\"Type_ID_DS_List\"><a href=\"../../GameMaker_Language/GML_Reference/Data_Structures/DS_Lists/ds_list_create.htm\" target=\"_blank\">DS List</a></span>) but <span class=\"inline2\">Id.dslist</span> is not.</p>",
         "text": "NOTE JSDoc base types are case-insensitive, so string and String are the same, however specifiers (after the .) are case-sensitive, meaning Id.DsList is valid (referring to a DS List) but Id.dslist is not."
       },
       {
         "type": "note",
-        "html": "<p class=\"note\"><span class=\"note\">NOTE</span>&nbsp;<em>*</em> The <strong>Specifier Examples</strong> column lists some example specifiers, but not all of them. For example, there may be more possible types under the <span class=\"inline2\">Id</span>, <span class=\"inline2\">Asset</span>, and <span class=\"inline2\">Constant</span> groups, which are not listed here.</p>",
         "text": "NOTE * The Specifier Examples column lists some example specifiers, but not all of them. For example, there may be more possible types under the Id, Asset, and Constant groups, which are not listed here."
       }
     ],
@@ -4074,17 +1232,14 @@
         "blocks": [
           {
             "type": "paragraph",
-            "html": "<p>A specifier is added after the base data type using a dot <span class=\"inline2\">.</span>, to specify the exact type of data in that group.</p>",
             "text": "A specifier is added after the base data type using a dot ., to specify the exact type of data in that group."
           },
           {
             "type": "paragraph",
-            "html": "<p>Types such as <span class=\"inline2\">Id.DsList</span>, <span class=\"inline2\">Asset.GMObject</span>, and <span class=\"inline2\">Constant.Color</span> use specifiers. Constructors are specified through the syntax&nbsp;<span class=\"inline2\">Struct.{ConstructorName}</span>. For example:</p>",
             "text": "Types such as Id.DsList, Asset.GMObject, and Constant.Color use specifiers. Constructors are specified through the syntax Struct.{ConstructorName}. For example:"
           },
           {
             "type": "code",
-            "html": "<p class=\"code\">function Person() constructor<br>\n    {<br>\n    <br>\n    }<br>\n    <br>\n    /// @param {Struct.Person} _person<br>\n    function do_business(_person)<br>\n    {<br>\n    <br>\n    }\n  </p>",
             "text": "function Person() constructor\n\n    {\n\n\n\n    }\n\n\n\n    /// @param {Struct.Person} _person\n\n    function do_business(_person)\n\n    {\n\n\n\n    }"
           }
         ]
@@ -4095,17 +1250,14 @@
         "blocks": [
           {
             "type": "paragraph",
-            "html": "<p>Types such as <span class=\"inline2\">Array</span> and <span class=\"inline2\">Id.DsList</span>, which are data structures that contain multiple values, are able to specify a single data type for all of their contents.</p>",
             "text": "Types such as Array and Id.DsList, which are data structures that contain multiple values, are able to specify a single data type for all of their contents."
           },
           {
             "type": "paragraph",
-            "html": "<p>This is done using Collection Types, which are appended to the type using angle brackets <span class=\"inline2\">&lt;&gt;</span>.</p>",
             "text": "This is done using Collection Types, which are appended to the type using angle brackets <>."
           },
           {
             "type": "paragraph",
-            "html": "<p>For example, an array containing strings would be <span class=\"inline2\">Array&lt;String&gt;</span>, and a DS List, containing an Array, containing Reals, would be <span class=\"inline2\">Id.DsList&lt;Array&lt;Real&gt;&gt;</span>.</p>",
             "text": "For example, an array containing strings would be Array<String>, and a DS List, containing an Array, containing Reals, would be Id.DsList<Array<Real>>."
           }
         ]
@@ -4116,7 +1268,6 @@
         "blocks": [
           {
             "type": "paragraph",
-            "html": "<p>Multiple data types can also be listed,&nbsp;separated by a comma <span class=\"inline2\">,</span>. For example&nbsp;<span class=\"inline2\">String,Array&lt;String&gt;</span>,&nbsp;<span class=\"inline2\">Id.Instance,Asset.GMObject</span>, etc.</p>",
             "text": "Multiple data types can also be listed, separated by a comma ,. For example String,Array<String>, Id.Instance,Asset.GMObject, etc."
           }
         ]
@@ -4435,12 +1586,10 @@
     "typeValidationBlocks": [
       {
         "type": "paragraph",
-        "html": "<p>The table below shows what happens if you pass a value of a certain type (rows) into a parameter requiring a data type (column).</p>",
         "text": "The table below shows what happens if you pass a value of a certain type (rows) into a parameter requiring a data type (column)."
       },
       {
         "type": "paragraph",
-        "html": "<p>For example, specifying <span class=\"inline2\">undefined</span> (first row) for a parameter requiring a string (second column) results in an error.</p>",
         "text": "For example, specifying undefined (first row) for a parameter requiring a string (second column) results in an error."
       }
     ]


### PR DESCRIPTION
## Summary
- update the feather metadata generator to strip HTML, capture list items, and normalise text content
- refactor diagnostic extraction to emit description, bad example, good example, and correction fields
- regenerate the feather metadata JSON with the new structure

## Testing
- node ./scripts/generate-feather-metadata.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e7218f0d08832f85d1f59df33b9396