### PR TITLE
Implement GM2034 feather fix

### DIFF
--- a/src/plugin/tests/testGM2034.input.gml
+++ b/src/plugin/tests/testGM2034.input.gml
@@ -1,0 +1,10 @@
+fnames = [];
+
+var _fname = file_find_first("*.txt", fa_none);
+
+while (_fname != "")
+{
+    array_push(fnames, _fname);
+
+    _fname = file_find_next();
+}

--- a/src/plugin/tests/testGM2034.options.json
+++ b/src/plugin/tests/testGM2034.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2034.output.gml
+++ b/src/plugin/tests/testGM2034.output.gml
@@ -1,0 +1,10 @@
+fnames = [];
+
+var _fname = file_find_first("*.txt", fa_none);
+
+while (_fname != "") {
+    array_push(fnames, _fname);
+
+    _fname = file_find_next();
+}
+file_find_close();


### PR DESCRIPTION
## Summary
- add an automatic GM2034 Feather fixer that injects `file_find_close()` when `file_find_first()` is used without a matching close
- capture metadata coverage for the new fixer in unit tests and add a dedicated Prettier fixture exercising the scenario

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821fabb88832f9eecdfacf0e07941