### PR TITLE
Add automated Feather GM1020 lerp fix

### DIFF
--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -93,6 +93,86 @@ describe("applyFeatherFixes transform", () => {
         assert.strictEqual(macroFixes[0].target, "SAMPLE");
     });
 
+    it("moves missing lerp interpolation arguments into nested calls", () => {
+        const source = [
+            "var clamp_result = clamp(lerp(start_value, end_value), 0.5, 0, 100);",
+            "var composite = process_value(lerp(current_value, target_value), weight, fallback);"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        applyFeatherFixes(ast, { sourceText: source });
+
+        const lerpCalls = [];
+        const visit = (node) => {
+            if (!node) {
+                return;
+            }
+
+            if (Array.isArray(node)) {
+                for (const child of node) {
+                    visit(child);
+                }
+                return;
+            }
+
+            if (typeof node !== "object") {
+                return;
+            }
+
+            if (node.type === "CallExpression" && node.object?.name === "lerp") {
+                lerpCalls.push(node);
+            }
+
+            for (const value of Object.values(node)) {
+                if (value && typeof value === "object") {
+                    visit(value);
+                }
+            }
+        };
+
+        visit(ast);
+
+        assert.strictEqual(lerpCalls.length, 2, "Expected to locate both lerp call expressions.");
+
+        const [clampLerp, processLerp] = lerpCalls;
+
+        assert.strictEqual(Array.isArray(clampLerp.arguments), true);
+        assert.strictEqual(clampLerp.arguments.length, 3);
+        assert.strictEqual(clampLerp.arguments[2]?.type, "Literal");
+        assert.strictEqual(clampLerp.arguments[2]?.value, "0.5");
+
+        assert.strictEqual(Array.isArray(processLerp.arguments), true);
+        assert.strictEqual(processLerp.arguments.length, 3);
+        assert.strictEqual(processLerp.arguments[2]?.type, "Identifier");
+        assert.strictEqual(processLerp.arguments[2]?.name, "weight");
+
+        const clampDiagnostics = clampLerp._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            clampDiagnostics.some((entry) => entry.id === "GM1020"),
+            true,
+            "Expected clamp lerp call to record the GM1020 fix metadata."
+        );
+
+        const processDiagnostics = processLerp._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            processDiagnostics.some((entry) => entry.id === "GM1020"),
+            true,
+            "Expected process lerp call to record the GM1020 fix metadata."
+        );
+
+        assert.ok(Array.isArray(ast._appliedFeatherDiagnostics));
+        const appliedIds = new Set(ast._appliedFeatherDiagnostics.map((entry) => entry.id));
+        assert.strictEqual(
+            appliedIds.has("GM1020"),
+            true,
+            "Expected program-level metadata to include the GM1020 fix."
+        );
+    });
+
     it("records manual Feather fix metadata for every diagnostic", () => {
         const source = "var value = 1;";
 

--- a/src/plugin/tests/testGM1020.input.gml
+++ b/src/plugin/tests/testGM1020.input.gml
@@ -1,0 +1,2 @@
+var clamp_result = clamp(lerp(start_value, end_value), 0.5, 0, 100);
+var composite = process_value(lerp(current_value, target_value), weight, fallback);

--- a/src/plugin/tests/testGM1020.options.json
+++ b/src/plugin/tests/testGM1020.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1020.output.gml
+++ b/src/plugin/tests/testGM1020.output.gml
@@ -1,0 +1,2 @@
+var clamp_result = clamp(lerp(start_value, end_value, 0.5), 0, 100);
+var composite = process_value(lerp(current_value, target_value, weight), fallback);


### PR DESCRIPTION
## Summary
- add a Feather GM1020 fixer that moves adjacent arguments into nested `lerp` calls and records metadata
- extend unit coverage for the new fixer and add a formatting fixture for the GM1020 scenario

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a4ed704832f9182976c77b2738a