### PR TITLE
Add automatic fix for GM2013 vertex format diagnostic

### DIFF
--- a/src/plugin/tests/testGM2013.input.gml
+++ b/src/plugin/tests/testGM2013.input.gml
@@ -1,0 +1,3 @@
+/// Create Event
+
+format = vertex_format_end();

--- a/src/plugin/tests/testGM2013.options.json
+++ b/src/plugin/tests/testGM2013.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2013.output.gml
+++ b/src/plugin/tests/testGM2013.output.gml
@@ -1,0 +1,4 @@
+vertex_format_begin();
+/// Create Event
+
+format = vertex_format_end();


### PR DESCRIPTION
## Summary
- add a GM2013 automatic fixer that injects `vertex_format_begin()` before unmatched `vertex_format_end()` calls and records metadata
- exercise the new fixer with unit coverage and a dedicated formatting fixture

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821ea5344832f90b3af95826f6796