### PR TITLE
Add GM1022 Feather fix handling

### DIFF
--- a/src/plugin/tests/testGM1022.input.gml
+++ b/src/plugin/tests/testGM1022.input.gml
@@ -1,0 +1,9 @@
+/// Create Event
+
+username;
+global.score; // inline comment should be removed
+display_name
+
+player_name
+    = get_string("Name?", "guest");
+player_title = display_name;

--- a/src/plugin/tests/testGM1022.options.json
+++ b/src/plugin/tests/testGM1022.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1022.output.gml
+++ b/src/plugin/tests/testGM1022.output.gml
@@ -1,0 +1,4 @@
+/// Create Event
+
+player_name = get_string("Name?", "guest");
+player_title = display_name;


### PR DESCRIPTION
## Summary
- remove standalone identifier statements flagged by GM1022 before parsing and capture applied fix metadata
- update Feather fix pipeline to skip duplicate manual diagnostics and expose preprocessing helpers
- add GM1022 fixture coverage and unit tests validating metadata emission

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80a4f4118832f86a742b45676f349