### PR TITLE
Add GM1035 Feather fix for numeric return strings

### DIFF
--- a/src/plugin/tests/testGM1035.input.gml
+++ b/src/plugin/tests/testGM1035.input.gml
@@ -1,0 +1,7 @@
+function get_random_number2() {
+    if (irandom(100) < 50) {
+        return 0;
+    }
+
+    return "1";
+}

--- a/src/plugin/tests/testGM1035.options.json
+++ b/src/plugin/tests/testGM1035.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1035.output.gml
+++ b/src/plugin/tests/testGM1035.output.gml
@@ -1,0 +1,8 @@
+/// @function get_random_number2
+function get_random_number2() {
+    if (irandom(100) < 50) {
+        return 0;
+    }
+
+    return 1;
+}


### PR DESCRIPTION
## Summary
- add a GM1035-specific feather fix that normalizes numeric string return literals and records metadata
- cover the new fixer with unit tests and add a dedicated formatting fixture with applyFeatherFixes enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80a5b848c832f8d66795909dec0b5