### PR TITLE
Add automatic GM2031 file find feather fix

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -126,6 +126,19 @@ function buildFeatherFixImplementations() {
             continue;
         }
 
+        if (diagnosticId === "GM2031") {
+            registerFeatherFixer(registry, diagnosticId, () => ({ ast }) => {
+                const fixes = ensureFileFindSearchesAreSerialized({ ast, diagnostic });
+
+                if (Array.isArray(fixes) && fixes.length > 0) {
+                    return fixes;
+                }
+
+                return registerManualFeatherFix({ ast, diagnostic });
+            });
+            continue;
+        }
+
         if (diagnosticId === "GM1063") {
             registerFeatherFixer(registry, diagnosticId, () => ({ ast }) => {
                 const fixes = harmonizeTexturePointerTernaries({ ast, diagnostic });
@@ -477,6 +490,365 @@ function ensureAlphaTestRefResetAfterCall(node, parent, property, diagnostic) {
     attachFeatherFixMetadata(resetCall, [fixDetail]);
 
     return fixDetail;
+}
+
+function ensureFileFindSearchesAreSerialized({ ast, diagnostic }) {
+    if (!diagnostic || !ast || typeof ast !== "object") {
+        return [];
+    }
+
+    const fixes = [];
+    const state = createFileFindState();
+
+    processStatementBlock(getProgramStatements(ast), state);
+
+    return fixes;
+
+    function processStatementBlock(statements, currentState) {
+        if (!Array.isArray(statements) || statements.length === 0 || !currentState) {
+            return;
+        }
+
+        let index = 0;
+
+        while (index < statements.length) {
+            const statement = statements[index];
+
+            if (isFileFindCloseStatement(statement)) {
+                currentState.openCount = Math.max(currentState.openCount - 1, 0);
+                index += 1;
+                continue;
+            }
+
+            const callNode = getFileFindFirstCallFromStatement(statement);
+
+            if (callNode && currentState.openCount > 0) {
+                const insertion = insertFileFindCloseBefore(statements, index, callNode);
+
+                if (insertion?.fixDetail) {
+                    fixes.push(insertion.fixDetail);
+                    currentState.openCount = Math.max(currentState.openCount - 1, 0);
+                    index += insertion.insertedBefore;
+                    continue;
+                }
+            }
+
+            if (callNode) {
+                currentState.openCount += 1;
+            }
+
+            handleNestedStatements(statement, currentState);
+            index += 1;
+        }
+    }
+
+    function handleNestedStatements(statement, currentState) {
+        if (!statement || typeof statement !== "object" || !currentState) {
+            return;
+        }
+
+        switch (statement.type) {
+            case "BlockStatement": {
+                processStatementBlock(statement.body ?? [], currentState);
+                break;
+            }
+            case "IfStatement": {
+                processBranch(statement, "consequent", currentState);
+
+                if (statement.alternate) {
+                    processBranch(statement, "alternate", currentState);
+                }
+
+                break;
+            }
+            case "WhileStatement":
+            case "RepeatStatement":
+            case "DoWhileStatement":
+            case "ForStatement": {
+                processBranch(statement, "body", currentState);
+                break;
+            }
+            case "SwitchStatement": {
+                const cases = Array.isArray(statement.cases) ? statement.cases : [];
+
+                for (const caseClause of cases) {
+                    const branchState = cloneFileFindState(currentState);
+                    processStatementBlock(caseClause?.consequent ?? [], branchState);
+                }
+                break;
+            }
+            case "TryStatement": {
+                if (statement.block) {
+                    processStatementBlock(statement.block.body ?? [], currentState);
+                }
+
+                if (statement.handler) {
+                    processBranch(statement.handler, "body", currentState);
+                }
+
+                if (statement.finalizer) {
+                    processStatementBlock(statement.finalizer.body ?? [], currentState);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    function processBranch(parent, key, currentState) {
+        if (!parent || typeof parent !== "object" || !currentState) {
+            return;
+        }
+
+        const statements = getBranchStatements(parent, key);
+
+        if (!statements) {
+            return;
+        }
+
+        const branchState = cloneFileFindState(currentState);
+        processStatementBlock(statements, branchState);
+    }
+
+    function getBranchStatements(parent, key) {
+        if (!parent || typeof parent !== "object" || !key) {
+            return null;
+        }
+
+        let target = parent[key];
+
+        if (!target) {
+            return null;
+        }
+
+        if (target.type !== "BlockStatement") {
+            target = ensureBlockStatement(parent, key, target);
+        }
+
+        if (!target || target.type !== "BlockStatement") {
+            return null;
+        }
+
+        return Array.isArray(target.body) ? target.body : [];
+    }
+
+    function insertFileFindCloseBefore(statements, index, callNode) {
+        if (!Array.isArray(statements) || typeof index !== "number") {
+            return null;
+        }
+
+        const closeCall = createFileFindCloseCall(callNode);
+
+        if (!closeCall) {
+            return null;
+        }
+
+        const fixDetail = createFeatherFixDetail(diagnostic, {
+            target: callNode?.object?.name ?? null,
+            range: {
+                start: getNodeStartIndex(callNode),
+                end: getNodeEndIndex(callNode)
+            }
+        });
+
+        if (!fixDetail) {
+            return null;
+        }
+
+        attachFeatherFixMetadata(closeCall, [fixDetail]);
+        statements.splice(index, 0, closeCall);
+
+        return {
+            fixDetail,
+            insertedBefore: 1
+        };
+    }
+
+    function getFileFindFirstCallFromStatement(statement) {
+        if (!statement || typeof statement !== "object") {
+            return null;
+        }
+
+        switch (statement.type) {
+            case "CallExpression":
+                return isIdentifierWithName(statement.object, "file_find_first") ? statement : null;
+            case "AssignmentExpression":
+                return getFileFindFirstCallFromExpression(statement.right);
+            case "VariableDeclaration": {
+                const declarations = Array.isArray(statement.declarations)
+                    ? statement.declarations
+                    : [];
+
+                for (const declarator of declarations) {
+                    const call = getFileFindFirstCallFromExpression(declarator?.init);
+                    if (call) {
+                        return call;
+                    }
+                }
+                return null;
+            }
+            case "ReturnStatement":
+            case "ThrowStatement":
+                return getFileFindFirstCallFromExpression(statement.argument);
+            case "ExpressionStatement":
+                return getFileFindFirstCallFromExpression(statement.expression);
+            default:
+                return null;
+        }
+    }
+
+    function getFileFindFirstCallFromExpression(expression) {
+        if (!expression || typeof expression !== "object") {
+            return null;
+        }
+
+        if (expression.type === "CallExpression") {
+            return isIdentifierWithName(expression.object, "file_find_first") ? expression : null;
+        }
+
+        if (expression.type === "ParenthesizedExpression") {
+            return getFileFindFirstCallFromExpression(expression.expression);
+        }
+
+        if (expression.type === "AssignmentExpression") {
+            return getFileFindFirstCallFromExpression(expression.right);
+        }
+
+        if (expression.type === "SequenceExpression") {
+            const expressions = Array.isArray(expression.expressions) ? expression.expressions : [];
+
+            for (const item of expressions) {
+                const call = getFileFindFirstCallFromExpression(item);
+                if (call) {
+                    return call;
+                }
+            }
+        }
+
+        if (expression.type === "BinaryExpression" || expression.type === "LogicalExpression") {
+            const leftCall = getFileFindFirstCallFromExpression(expression.left);
+            if (leftCall) {
+                return leftCall;
+            }
+
+            return getFileFindFirstCallFromExpression(expression.right);
+        }
+
+        if (expression.type === "ConditionalExpression" || expression.type === "TernaryExpression") {
+            const consequentCall = getFileFindFirstCallFromExpression(expression.consequent);
+            if (consequentCall) {
+                return consequentCall;
+            }
+
+            return getFileFindFirstCallFromExpression(expression.alternate);
+        }
+
+        return null;
+    }
+
+    function isFileFindCloseStatement(statement) {
+        if (!statement || typeof statement !== "object") {
+            return false;
+        }
+
+        if (statement.type === "CallExpression") {
+            return isIdentifierWithName(statement.object, "file_find_close");
+        }
+
+        if (statement.type === "ExpressionStatement") {
+            return isFileFindCloseStatement(statement.expression);
+        }
+
+        if (statement.type === "ReturnStatement" || statement.type === "ThrowStatement") {
+            return isFileFindCloseStatement(statement.argument);
+        }
+
+        return false;
+    }
+
+    function getProgramStatements(node) {
+        if (!node || typeof node !== "object") {
+            return [];
+        }
+
+        if (Array.isArray(node.body)) {
+            return node.body;
+        }
+
+        if (node.body && Array.isArray(node.body.body)) {
+            return node.body.body;
+        }
+
+        return [];
+    }
+
+    function createFileFindState() {
+        return {
+            openCount: 0
+        };
+    }
+
+    function cloneFileFindState(existing) {
+        if (!existing || typeof existing !== "object") {
+            return createFileFindState();
+        }
+
+        return {
+            openCount: existing.openCount ?? 0
+        };
+    }
+
+    function createFileFindCloseCall(template) {
+        const identifier = createIdentifier("file_find_close", template?.object ?? template);
+
+        if (!identifier) {
+            return null;
+        }
+
+        const callExpression = {
+            type: "CallExpression",
+            object: identifier,
+            arguments: []
+        };
+
+        if (Object.prototype.hasOwnProperty.call(template, "start")) {
+            callExpression.start = cloneLocation(template.start);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(template, "end")) {
+            callExpression.end = cloneLocation(template.end);
+        }
+
+        return callExpression;
+    }
+
+    function ensureBlockStatement(parent, key, statement) {
+        if (!parent || typeof parent !== "object" || !key) {
+            return null;
+        }
+
+        if (!statement || typeof statement !== "object") {
+            return null;
+        }
+
+        const block = {
+            type: "BlockStatement",
+            body: [statement]
+        };
+
+        if (Object.prototype.hasOwnProperty.call(statement, "start")) {
+            block.start = cloneLocation(statement.start);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(statement, "end")) {
+            block.end = cloneLocation(statement.end);
+        }
+
+        parent[key] = block;
+
+        return block;
+    }
 }
 
 function harmonizeTexturePointerTernaries({ ast, diagnostic }) {

--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -169,4 +169,54 @@ describe("applyFeatherFixes transform", () => {
         const ternaryDiagnostics = fixedTernary._appliedFeatherDiagnostics ?? [];
         assert.strictEqual(ternaryDiagnostics.some((entry) => entry.id === "GM1063"), true);
     });
+
+    it("inserts a file_find_close call before nested file_find_first invocations flagged by GM2031", () => {
+        const source = [
+            "var _look_for_description = true;",
+            "",
+            "var _file = file_find_first(\"/game_data/*.bin\", fa_none);",
+            "",
+            "if (_look_for_description)",
+            "{",
+            "    _file2 = file_find_first(\"/game_data/*.json\", fa_none);",
+            "}",
+            "",
+            "file_find_close();"
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        applyFeatherFixes(ast, { sourceText: source });
+
+        const appliedDiagnostics = ast._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            appliedDiagnostics.some((entry) => entry.id === "GM2031"),
+            true,
+            "Expected GM2031 metadata to be recorded on the AST."
+        );
+
+        const ifStatement = ast.body?.find((node) => node?.type === "IfStatement");
+        assert.ok(ifStatement, "Expected an if statement in the parsed AST.");
+
+        const consequentBody = ifStatement?.consequent?.body ?? [];
+        assert.strictEqual(consequentBody.length, 2);
+
+        const [firstStatement, secondStatement] = consequentBody;
+        assert.strictEqual(firstStatement?.type, "CallExpression");
+        assert.strictEqual(firstStatement?.object?.name, "file_find_close");
+
+        const closeDiagnostics = firstStatement?._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            closeDiagnostics.some((entry) => entry.id === "GM2031"),
+            true,
+            "Expected GM2031 metadata on the inserted file_find_close call."
+        );
+
+        assert.strictEqual(secondStatement?.type, "AssignmentExpression");
+        assert.strictEqual(secondStatement?.right?.type, "CallExpression");
+        assert.strictEqual(secondStatement?.right?.object?.name, "file_find_first");
+    });
 });

--- a/src/plugin/tests/testGM2031.input.gml
+++ b/src/plugin/tests/testGM2031.input.gml
@@ -1,0 +1,10 @@
+var _look_for_description = true;
+
+var _file = file_find_first("/game_data/*.bin", fa_none);
+
+if (_look_for_description)
+{
+    _file2 = file_find_first("/game_data/*.json", fa_none);
+}
+
+file_find_close();

--- a/src/plugin/tests/testGM2031.options.json
+++ b/src/plugin/tests/testGM2031.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2031.output.gml
+++ b/src/plugin/tests/testGM2031.output.gml
@@ -1,0 +1,10 @@
+var _look_for_description = true;
+
+var _file = file_find_first("/game_data/*.bin", fa_none);
+
+if (_look_for_description) {
+    file_find_close();
+    _file2 = file_find_first("/game_data/*.json", fa_none);
+}
+
+file_find_close();


### PR DESCRIPTION
## Summary
- register GM2031 with the feather fix registry and implement `ensureFileFindSearchesAreSerialized`
- ensure nested `file_find_first` calls insert an automatic `file_find_close` before running
- add regression tests and new fixture exercising the GM2031 behaviour under `applyFeatherFixes`

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821f84044832fb06eb3aad0cdb8e6