### PR TITLE
Add Feather fix for GM2054 alpha test ref resets

### DIFF
--- a/src/plugin/tests/test44.input.gml
+++ b/src/plugin/tests/test44.input.gml
@@ -1,0 +1,9 @@
+/// Draw Event
+
+gpu_set_alphatestenable(true);
+
+gpu_set_alphatestref(128);
+
+draw_self();
+
+gpu_set_alphatestenable(false);

--- a/src/plugin/tests/test44.options.json
+++ b/src/plugin/tests/test44.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/test44.output.gml
+++ b/src/plugin/tests/test44.output.gml
@@ -1,0 +1,11 @@
+/// Draw Event
+
+gpu_set_alphatestenable(true);
+
+gpu_set_alphatestref(128);
+
+gpu_set_alphatestref(0);
+
+draw_self();
+
+gpu_set_alphatestenable(false);


### PR DESCRIPTION
## Summary
- add an automatic Feather fixer for GM2054 to append an alpha test ref reset call when safe
- create helpers to detect and build gpu_set_alphatestref calls with zero literals
- add a new applyFeatherFixes fixture covering the GM2054 scenario

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e803f8fdd8832fb03be60873dcc8bc