### PR TITLE
Add automated GM2010 vertex batch feather fix

### DIFF
--- a/src/plugin/tests/testGM2010.input.gml
+++ b/src/plugin/tests/testGM2010.input.gml
@@ -1,0 +1,10 @@
+vertex_format_begin();
+vertex_format_add_position_3d();
+format = vertex_format_end();
+vb = vertex_create_buffer();
+
+vertex_begin(vb, format);
+vertex_end(vb);
+vertex_position_3d(vb, x, y, 0);
+vertex_position_3d(vb, x + 100, y, 0);
+vertex_position_3d(vb, x, y + 100, 0);

--- a/src/plugin/tests/testGM2010.options.json
+++ b/src/plugin/tests/testGM2010.options.json
@@ -1,0 +1,3 @@
+{
+    "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2010.output.gml
+++ b/src/plugin/tests/testGM2010.output.gml
@@ -1,0 +1,10 @@
+vertex_format_begin();
+vertex_format_add_position_3d();
+format = vertex_format_end();
+vb = vertex_create_buffer();
+
+vertex_begin(vb, format);
+vertex_position_3d(vb, x, y, 0);
+vertex_position_3d(vb, x + 100, y, 0);
+vertex_position_3d(vb, x, y + 100, 0);
+vertex_end(vb);


### PR DESCRIPTION
## Summary
- add an automatic GM2010 feather fixer that relocates vertex data calls into the surrounding vertex_begin/vertex_end block
- exercise the new fixer with a targeted unit test that verifies metadata is recorded
- add GM2010 formatter fixtures that enable applyFeatherFixes to ensure integration coverage

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821e8366c832fbc8a8905b93251b6