### PR TITLE
Add automatic fix for Feather GM1042

### DIFF
--- a/src/plugin/tests/testGM1042.input.gml
+++ b/src/plugin/tests/testGM1042.input.gml
@@ -1,0 +1,7 @@
+/// @func sum(_v1, _v2);
+/// @arg {Array<Real>} _v1 The first vector
+/// @arg {Array<Real>} _v2 The second vector
+function sum(_v, _v2)
+{
+    return [_v, _v2];
+}

--- a/src/plugin/tests/testGM1042.options.json
+++ b/src/plugin/tests/testGM1042.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1042.output.gml
+++ b/src/plugin/tests/testGM1042.output.gml
@@ -1,0 +1,6 @@
+/// @function sum(_v, _v2);
+/// @param {array<real>} v The first vector
+/// @param {array<real>} v2 The second vector
+function sum(_v, _v2) {
+    return [_v, _v2];
+}


### PR DESCRIPTION
## Summary
- align Feather GM1042 diagnostics by normalizing leading jsdoc comments to match function parameter names
- register the new fixer so that GM1042 emits automatic fix metadata when possible
- cover the behaviour with a focused unit test and formatter fixture

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a5f70b4832fa1c8aee135f199c0