### PR TITLE
Add GM2056 texture repeat feather fix

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -152,6 +152,19 @@ function buildFeatherFixImplementations() {
             continue;
         }
 
+        if (diagnosticId === "GM2056") {
+            registerFeatherFixer(registry, diagnosticId, () => ({ ast }) => {
+                const fixes = ensureTextureRepeatIsReset({ ast, diagnostic });
+
+                if (Array.isArray(fixes) && fixes.length > 0) {
+                    return fixes;
+                }
+
+                return registerManualFeatherFix({ ast, diagnostic });
+            });
+            continue;
+        }
+
         registerFeatherFixer(registry, diagnosticId, () => ({ ast }) =>
             registerManualFeatherFix({ ast, diagnostic })
         );
@@ -479,6 +492,104 @@ function ensureAlphaTestRefResetAfterCall(node, parent, property, diagnostic) {
     return fixDetail;
 }
 
+function ensureTextureRepeatIsReset({ ast, diagnostic }) {
+    if (!diagnostic || !ast || typeof ast !== "object") {
+        return [];
+    }
+
+    const fixes = [];
+
+    const visit = (node, parent, property) => {
+        if (!node) {
+            return;
+        }
+
+        if (Array.isArray(node)) {
+            for (let index = 0; index < node.length; index += 1) {
+                visit(node[index], node, index);
+            }
+            return;
+        }
+
+        if (typeof node !== "object") {
+            return;
+        }
+
+        if (node.type === "CallExpression") {
+            const fix = ensureTextureRepeatResetAfterCall(node, parent, property, diagnostic);
+
+            if (fix) {
+                fixes.push(fix);
+                return;
+            }
+        }
+
+        for (const [key, value] of Object.entries(node)) {
+            if (value && typeof value === "object") {
+                visit(value, node, key);
+            }
+        }
+    };
+
+    visit(ast, null, null);
+
+    return fixes;
+}
+
+function ensureTextureRepeatResetAfterCall(node, parent, property, diagnostic) {
+    if (!Array.isArray(parent) || typeof property !== "number") {
+        return null;
+    }
+
+    if (!node || node.type !== "CallExpression") {
+        return null;
+    }
+
+    if (!isIdentifierWithName(node.object, "gpu_set_texrepeat")) {
+        return null;
+    }
+
+    const args = Array.isArray(node.arguments) ? node.arguments : [];
+
+    if (args.length === 0) {
+        return null;
+    }
+
+    if (!shouldResetTextureRepeat(args[0])) {
+        return null;
+    }
+
+    const siblings = parent;
+    const nextNode = siblings[property + 1];
+
+    if (isTextureRepeatResetCall(nextNode)) {
+        return null;
+    }
+
+    const resetCall = createTextureRepeatResetCall(node);
+
+    if (!resetCall) {
+        return null;
+    }
+
+    const fixDetail = createFeatherFixDetail(diagnostic, {
+        target: node.object?.name ?? null,
+        range: {
+            start: getNodeStartIndex(node),
+            end: getNodeEndIndex(node)
+        }
+    });
+
+    if (!fixDetail) {
+        return null;
+    }
+
+    siblings.splice(property + 1, 0, resetCall);
+    attachFeatherFixMetadata(resetCall, [fixDetail]);
+
+    return fixDetail;
+}
+
 function harmonizeTexturePointerTernaries({ ast, diagnostic }) {
     if (!diagnostic || !ast || typeof ast !== "object") {
         return [];
@@ -633,6 +744,30 @@ function isLiteralZero(node) {
     return node.value === "0" || node.value === 0;
 }
 
+function isLiteralOne(node) {
+    if (!node || node.type !== "Literal") {
+        return false;
+    }
+
+    return node.value === "1" || node.value === 1;
+}
+
+function isLiteralTrue(node) {
+    if (!node || node.type !== "Literal") {
+        return false;
+    }
+
+    return node.value === "true" || node.value === true;
+}
+
+function isLiteralFalse(node) {
+    if (!node || node.type !== "Literal") {
+        return false;
+    }
+
+    return node.value === "false" || node.value === false;
+}
+
 function isAlphaTestRefResetCall(node) {
     if (!node || node.type !== "CallExpression") {
         return false;
@@ -668,6 +803,68 @@ function createAlphaTestRefResetCall(template) {
         type: "CallExpression",
         object: identifier,
         arguments: [literalZero]
+    };
+
+    if (Object.prototype.hasOwnProperty.call(template, "start")) {
+        callExpression.start = cloneLocation(template.start);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(template, "end")) {
+        callExpression.end = cloneLocation(template.end);
+    }
+
+    return callExpression;
+}
+
+function shouldResetTextureRepeat(argument) {
+    if (!argument || typeof argument !== "object") {
+        return false;
+    }
+
+    if (isLiteralFalse(argument) || isLiteralZero(argument)) {
+        return false;
+    }
+
+    return isLiteralTrue(argument) || isLiteralOne(argument);
+}
+
+function isTextureRepeatResetCall(node) {
+    if (!node || node.type !== "CallExpression") {
+        return false;
+    }
+
+    if (!isIdentifierWithName(node.object, "gpu_set_texrepeat")) {
+        return false;
+    }
+
+    const args = Array.isArray(node.arguments) ? node.arguments : [];
+
+    if (args.length === 0) {
+        return false;
+    }
+
+    const [argument] = args;
+
+    return isLiteralFalse(argument) || isLiteralZero(argument);
+}
+
+function createTextureRepeatResetCall(template) {
+    if (!template || template.type !== "CallExpression") {
+        return null;
+    }
+
+    const identifier = cloneIdentifier(template.object);
+
+    if (!identifier || identifier.name !== "gpu_set_texrepeat") {
+        return null;
+    }
+
+    const literalFalse = createLiteral("false", template.arguments?.[0]);
+
+    const callExpression = {
+        type: "CallExpression",
+        object: identifier,
+        arguments: [literalFalse]
     };
 
     if (Object.prototype.hasOwnProperty.call(template, "start")) {

--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -131,6 +131,49 @@ describe("applyFeatherFixes transform", () => {
         }
     });
 
+    it("resets texture repeat flagged by GM2056 and records metadata", () => {
+        const source = [
+            "gpu_set_texrepeat(true);",
+            "",
+            "vertex_submit(vb_world, pr_trianglelist, tex);"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        applyFeatherFixes(ast, { sourceText: source });
+
+        const [setRepeatCall, resetCall, submitCall] = ast.body ?? [];
+
+        assert.ok(setRepeatCall);
+        assert.ok(resetCall);
+        assert.ok(submitCall);
+        assert.strictEqual(resetCall.type, "CallExpression");
+        assert.strictEqual(resetCall.object?.name, "gpu_set_texrepeat");
+
+        const args = Array.isArray(resetCall.arguments) ? resetCall.arguments : [];
+        assert.strictEqual(args.length > 0, true);
+        assert.strictEqual(args[0]?.type, "Literal");
+        assert.strictEqual(args[0]?.value, "false");
+
+        const appliedDiagnostics = ast._appliedFeatherDiagnostics ?? [];
+        const gm2056 = appliedDiagnostics.find((entry) => entry.id === "GM2056");
+
+        assert.ok(gm2056, "Expected GM2056 metadata to be recorded on the AST.");
+        assert.strictEqual(gm2056.automatic, true);
+        assert.strictEqual(gm2056.target, "gpu_set_texrepeat");
+        assert.ok(gm2056.range);
+
+        const resetMetadata = resetCall._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            resetMetadata.some((entry) => entry.id === "GM2056"),
+            true,
+            "Expected GM2056 metadata to be recorded on the inserted reset call."
+        );
+    });
+
     it("harmonizes texture ternaries flagged by GM1063 and records metadata", () => {
         const source = [
             "/// Create Event",

--- a/src/plugin/tests/testGM2056.input.gml
+++ b/src/plugin/tests/testGM2056.input.gml
@@ -1,0 +1,5 @@
+/// Draw Event
+
+gpu_set_texrepeat(true);
+
+vertex_submit(vb_world, pr_trianglelist, tex);

--- a/src/plugin/tests/testGM2056.options.json
+++ b/src/plugin/tests/testGM2056.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2056.output.gml
+++ b/src/plugin/tests/testGM2056.output.gml
@@ -1,0 +1,7 @@
+/// Draw Event
+
+gpu_set_texrepeat(true);
+
+gpu_set_texrepeat(false);
+
+vertex_submit(vb_world, pr_trianglelist, tex);


### PR DESCRIPTION
## Summary
- extend the feather fix registry with an automated GM2056 implementation that inserts a gpu_set_texrepeat(false) reset
- add GM2056 fixture files and metadata assertions to cover the new behaviour

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e82208054c832f957084979149d012