### PR TITLE
Add GM2047 feather fixer for constant condition branches

### DIFF
--- a/src/plugin/tests/testGM2047.input.gml
+++ b/src/plugin/tests/testGM2047.input.gml
@@ -1,0 +1,15 @@
+if (false)
+{
+    show_debug_message("never");
+}
+
+if (true)
+{
+    show_debug_message("always");
+}
+else
+{
+    show_debug_message("nope");
+}
+
+var value = 1;

--- a/src/plugin/tests/testGM2047.options.json
+++ b/src/plugin/tests/testGM2047.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2047.output.gml
+++ b/src/plugin/tests/testGM2047.output.gml
@@ -1,0 +1,2 @@
+show_debug_message("always");
+var value = 1;


### PR DESCRIPTION
## Summary
- implement a GM2047 auto-fix that removes constant conditional branches and records metadata
- add feather fix unit coverage and a plugin fixture for the GM2047 scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e82200dc8c832fa8bbaf32721664ae