### PR TITLE
Standardize Feather diagnostic fix registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
   Preserve banner-style comments that already have at least this many consecutive `/` characters. Decrease the value if your
   project prefers shorter banners, or raise it to require a longer prefix before a comment is treated as a banner.
 
+- `applyFeatherFixes` (default: `false`)
+
+  Enables opt-in auto-fixes that leverage the bundled GameMaker Feather metadata. When enabled the formatter removes the
+  trailing semicolon from `#macro` declarations, satisfying the GM1051 diagnostic in the official Feather catalogue while
+  preserving all existing spacing inside the macro body.
+
 - `lineCommentBannerAutofillThreshold` (default: `4`)
 
   Automatically pad banner comments up to the minimum slash count when they already start with at least this many `/` characters.

--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -1,0 +1,219 @@
+import { getNodeEndIndex, getNodeStartIndex } from "../../../shared/ast-locations.js";
+import { getFeatherDiagnostics } from "../../../shared/feather/metadata.js";
+
+const FEATHER_FIX_IMPLEMENTATIONS = buildFeatherFixImplementations();
+const FEATHER_DIAGNOSTIC_FIXERS = buildFeatherDiagnosticFixers();
+
+export function getFeatherDiagnosticFixers() {
+    return new Map(FEATHER_DIAGNOSTIC_FIXERS);
+}
+
+export function applyFeatherFixes(ast, { sourceText } = {}) {
+    if (!ast || typeof ast !== "object") {
+        return ast;
+    }
+
+    const appliedFixes = [];
+
+    for (const entry of FEATHER_DIAGNOSTIC_FIXERS.values()) {
+        const fixes = entry.applyFix(ast, { sourceText });
+
+        if (Array.isArray(fixes) && fixes.length > 0) {
+            appliedFixes.push(...fixes);
+        }
+    }
+
+    if (appliedFixes.length > 0) {
+        attachFeatherFixMetadata(ast, appliedFixes);
+    }
+
+    return ast;
+}
+
+function buildFeatherDiagnosticFixers() {
+    const diagnostics = getFeatherDiagnostics();
+    const registry = new Map();
+
+    for (const diagnostic of diagnostics) {
+        const diagnosticId = diagnostic?.id;
+
+        if (!diagnosticId || registry.has(diagnosticId)) {
+            continue;
+        }
+
+        const applyFix = createFixerForDiagnostic(diagnostic);
+
+        if (typeof applyFix !== "function") {
+            continue;
+        }
+
+        registry.set(diagnosticId, {
+            diagnostic,
+            applyFix
+        });
+    }
+
+    return registry;
+}
+
+function createFixerForDiagnostic(diagnostic) {
+    const implementationFactory = FEATHER_FIX_IMPLEMENTATIONS.get(diagnostic?.id);
+
+    if (typeof implementationFactory === "function") {
+        const implementation = implementationFactory(diagnostic);
+
+        if (typeof implementation === "function") {
+            return (ast, context) => {
+                const fixes = implementation({
+                    ast,
+                    sourceText: context?.sourceText
+                });
+
+                return Array.isArray(fixes) ? fixes : [];
+            };
+        }
+    }
+
+    return createNoOpFixer();
+}
+
+function createNoOpFixer() {
+    return () => [];
+}
+
+function buildFeatherFixImplementations() {
+    const registry = new Map();
+
+    registerFeatherFixer(registry, "GM1051", (diagnostic) => ({ ast, sourceText }) =>
+        removeTrailingMacroSemicolons({
+            ast,
+            sourceText,
+            diagnostic
+        })
+    );
+
+    return registry;
+}
+
+function registerFeatherFixer(registry, diagnosticId, factory) {
+    if (!registry || typeof registry.set !== "function") {
+        return;
+    }
+
+    if (!diagnosticId || typeof factory !== "function") {
+        return;
+    }
+
+    if (!registry.has(diagnosticId)) {
+        registry.set(diagnosticId, factory);
+    }
+}
+
+function removeTrailingMacroSemicolons({ ast, sourceText, diagnostic }) {
+    if (!diagnostic || typeof sourceText !== "string" || sourceText.length === 0) {
+        return [];
+    }
+
+    const fixes = [];
+
+    const visit = (node) => {
+        if (!node || typeof node !== "object") {
+            return;
+        }
+
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                visit(item);
+            }
+            return;
+        }
+
+        if (node.type === "MacroDeclaration") {
+            const fixInfo = sanitizeMacroDeclaration(node, sourceText, diagnostic);
+            if (fixInfo) {
+                fixes.push(fixInfo);
+            }
+        }
+
+        for (const value of Object.values(node)) {
+            if (value && typeof value === "object") {
+                visit(value);
+            }
+        }
+    };
+
+    visit(ast);
+
+    return fixes;
+}
+
+function sanitizeMacroDeclaration(node, sourceText, diagnostic) {
+    if (!node || typeof node !== "object") {
+        return null;
+    }
+
+    const tokens = Array.isArray(node.tokens) ? node.tokens : null;
+    if (!tokens || tokens.length === 0) {
+        return null;
+    }
+
+    const lastToken = tokens[tokens.length - 1];
+    if (lastToken !== ";") {
+        return null;
+    }
+
+    const startIndex = node.start?.index;
+    const endIndex = node.end?.index;
+
+    if (typeof startIndex !== "number" || typeof endIndex !== "number") {
+        return null;
+    }
+
+    const originalText = sourceText.slice(startIndex, endIndex + 1);
+
+    // Only strip semicolons that appear at the end of the macro definition.
+    const sanitizedText = originalText.replace(/;(?=[^\S\r\n]*(?:\r?\n|$))/, "");
+
+    if (sanitizedText === originalText) {
+        return null;
+    }
+
+    node.tokens = tokens.slice(0, tokens.length - 1);
+    node._featherMacroText = sanitizedText;
+
+    const fixDetail = {
+        id: diagnostic.id,
+        title: diagnostic.title,
+        description: diagnostic.description,
+        correction: diagnostic.correction,
+        target: node.name?.name ?? null,
+        range: {
+            start: getNodeStartIndex(node),
+            end: getNodeEndIndex(node)
+        }
+    };
+
+    attachFeatherFixMetadata(node, [fixDetail]);
+
+    return fixDetail;
+}
+
+function attachFeatherFixMetadata(target, fixes) {
+    if (!target || typeof target !== "object" || !Array.isArray(fixes) || fixes.length === 0) {
+        return;
+    }
+
+    const key = "_appliedFeatherDiagnostics";
+
+    if (!Array.isArray(target[key])) {
+        Object.defineProperty(target, key, {
+            configurable: true,
+            enumerable: false,
+            writable: true,
+            value: []
+        });
+    }
+
+    target[key].push(...fixes);
+}
+

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -104,6 +104,14 @@ export const options = {
         range: { start: 0, end: Infinity },
         description:
             "Maximum number of arguments allowed on a single line before a function call is forced to wrap. Set to 0 to disable.",
+    },
+    applyFeatherFixes: {
+        since: "0.0.0",
+        type: "boolean",
+        category: "gml",
+        default: false,
+        description:
+            "Apply safe auto-fixes derived from GameMaker Feather diagnostics (e.g. remove trailing semicolons from macro declarations flagged by GM1051).",
     }
 };
 
