### PR TITLE
Add GM2014 feather fix automation

### DIFF
--- a/src/plugin/tests/testGM2014.input.gml
+++ b/src/plugin/tests/testGM2014.input.gml
@@ -1,0 +1,5 @@
+vertex_format_add_position_3d();
+vertex_format_add_colour();
+vertex_format_begin();
+vertex_format_add_texcoord();
+format = vertex_format_end();

--- a/src/plugin/tests/testGM2014.options.json
+++ b/src/plugin/tests/testGM2014.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2014.output.gml
+++ b/src/plugin/tests/testGM2014.output.gml
@@ -1,0 +1,5 @@
+vertex_format_begin();
+vertex_format_add_position_3d();
+vertex_format_add_colour();
+vertex_format_add_texcoord();
+format = vertex_format_end();


### PR DESCRIPTION
## Summary
- implement an automatic GM2014 fixer that reorders `vertex_format_begin` ahead of `vertex_format_add_*` calls and tags metadata
- cover the new behaviour in the feather fixes unit suite
- add GM2014 parser/formatter fixtures that exercise the new fixer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821eaf5b8832f84d08cc2ba8abbe5