### PR TITLE
Implement GM2048 Feather fix

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -181,6 +181,19 @@ function buildFeatherFixImplementations() {
             continue;
         }
 
+        if (diagnosticId === "GM2048") {
+            registerFeatherFixer(registry, diagnosticId, () => ({ ast }) => {
+                const fixes = ensureBlendingIsReenabled({ ast, diagnostic });
+
+                if (Array.isArray(fixes) && fixes.length > 0) {
+                    return fixes;
+                }
+
+                return registerManualFeatherFix({ ast, diagnostic });
+            });
+            continue;
+        }
+
         if (diagnosticId === "GM2054") {
             registerFeatherFixer(registry, diagnosticId, () => ({ ast }) => {
                 const fixes = ensureAlphaTestRefIsReset({ ast, diagnostic });
@@ -944,6 +957,104 @@ function ensureAlphaTestRefResetAfterCall(node, parent, property, diagnostic) {
     return fixDetail;
 }
 
+function ensureBlendingIsReenabled({ ast, diagnostic }) {
+    if (!diagnostic || !ast || typeof ast !== "object") {
+        return [];
+    }
+
+    const fixes = [];
+
+    const visit = (node, parent, property) => {
+        if (!node) {
+            return;
+        }
+
+        if (Array.isArray(node)) {
+            for (let index = 0; index < node.length; index += 1) {
+                visit(node[index], node, index);
+            }
+            return;
+        }
+
+        if (typeof node !== "object") {
+            return;
+        }
+
+        if (node.type === "CallExpression") {
+            const fix = ensureBlendingResetAfterCall(node, parent, property, diagnostic);
+
+            if (fix) {
+                fixes.push(fix);
+                return;
+            }
+        }
+
+        for (const [key, value] of Object.entries(node)) {
+            if (value && typeof value === "object") {
+                visit(value, node, key);
+            }
+        }
+    };
+
+    visit(ast, null, null);
+
+    return fixes;
+}
+
+function ensureBlendingResetAfterCall(node, parent, property, diagnostic) {
+    if (!Array.isArray(parent) || typeof property !== "number") {
+        return null;
+    }
+
+    if (!node || node.type !== "CallExpression") {
+        return null;
+    }
+
+    if (!isIdentifierWithName(node.object, "gpu_set_blendenable")) {
+        return null;
+    }
+
+    const args = Array.isArray(node.arguments) ? node.arguments : [];
+
+    if (args.length === 0) {
+        return null;
+    }
+
+    if (!shouldReenableBlending(args[0])) {
+        return null;
+    }
+
+    const siblings = parent;
+    const nextNode = siblings[property + 1];
+
+    if (isBlendEnableResetCall(nextNode)) {
+        return null;
+    }
+
+    const resetCall = createBlendEnableResetCall(node);
+
+    if (!resetCall) {
+        return null;
+    }
+
+    const fixDetail = createFeatherFixDetail(diagnostic, {
+        target: node.object?.name ?? null,
+        range: {
+            start: getNodeStartIndex(node),
+            end: getNodeEndIndex(node)
+        }
+    });
+
+    if (!fixDetail) {
+        return null;
+    }
+
+    siblings.splice(property + 1, 0, resetCall);
+    attachFeatherFixMetadata(resetCall, [fixDetail]);
+
+    return fixDetail;
+}
+
 function ensureTextureRepeatIsReset({ ast, diagnostic }) {
     if (!diagnostic || !ast || typeof ast !== "object") {
         return [];
@@ -1280,6 +1391,14 @@ function shouldResetTextureRepeat(argument) {
     return isLiteralTrue(argument) || isLiteralOne(argument);
 }
 
+function shouldReenableBlending(argument) {
+    if (!argument || typeof argument !== "object") {
+        return false;
+    }
+
+    return isLiteralFalse(argument) || isLiteralZero(argument);
+}
+
 function isTextureRepeatResetCall(node) {
     if (!node || node.type !== "CallExpression") {
         return false;
@@ -1317,6 +1436,56 @@ function createTextureRepeatResetCall(template) {
         type: "CallExpression",
         object: identifier,
         arguments: [literalFalse]
+    };
+
+    if (Object.prototype.hasOwnProperty.call(template, "start")) {
+        callExpression.start = cloneLocation(template.start);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(template, "end")) {
+        callExpression.end = cloneLocation(template.end);
+    }
+
+    return callExpression;
+}
+
+function isBlendEnableResetCall(node) {
+    if (!node || node.type !== "CallExpression") {
+        return false;
+    }
+
+    if (!isIdentifierWithName(node.object, "gpu_set_blendenable")) {
+        return false;
+    }
+
+    const args = Array.isArray(node.arguments) ? node.arguments : [];
+
+    if (args.length === 0) {
+        return false;
+    }
+
+    const [argument] = args;
+
+    return isLiteralTrue(argument) || isLiteralOne(argument);
+}
+
+function createBlendEnableResetCall(template) {
+    if (!template || template.type !== "CallExpression") {
+        return null;
+    }
+
+    const identifier = cloneIdentifier(template.object);
+
+    if (!identifier || identifier.name !== "gpu_set_blendenable") {
+        return null;
+    }
+
+    const literalTrue = createLiteral("true", template.arguments?.[0]);
+
+    const callExpression = {
+        type: "CallExpression",
+        object: identifier,
+        arguments: [literalTrue]
     };
 
     if (Object.prototype.hasOwnProperty.call(template, "start")) {

--- a/src/plugin/tests/testGM2048.input.gml
+++ b/src/plugin/tests/testGM2048.input.gml
@@ -1,0 +1,5 @@
+/// Draw Event
+
+gpu_set_blendenable(false);
+
+draw_self();

--- a/src/plugin/tests/testGM2048.options.json
+++ b/src/plugin/tests/testGM2048.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2048.output.gml
+++ b/src/plugin/tests/testGM2048.output.gml
@@ -1,0 +1,7 @@
+/// Draw Event
+
+gpu_set_blendenable(false);
+
+gpu_set_blendenable(true);
+
+draw_self();


### PR DESCRIPTION
## Summary
- add an automatic Feather fix for GM2048 that reinserts gpu_set_blendenable(true) when blending is disabled
- cover the new fix with a unit test and golden fixture exercising the inserted re-enable call

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e826628788832fa882cda2c62f4810