@@ -120,6 +128,7 @@ export const defaultOptions = {
     alignAssignmentsMinGroupSize: 3,
     maxParamsPerLine: 0,
     allowSingleLineIfStatements: true,
-    preserveGlobalVarStatements: true
+    preserveGlobalVarStatements: true,
+    applyFeatherFixes: false
 };
 

--- a/src/plugin/src/parsers/gml-parser-adapter.js
+++ b/src/plugin/src/parsers/gml-parser-adapter.js
@@ -5,6 +5,7 @@
 import { util } from "prettier";
 import GMLParser from "gamemaker-language-parser";
 import { consolidateStructAssignments } from "../ast-transforms/consolidate-struct-assignments.js";
+import { applyFeatherFixes } from "../ast-transforms/apply-feather-fixes.js";
 import { getStartIndex, getEndIndex } from "../../../shared/ast-locations.js";
 
 const { addTrailingComment } = util;
@@ -20,7 +21,13 @@ function parse(text, options) {
     }
 
     if (options?.condenseStructAssignments ?? true) {
-        return consolidateStructAssignments(ast, { addTrailingComment });
+        consolidateStructAssignments(ast, { addTrailingComment });
+    }
+
+    if (options?.applyFeatherFixes) {
+        applyFeatherFixes(ast, {
+            sourceText: text
+        });
     }
 
     return ast;

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -647,7 +647,10 @@ export function print(path, options, print) {
             }
         }
         case "MacroDeclaration": {
-        // can't touch this
+            if (typeof node._featherMacroText === "string") {
+                return concat(node._featherMacroText);
+            }
+
             return options.originalText.slice(node.start.index, node.end.index + 1);
         }
         case "RegionStatement": {

--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+
+import { describe, it } from "mocha";
+
+import { getFeatherMetadata } from "../../shared/feather/metadata.js";
+import { getFeatherDiagnosticFixers } from "../src/ast-transforms/apply-feather-fixes.js";
+
+describe("Feather diagnostic fixer registry", () => {
+    it("registers a fixer entry for every diagnostic", () => {
+        const metadata = getFeatherMetadata();
+        const diagnostics = Array.isArray(metadata?.diagnostics) ? metadata.diagnostics : [];
+        const registry = getFeatherDiagnosticFixers();
+
+        assert.strictEqual(
+            registry.size,
+            diagnostics.length,
+            "Expected the fixer registry to include every Feather diagnostic."
+        );
+
+        for (const diagnostic of diagnostics) {
+            assert.ok(
+                registry.has(diagnostic.id),
+                `Missing fixer entry for Feather diagnostic ${diagnostic.id}.`
+            );
+        }
+    });
+});

--- a/src/plugin/tests/test41.input.gml
+++ b/src/plugin/tests/test41.input.gml
@@ -1,0 +1,4 @@
+#macro FOO 1;
+#macro BAR (value + 1);
+
+var answer = FOO + BAR;

--- a/src/plugin/tests/test41.options.json
+++ b/src/plugin/tests/test41.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/test41.output.gml
+++ b/src/plugin/tests/test41.output.gml
@@ -1,0 +1,5 @@
+#macro FOO 1
+
+#macro BAR (value + 1)
+
+var answer = FOO + BAR;

--- a/src/shared/feather/metadata.js
+++ b/src/shared/feather/metadata.js
@@ -1,0 +1,48 @@
+// Lightweight helpers for accessing the bundled Feather metadata artefact.
+//
+// The formatter needs to query individual diagnostics to understand
+// the intent behind specific auto-fixes. Centralising the metadata
+// access keeps downstream modules from worrying about relative path
+// resolution or cache management.
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+let cachedMetadata = null;
+
+function loadFeatherMetadata() {
+    if (cachedMetadata) {
+        return cachedMetadata;
+    }
+
+    const metadata = require("../../../resources/feather-metadata.json");
+    cachedMetadata = metadata;
+    return metadata;
+}
+
+export function getFeatherMetadata() {
+    return loadFeatherMetadata();
+}
+
+export function getFeatherDiagnostics() {
+    const metadata = loadFeatherMetadata();
+    const diagnostics = metadata?.diagnostics;
+
+    if (!Array.isArray(diagnostics)) {
+        return [];
+    }
+
+    return diagnostics;
+}
+
+export function getFeatherDiagnosticById(id) {
+    if (!id) {
+        return null;
+    }
+
+    const diagnostics = getFeatherDiagnostics();
+
+    return diagnostics.find((diagnostic) => diagnostic?.id === id) ?? null;
+}
+


### PR DESCRIPTION
## Summary
- unify the Feather fixer registry around a shared implementation map so diagnostics are handled consistently
- expose a registration helper that wires GM1051 through the same pipeline as other diagnostics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e729a61e88832f95aa0ab74788cf16