### PR TITLE
Add GM2055 Feather fix to reset texture filtering

### DIFF
--- a/src/plugin/tests/testGM2055.input.gml
+++ b/src/plugin/tests/testGM2055.input.gml
@@ -1,0 +1,4 @@
+gpu_push_state();
+gpu_set_texfilter(true);
+vertex_submit(vb_world, pr_trianglelist, tex);
+gpu_pop_state();

--- a/src/plugin/tests/testGM2055.options.json
+++ b/src/plugin/tests/testGM2055.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2055.output.gml
+++ b/src/plugin/tests/testGM2055.output.gml
@@ -1,0 +1,5 @@
+gpu_push_state();
+gpu_set_texfilter(true);
+gpu_set_texfilter(false);
+vertex_submit(vb_world, pr_trianglelist, tex);
+gpu_pop_state();


### PR DESCRIPTION
## Summary
- register an automatic fix for GM2055 that inserts a gpu_set_texfilter(false) reset after enabling texture filtering and records metadata
- add a unit test covering the GM2055 fixer behaviour
- provide GM2055 input/output fixtures with applyFeatherFixes enabled to exercise the formatter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e823dc7744832f9248b68b95c092c7