### PR TITLE
Add GM1009 Feather fixer

### DIFF
--- a/src/plugin/tests/testGM1009.input.gml
+++ b/src/plugin/tests/testGM1009.input.gml
@@ -1,0 +1,4 @@
+var _attribs = fa_readonly + fa_archive;
+var next_room = room + 1;
+var previous_room = room - 1;
+room_goto(room + 1);

--- a/src/plugin/tests/testGM1009.options.json
+++ b/src/plugin/tests/testGM1009.options.json
@@ -1,0 +1,3 @@
+{
+    "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1009.output.gml
+++ b/src/plugin/tests/testGM1009.output.gml
@@ -1,0 +1,4 @@
+var _attribs = fa_readonly | fa_archive;
+var next_room = room_next(room);
+var previous_room = room_previous(room);
+room_goto_next();


### PR DESCRIPTION
## Summary
- add a GM1009 Feather fixer that rewrites flag additions to bitwise ORs and room arithmetic to the dedicated helper calls
- extend the Feather fix tests and add GM1009 input/output fixtures to verify automatic metadata capture

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80a456eac832fa91c3c407409752a