### PR TITLE
Add GM1019 nested call fix

### DIFF
--- a/src/plugin/tests/testGM1019.input.gml
+++ b/src/plugin/tests/testGM1019.input.gml
@@ -1,0 +1,1 @@
+var _dmg = clamp(lerp(dmg1, dmg2, 0.5, 0, 100));

--- a/src/plugin/tests/testGM1019.options.json
+++ b/src/plugin/tests/testGM1019.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1019.output.gml
+++ b/src/plugin/tests/testGM1019.output.gml
@@ -1,0 +1,1 @@
+var _dmg = clamp(lerp(dmg1, dmg2, 0.5), 0, 100);


### PR DESCRIPTION
## Summary
- add an automatic GM1019 fixer that rehomes overflow arguments from nested call expressions
- cover the GM1019 behaviour with a targeted unit test and formatter fixture using Feather metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80a4cd094832f9818bebeb45a02c8