### PR TITLE
Add automatic GM2049 feather fix

### DIFF
--- a/src/plugin/tests/testGM2049.input.gml
+++ b/src/plugin/tests/testGM2049.input.gml
@@ -1,0 +1,9 @@
+/// Draw Event
+
+gpu_set_ztestenable(true);
+
+gpu_set_zfunc(cmpfunc_greater);
+
+vertex_submit(vb, pr_trianglelist, tex);
+
+gpu_set_ztestenable(false);

--- a/src/plugin/tests/testGM2049.options.json
+++ b/src/plugin/tests/testGM2049.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2049.output.gml
+++ b/src/plugin/tests/testGM2049.output.gml
@@ -1,0 +1,11 @@
+/// Draw Event
+
+gpu_set_ztestenable(true);
+
+gpu_set_zfunc(cmpfunc_greater);
+
+vertex_submit(vb, pr_trianglelist, tex);
+
+gpu_set_zfunc(cmpfunc_lessequal);
+
+gpu_set_ztestenable(false);


### PR DESCRIPTION
## Summary
- add a GM2049 feather fixer that inserts a gpu_set_zfunc(cmpfunc_lessequal) reset before z-test is disabled
- cover the new fixer with dedicated unit assertions and a formatter fixture
- ensure the GM2049 fixture runs with feather fixes enabled

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e82202fa20832f8931ab52b1a8cb93