### PR TITLE
Add GM2017 feather fix support

### DIFF
--- a/src/plugin/tests/testGM2017.input.gml
+++ b/src/plugin/tests/testGM2017.input.gml
@@ -1,0 +1,13 @@
+var s = sprSprite;
+
+enum size
+{
+    small,
+    medium,
+    large
+}
+
+function Show()
+{
+    show_debug_message("Here it is!");
+}

--- a/src/plugin/tests/testGM2017.options.json
+++ b/src/plugin/tests/testGM2017.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2017.output.gml
+++ b/src/plugin/tests/testGM2017.output.gml
@@ -1,0 +1,12 @@
+var _s = sprSprite;
+
+enum SIZE {
+    SMALL,
+    MEDIUM,
+    LARGE
+}
+
+/// @function show
+function show() {
+    show_debug_message("Here it is!");
+}


### PR DESCRIPTION
## Summary
- add a GM2017-specific feather fixer that normalises enum names, enum members, PascalCase functions, and single-letter locals using metadata guidance
- record GM2017 metadata coverage with a targeted unit test and fixture that exercises the new fixer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821ed1148832f802924e1e44f1371