### PR TITLE
Add automatic GM2028 feather fix

### DIFF
--- a/src/plugin/tests/testGM2028.input.gml
+++ b/src/plugin/tests/testGM2028.input.gml
@@ -1,0 +1,3 @@
+/// Draw Event
+
+draw_primitive_end();

--- a/src/plugin/tests/testGM2028.options.json
+++ b/src/plugin/tests/testGM2028.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2028.output.gml
+++ b/src/plugin/tests/testGM2028.output.gml
@@ -1,0 +1,4 @@
+/// Draw Event
+
+draw_primitive_begin(pr_linelist);
+draw_primitive_end();


### PR DESCRIPTION
## Summary
- implement an automatic GM2028 feather fix that inserts a draw_primitive_begin call before unmatched draw_primitive_end usage
- add unit coverage and golden fixtures for the GM2028 scenario with feather metadata checks

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821f586ec832f94f9ed14b4cb860e