### PR TITLE
Add auto-fix for GM1050 local variable scope accesses

### DIFF
--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -93,6 +93,107 @@ describe("applyFeatherFixes transform", () => {
         assert.strictEqual(macroFixes[0].target, "SAMPLE");
     });
 
+    it("normalizes self-prefixed local variable references and records metadata", () => {
+        const source = [
+            "var _condition = false;",
+            "",
+            "function check(localValue)",
+            "{",
+            "    var counter = 0;",
+            "    if (self.localValue)",
+            "    {",
+            "        self.localValue = counter + 1;",
+            "    }",
+            "",
+            "    counter = self.counter + self.localValue;",
+            "    return self.localValue + counter;",
+            "}",
+            "",
+            "if (self._condition)",
+            "{",
+            "    self._condition = true;",
+            "}"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        applyFeatherFixes(ast, { sourceText: source });
+
+        const appliedDiagnostics = ast._appliedFeatherDiagnostics;
+        assert.ok(Array.isArray(appliedDiagnostics));
+
+        const automaticGm1050Fixes = appliedDiagnostics.filter(
+            (entry) => entry.id === "GM1050" && entry.automatic === true
+        );
+
+        assert.ok(
+            automaticGm1050Fixes.length >= 6,
+            "Expected multiple automatic GM1050 fixes to be recorded."
+        );
+
+        const unwrap = (expression) =>
+            expression?.type === "ParenthesizedExpression" ? expression.expression : expression;
+
+        const programIf = ast.body?.find((node) => node.type === "IfStatement");
+        assert.ok(programIf);
+
+        const programCondition = unwrap(programIf.test);
+        assert.strictEqual(programCondition?.type, "Identifier");
+        assert.strictEqual(programCondition?.name, "_condition");
+        assert.strictEqual(programCondition?._appliedFeatherDiagnostics?.[0]?.id, "GM1050");
+
+        const programAssignment = programIf.consequent?.body?.[0];
+        assert.ok(programAssignment);
+        assert.strictEqual(programAssignment.left?.type, "Identifier");
+        assert.strictEqual(programAssignment.left?.name, "_condition");
+        assert.strictEqual(
+            programAssignment.left?._appliedFeatherDiagnostics?.[0]?.target,
+            "_condition"
+        );
+
+        const functionDeclaration = ast.body?.find((node) => node.type === "FunctionDeclaration");
+        assert.ok(functionDeclaration);
+
+        const functionBody = Array.isArray(functionDeclaration.body?.body)
+            ? functionDeclaration.body.body
+            : [];
+        const functionIf = functionBody.find((node) => node.type === "IfStatement");
+        assert.ok(functionIf);
+
+        const functionCondition = unwrap(functionIf.test);
+        assert.strictEqual(functionCondition?.type, "Identifier");
+        assert.strictEqual(functionCondition?.name, "localValue");
+        assert.strictEqual(functionCondition?._appliedFeatherDiagnostics?.[0]?.id, "GM1050");
+
+        const innerAssignment = functionIf.consequent?.body?.[0];
+        assert.ok(innerAssignment);
+        assert.strictEqual(innerAssignment.left?.type, "Identifier");
+        assert.strictEqual(innerAssignment.left?.name, "localValue");
+
+        const subsequentAssignment = functionBody.find(
+            (node) => node !== innerAssignment && node.type === "AssignmentExpression"
+        );
+        assert.ok(subsequentAssignment);
+
+        const assignmentRight = subsequentAssignment.right;
+        assert.strictEqual(assignmentRight?.type, "BinaryExpression");
+        assert.strictEqual(assignmentRight.left?.type, "Identifier");
+        assert.strictEqual(assignmentRight.left?.name, "counter");
+        assert.strictEqual(assignmentRight.right?.type, "Identifier");
+        assert.strictEqual(assignmentRight.right?.name, "localValue");
+
+        const returnExpression = functionBody.find((node) => node.type === "ReturnStatement");
+        assert.ok(returnExpression);
+        const returnArgument = returnExpression.argument;
+        assert.strictEqual(returnArgument?.type, "BinaryExpression");
+        assert.strictEqual(returnArgument.left?.type, "Identifier");
+        assert.strictEqual(returnArgument.left?.name, "localValue");
+        assert.strictEqual(returnArgument.left?._appliedFeatherDiagnostics?.[0]?.target, "localValue");
+    });
+
     it("records manual Feather fix metadata for every diagnostic", () => {
         const source = "var value = 1;";
 

--- a/src/plugin/tests/testGM1050.input.gml
+++ b/src/plugin/tests/testGM1050.input.gml
@@ -1,0 +1,18 @@
+var _condition = false;
+
+function check(localValue)
+{
+    var counter = 0;
+    if (self.localValue)
+    {
+        self.localValue = counter + 1;
+    }
+
+    counter = self.counter + self.localValue;
+    return self.localValue + counter;
+}
+
+if (self._condition)
+{
+    self._condition = true;
+}

--- a/src/plugin/tests/testGM1050.options.json
+++ b/src/plugin/tests/testGM1050.options.json
@@ -1,0 +1,3 @@
+{
+    "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1050.output.gml
+++ b/src/plugin/tests/testGM1050.output.gml
@@ -1,0 +1,17 @@
+var _condition = false;
+
+/// @function check
+/// @param localValue
+function check(localValue) {
+    var counter = 0;
+    if (localValue) {
+        localValue = counter + 1;
+    }
+
+    counter = counter + localValue;
+    return localValue + counter;
+}
+
+if (_condition) {
+    _condition = true;
+}


### PR DESCRIPTION
## Summary
- add a GM1050 fixer that rewrites self-prefixed local variable member expressions using Feather metadata
- collect local variable scope information and attach automatic fix metadata for the transformed identifiers
- extend unit coverage and add a formatter fixture for GM1050 with applyFeatherFixes enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80a62b59c832f801ce603d5c980bb