### PR TITLE
Add automatic Feather GM1045 fixer

### DIFF
--- a/src/plugin/tests/testGM1045.input.gml
+++ b/src/plugin/tests/testGM1045.input.gml
@@ -1,0 +1,5 @@
+/// @returns {Id.Instance}
+function return_something()
+{
+    return "something";
+}

--- a/src/plugin/tests/testGM1045.options.json
+++ b/src/plugin/tests/testGM1045.options.json
@@ -1,0 +1,18 @@
+{
+  "applyFeatherFixes": true,
+  "metadataAssertions": {
+    "appliedFeatherDiagnostics": [
+      {
+        "id": "GM1045",
+        "automatic": true,
+        "target": "return_something"
+      }
+    ],
+    "commentDiagnostics": [
+      {
+        "id": "GM1045",
+        "target": "return_something"
+      }
+    ]
+  }
+}

--- a/src/plugin/tests/testGM1045.output.gml
+++ b/src/plugin/tests/testGM1045.output.gml
@@ -1,0 +1,6 @@
+/// @returns {string}
+
+/// @function return_something
+function return_something() {
+    return "something";
+}


### PR DESCRIPTION
## Summary
- add an automatic GM1045 fixer that normalizes @returns doc comments to match inferred return literals
- extend the plugin fixture harness to support metadata assertions for Feather diagnostics
- add a GM1045 formatting fixture exercising the new fixer and metadata validation

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a62443c832faf67baaf69df2b2d