### PR TITLE
Handle Feather macro semicolons before comments

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -3,6 +3,9 @@ import { getFeatherDiagnostics } from "../../../shared/feather/metadata.js";
 
 const FEATHER_FIX_IMPLEMENTATIONS = buildFeatherFixImplementations();
 const FEATHER_DIAGNOSTIC_FIXERS = buildFeatherDiagnosticFixers();
+const TRAILING_MACRO_SEMICOLON_PATTERN = new RegExp(
+    ";(?=[^\\S\\r\\n]*(?:(?:\\/\\/[^\\r\\n]*|\\/\\*[\\s\\S]*?\\*\/)[^\\S\\r\\n]*)*(?:\\r?\\n|$))"
+);
 
 export function getFeatherDiagnosticFixers() {
     return new Map(FEATHER_DIAGNOSTIC_FIXERS);
@@ -172,7 +175,7 @@ function sanitizeMacroDeclaration(node, sourceText, diagnostic) {
     const originalText = sourceText.slice(startIndex, endIndex + 1);
 
     // Only strip semicolons that appear at the end of the macro definition.
-    const sanitizedText = originalText.replace(/;(?=[^\S\r\n]*(?:\r?\n|$))/, "");
+    const sanitizedText = originalText.replace(TRAILING_MACRO_SEMICOLON_PATTERN, "");
 
     if (sanitizedText === originalText) {
         return null;

--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -62,7 +62,7 @@ describe("applyFeatherFixes transform", () => {
         assert.strictEqual(macroFixes[0].target, "SAMPLE");
     });
 
-    it("keeps inline macro semicolons when they are not trailing", () => {
+    it("removes trailing macro semicolons before inline comments", () => {
         const source = [
             "#macro SAMPLE value; // comment",
             "",
@@ -79,9 +79,13 @@ describe("applyFeatherFixes transform", () => {
 
         assert.ok(macro);
         assert.ok(Array.isArray(macro.tokens));
-        assert.strictEqual(macro.tokens.includes(";"), true);
-        assert.strictEqual(macro._featherMacroText, undefined);
-        assert.strictEqual(macro._appliedFeatherDiagnostics, undefined);
-        assert.strictEqual(ast._appliedFeatherDiagnostics, undefined);
+        assert.strictEqual(macro.tokens.includes(";"), false);
+        assert.strictEqual(typeof macro._featherMacroText, "string");
+        assert.strictEqual(macro._featherMacroText.trimEnd(), "#macro SAMPLE value // comment");
+
+        const macroFixes = macro._appliedFeatherDiagnostics;
+        assert.ok(Array.isArray(macroFixes));
+        assert.strictEqual(macroFixes.length, 1);
+        assert.strictEqual(macroFixes[0].target, "SAMPLE");
     });
 });

--- a/src/plugin/tests/plugin.test.js
+++ b/src/plugin/tests/plugin.test.js
@@ -236,7 +236,7 @@ describe('Prettier GameMaker plugin fixtures', () => {
     assert.strictEqual(formatted, expected);
   });
 
-  it('leaves inline macro semicolons untouched when they are not trailing', async () => {
+  it('strips trailing macro semicolons before inline comments when Feather fixes are applied', async () => {
     const source = [
       '#macro FOO(value) (value + 1); // comment',
       '#macro BAR value + 2;',
@@ -247,7 +247,7 @@ describe('Prettier GameMaker plugin fixtures', () => {
     const formatted = await formatWithPlugin(source, { applyFeatherFixes: true });
 
     const expected = [
-      '#macro FOO(value) (value + 1); // comment',
+      '#macro FOO(value) (value + 1) // comment',
       '',
       '#macro BAR value + 2',
       '',

--- a/src/plugin/tests/test42.input.gml
+++ b/src/plugin/tests/test42.input.gml
@@ -1,0 +1,7 @@
+#macro FOO(value) (value + 1); // increments input
+#macro BAR script_call();/* block comment ; sentinel */
+#macro BAZ array_pop(stack); /* multi-line
+    comment with ; inside */
+#macro KEEP value;value // ensure this macro still retains its inline semicolon usage
+
+var total = FOO(2) + BAR + BAZ + KEEP;

--- a/src/plugin/tests/test42.options.json
+++ b/src/plugin/tests/test42.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/test42.output.gml
+++ b/src/plugin/tests/test42.output.gml
@@ -1,0 +1,10 @@
+#macro FOO(value) (value + 1) // increments input
+
+#macro BAR script_call()/* block comment ; sentinel */
+
+#macro BAZ array_pop(stack) /* multi-line
+    comment with ; inside */
+
+#macro KEEP value;value // ensure this macro still retains its inline semicolon usage
+
+var total = ((FOO(2) + BAR) + BAZ) + KEEP;


### PR DESCRIPTION
## Summary
- extend the Feather fixer to detect trailing macro semicolons even when followed by inline or block comments
- update macro Feather-fix unit tests and add a fixture covering comment scenarios with applyFeatherFixes enabled

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68e7ef950374832f8da48403e5123897