### PR TITLE
Add GM1063 feather fix for texture ternaries

### DIFF
--- a/src/plugin/tests/testGM1063.input.gml
+++ b/src/plugin/tests/testGM1063.input.gml
@@ -1,0 +1,7 @@
+/// Create Event
+
+tex = (texture_defined) ? sprite_get_texture(sprite_index, 0) : -1;
+
+/// Draw Event
+
+vertex_submit(vb, pr_trianglelist, tex);

--- a/src/plugin/tests/testGM1063.options.json
+++ b/src/plugin/tests/testGM1063.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1063.output.gml
+++ b/src/plugin/tests/testGM1063.output.gml
@@ -1,0 +1,7 @@
+/// Create Event
+
+tex = (texture_defined) ? sprite_get_texture(sprite_index, 0) : pointer_null;
+
+/// Draw Event
+
+vertex_submit(vb, pr_trianglelist, tex);


### PR DESCRIPTION
## Summary
- add an automatic fix for GM1063 ternary diagnostics that replaces `-1` sentinels with `pointer_null` when calling `sprite_get_texture`
- record diagnostic metadata for the ternary fix and cover it with unit and fixture tests

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a69d4a4832f8d4790894b0fa376