### PR TITLE
Implement Feather fix for GM2048 blend enable warnings

### DIFF
--- a/src/plugin/tests/testGM2048.input.gml
+++ b/src/plugin/tests/testGM2048.input.gml
@@ -1,0 +1,5 @@
+/// Draw Event
+
+gpu_set_blendenable(false);
+
+draw_text(0, 0, "Hello!");

--- a/src/plugin/tests/testGM2048.options.json
+++ b/src/plugin/tests/testGM2048.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2048.output.gml
+++ b/src/plugin/tests/testGM2048.output.gml
@@ -1,0 +1,7 @@
+/// Draw Event
+
+gpu_set_blendenable(false);
+
+gpu_set_blendenable(true);
+
+draw_text(0, 0, "Hello!");


### PR DESCRIPTION
## Summary
- add an automatic Feather fix for GM2048 that restores gpu_set_blendenable(true)
- cover the new fixer with unit coverage and add GM2048 formatter fixtures

## Testing
- npm test -- feather-fixes

------
https://chatgpt.com/codex/tasks/task_e_68e8246e4098832fb464ea64943e7759