### PR TITLE
Add GM2022 feather fix for unused pure function returns

### DIFF
--- a/src/plugin/tests/testGM2022.input.gml
+++ b/src/plugin/tests/testGM2022.input.gml
@@ -1,0 +1,10 @@
+/// Feather GM2022 sample
+
+variable_get_hash("member");
+
+choose("a", "b", "c");
+
+choose("d", "e", "f");
+
+if (flag)
+    make_colour_rgb(255, 255, 0);

--- a/src/plugin/tests/testGM2022.options.json
+++ b/src/plugin/tests/testGM2022.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2022.output.gml
+++ b/src/plugin/tests/testGM2022.output.gml
@@ -1,0 +1,11 @@
+/// Feather GM2022 sample
+
+var __feather_variable_get_hash_result_1 = variable_get_hash("member");
+
+var __feather_choose_result_1 = choose("a", "b", "c");
+
+var __feather_choose_result_2 = choose("d", "e", "f");
+
+if (flag) {
+    var __feather_make_colour_rgb_result_1 = make_colour_rgb(255, 255, 0);
+}


### PR DESCRIPTION
## Summary
- add a GM2022 auto fixer that rewrites known pure function calls using metadata-derived allow lists
- generate deterministic temporary identifiers for rewritten calls and attach diagnostic metadata
- cover the behaviour with a dedicated unit test and golden fixture

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821ee5e30832fbf55e949f6e80176