### PR TITLE
Add GM1001 feather fixer and tests

### DIFF
--- a/src/plugin/tests/testGM1001.input.gml
+++ b/src/plugin/tests/testGM1001.input.gml
@@ -1,0 +1,10 @@
+var value = 1;
+
+continue;
+
+repeat (2)
+{
+    continue;
+}
+
+show_debug_message("done");

--- a/src/plugin/tests/testGM1001.options.json
+++ b/src/plugin/tests/testGM1001.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM1001.output.gml
+++ b/src/plugin/tests/testGM1001.output.gml
@@ -1,0 +1,7 @@
+var value = 1;
+
+repeat (2) {
+    continue;
+}
+
+show_debug_message("done");


### PR DESCRIPTION
## Summary
- add an automatic fixer for the GM1001 diagnostic that removes stray continue statements
- ensure fixes are applied before loop bodies and record metadata for GM1001
- cover the new fixer with unit coverage and a golden formatting fixture

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e80a3ed7c4832fa9c042d07fc28075