### PR TITLE
Codex: Helper Substitution

### DIFF
--- a/src/plugin/src/printer/optimizations/loop-size-hoisting.js
+++ b/src/plugin/src/printer/optimizations/loop-size-hoisting.js
@@ -176,6 +176,14 @@ function getIdentifierText(node) {
         return null;
     }
 
+    if (typeof node === "string") {
+        return node;
+    }
+
+    if (typeof node.name === "string") {
+        return node.name;
+    }
+
     if (node.type === "Identifier") {
         return node.name || null;
     }
@@ -221,5 +229,6 @@ export {
     DEFAULT_SIZE_RETRIEVAL_FUNCTION_SUFFIXES,
     buildCachedSizeVariableName,
     getArrayLengthHoistInfo,
-    getSizeRetrievalFunctionSuffixes
+    getSizeRetrievalFunctionSuffixes,
+    getIdentifierText
 };

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -32,6 +32,7 @@ import {
 import {
     buildCachedSizeVariableName,
     getArrayLengthHoistInfo,
+    getIdentifierText,
     getSizeRetrievalFunctionSuffixes
 } from "./optimizations/loop-size-hoisting.js";
 import { preprocessFunctionArgumentDefaults } from "../ast-transforms/preprocess-function-argument-defaults.js";
@@ -2146,22 +2147,6 @@ function getNodeName(node) {
     }
 
     return getIdentifierText(node);
-}
-
-function getIdentifierText(identifier) {
-    if (!identifier) {
-        return null;
-    }
-
-    if (typeof identifier === "string") {
-        return identifier;
-    }
-
-    if (typeof identifier.name === "string") {
-        return identifier.name;
-    }
-
-    return null;
 }
 
 function stripSyntheticParameterSentinels(name) {


### PR DESCRIPTION
## Summary
- reuse the loop-size-hoisting identifier helper in the printer so synthetic doc generation stops duplicating lookup logic
- extend the shared helper to cover plain string and name-bearing objects so existing printer call sites continue to resolve identifiers correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7c801f01c832fb636a22e7a73cb34