### PR TITLE
Add GM2039 auto-fix for script asset execution

### DIFF
--- a/src/plugin/tests/testGM2039.input.gml
+++ b/src/plugin/tests/testGM2039.input.gml
@@ -1,0 +1,3 @@
+/// my_function
+
+show_debug_message("my_function calling!");

--- a/src/plugin/tests/testGM2039.options.json
+++ b/src/plugin/tests/testGM2039.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2039.output.gml
+++ b/src/plugin/tests/testGM2039.output.gml
@@ -1,0 +1,6 @@
+/// my_function
+
+/// @function my_function
+function my_function() {
+    show_debug_message("my_function calling!");
+}


### PR DESCRIPTION
## Summary
- add an automatic GM2039 fixer that wraps script asset bodies in function declarations
- infer script names from top-level comments to drive the transformation and metadata
- cover the new behaviour with a focused unit test and formatter fixtures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e821fbc118832f89d556af14e49507