### PR TITLE
Add GM2027 primitive closing feather fix

### DIFF
--- a/src/plugin/tests/testGM2027.input.gml
+++ b/src/plugin/tests/testGM2027.input.gml
@@ -1,0 +1,11 @@
+draw_primitive_begin(pr_linestrip);
+
+draw_vertex(0, 0);
+
+draw_vertex(10, 0);
+
+draw_primitive_begin(pr_trianglelist);
+
+draw_vertex(20, 0);
+
+draw_primitive_end();

--- a/src/plugin/tests/testGM2027.options.json
+++ b/src/plugin/tests/testGM2027.options.json
@@ -1,0 +1,3 @@
+{
+    "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2027.output.gml
+++ b/src/plugin/tests/testGM2027.output.gml
@@ -1,0 +1,13 @@
+draw_primitive_begin(pr_linestrip);
+
+draw_vertex(0, 0);
+
+draw_vertex(10, 0);
+
+draw_primitive_end();
+
+draw_primitive_begin(pr_trianglelist);
+
+draw_vertex(20, 0);
+
+draw_primitive_end();


### PR DESCRIPTION
## Summary
- add an automatic Feather fix for GM2027 that inserts missing draw_primitive_end calls before opening a new primitive
- extend the Feather fixes unit suite to assert the GM2027 metadata captured on inserted calls
- add a formatting fixture that exercises GM2027 feather fixes through the Prettier plugin

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821f4739c832f957ebef418bbba77