### PR TITLE
Add Feather fixer for GM2020 assignments

### DIFF
--- a/src/plugin/tests/test43.input.gml
+++ b/src/plugin/tests/test43.input.gml
@@ -1,0 +1,6 @@
+/// Step Event
+// apply value to every instance
+all.hp = base_hp;
+
+// unaffected statement
+global.buff = true;

--- a/src/plugin/tests/test43.options.json
+++ b/src/plugin/tests/test43.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/test43.output.gml
+++ b/src/plugin/tests/test43.output.gml
@@ -1,0 +1,8 @@
+/// Step Event
+// apply value to every instance
+with (all) {
+    hp = base_hp;
+}
+
+// unaffected statement
+global.buff = true;


### PR DESCRIPTION
## Summary
- implement an automatic Feather fixer for diagnostic GM2020 that converts illegal `all.` member assignments into `with (all)` blocks
- add a new applyFeatherFixes formatting fixture covering the GM2020 auto-fix scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7ffe05df8832fb58d50875c18eec2