### PR TITLE
Add automatic GM2019 feather fix and tests

### DIFF
--- a/src/plugin/tests/testGM2019.input.gml
+++ b/src/plugin/tests/testGM2019.input.gml
@@ -1,0 +1,9 @@
+/// Draw GUI Begin Event
+
+draw_set_valign(fa_bottom);
+
+draw_text(5, room_height - 5, "In the bottom-left corner");
+
+/// Draw GUI Event
+
+draw_text(5, 5, "In the top-left corner");

--- a/src/plugin/tests/testGM2019.options.json
+++ b/src/plugin/tests/testGM2019.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2019.output.gml
+++ b/src/plugin/tests/testGM2019.output.gml
@@ -1,0 +1,11 @@
+/// Draw GUI Begin Event
+
+draw_set_valign(fa_bottom);
+
+draw_set_valign(fa_top);
+
+draw_text(5, room_height - 5, "In the bottom-left corner");
+
+/// Draw GUI Event
+
+draw_text(5, 5, "In the top-left corner");


### PR DESCRIPTION
## Summary
- add an automatic GM2019 feather fix to reinsert draw_set_valign(fa_top) resets and capture metadata
- cover the new fixer with unit tests and a formatter fixture for GM2019 cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821ee5950832fae419bdeade98f2e