### PR TITLE
Add GM1006 Feather fixer

### DIFF
--- a/src/plugin/tests/testGM1006.input.gml
+++ b/src/plugin/tests/testGM1006.input.gml
@@ -1,0 +1,11 @@
+enum FRUIT
+{
+    APPLE,
+    ORANGE
+}
+
+enum FRUIT
+{
+    BLUEBERRY,
+    CHERRY
+}

--- a/src/plugin/tests/testGM1006.options.json
+++ b/src/plugin/tests/testGM1006.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1006.output.gml
+++ b/src/plugin/tests/testGM1006.output.gml
@@ -1,0 +1,6 @@
+enum FRUIT {
+    APPLE,
+    ORANGE,
+    BLUEBERRY,
+    CHERRY
+}


### PR DESCRIPTION
## Summary
- add an automatic GM1006 fixer that merges duplicate enum declarations before formatting
- cover the new fixer with unit tests and GM1006-specific plugin fixtures

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a42cdc0832f8fe8be078e51f5ec