### PR TITLE
Add tests for Feather fixes

### DIFF
--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -2,8 +2,13 @@ import assert from "node:assert/strict";
 
 import { describe, it } from "mocha";
 
+import GMLParser from "gamemaker-language-parser";
+
 import { getFeatherMetadata } from "../../shared/feather/metadata.js";
-import { getFeatherDiagnosticFixers } from "../src/ast-transforms/apply-feather-fixes.js";
+import {
+    applyFeatherFixes,
+    getFeatherDiagnosticFixers
+} from "../src/ast-transforms/apply-feather-fixes.js";
 
 describe("Feather diagnostic fixer registry", () => {
     it("registers a fixer entry for every diagnostic", () => {
@@ -23,5 +28,60 @@ describe("Feather diagnostic fixer registry", () => {
                 `Missing fixer entry for Feather diagnostic ${diagnostic.id}.`
             );
         }
+    });
+});
+
+describe("applyFeatherFixes transform", () => {
+    it("removes trailing macro semicolons and records fix metadata", () => {
+        const source = [
+            "#macro SAMPLE value;",
+            "",
+            "var data = SAMPLE;"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        const [macro] = ast.body ?? [];
+        applyFeatherFixes(ast, { sourceText: source });
+
+        assert.ok(Array.isArray(ast._appliedFeatherDiagnostics));
+        assert.strictEqual(ast._appliedFeatherDiagnostics.length > 0, true);
+
+        assert.ok(macro);
+        assert.ok(Array.isArray(macro.tokens));
+        assert.strictEqual(macro.tokens.includes(";"), false);
+        assert.strictEqual(typeof macro._featherMacroText, "string");
+        assert.strictEqual(macro._featherMacroText.trimEnd(), "#macro SAMPLE value");
+
+        const macroFixes = macro._appliedFeatherDiagnostics;
+        assert.ok(Array.isArray(macroFixes));
+        assert.strictEqual(macroFixes.length, 1);
+        assert.strictEqual(macroFixes[0].target, "SAMPLE");
+    });
+
+    it("keeps inline macro semicolons when they are not trailing", () => {
+        const source = [
+            "#macro SAMPLE value; // comment",
+            "",
+            "var data = SAMPLE;"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        const [macro] = ast.body ?? [];
+        applyFeatherFixes(ast, { sourceText: source });
+
+        assert.ok(macro);
+        assert.ok(Array.isArray(macro.tokens));
+        assert.strictEqual(macro.tokens.includes(";"), true);
+        assert.strictEqual(macro._featherMacroText, undefined);
+        assert.strictEqual(macro._appliedFeatherDiagnostics, undefined);
+        assert.strictEqual(ast._appliedFeatherDiagnostics, undefined);
     });
 });

--- a/src/plugin/tests/plugin.test.js
+++ b/src/plugin/tests/plugin.test.js
@@ -214,4 +214,46 @@ describe('Prettier GameMaker plugin fixtures', () => {
       "Expected formatter to omit 'globalvar' declarations when disabled."
     );
   });
+
+  it('strips trailing macro semicolons when Feather fixes are applied', async () => {
+    const source = [
+      '#macro FOO(value) (value + 1);',
+      '#macro BAR 100;',
+      '',
+      'var result = FOO(1) + BAR;',
+    ].join('\n');
+
+    const formatted = await formatWithPlugin(source, { applyFeatherFixes: true });
+
+    const expected = [
+      '#macro FOO(value) (value + 1)',
+      '',
+      '#macro BAR 100',
+      '',
+      'var result = FOO(1) + BAR;',
+    ].join('\n');
+
+    assert.strictEqual(formatted, expected);
+  });
+
+  it('leaves inline macro semicolons untouched when they are not trailing', async () => {
+    const source = [
+      '#macro FOO(value) (value + 1); // comment',
+      '#macro BAR value + 2;',
+      '',
+      'var result = FOO(3) + BAR;',
+    ].join('\n');
+
+    const formatted = await formatWithPlugin(source, { applyFeatherFixes: true });
+
+    const expected = [
+      '#macro FOO(value) (value + 1); // comment',
+      '',
+      '#macro BAR value + 2',
+      '',
+      'var result = FOO(3) + BAR;',
+    ].join('\n');
+
+    assert.strictEqual(formatted, expected);
+  });
 });


### PR DESCRIPTION
## Summary
- add unit tests for applyFeatherFixes to verify macro fix metadata and non-trailing semicolon behavior
- extend plugin integration tests to cover Feather fixes applied during formatting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7eaa07d58832f9c2d925d0d00b80a