### PR TITLE
Add Feather fix for GM2044 redeclarations

### DIFF
--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -169,4 +169,69 @@ describe("applyFeatherFixes transform", () => {
         const ternaryDiagnostics = fixedTernary._appliedFeatherDiagnostics ?? [];
         assert.strictEqual(ternaryDiagnostics.some((entry) => entry.id === "GM1063"), true);
     });
+
+    it("deduplicates local variables flagged by GM2044 and records metadata", () => {
+        const source = [
+            "function demo() {",
+            "    var total = 1;",
+            "    var total = 2;",
+            "    var count;",
+            "    var count;",
+            "    if (true) {",
+            "        var temp = 0;",
+            "        var temp = 1;",
+            "    }",
+            "}",
+            ""
+        ].join("\n");
+
+        const ast = GMLParser.parse(source, {
+            getLocations: true,
+            simplifyLocations: false
+        });
+
+        applyFeatherFixes(ast, { sourceText: source });
+
+        const functionNode = ast.body?.[0];
+        assert.ok(functionNode?.type === "FunctionDeclaration");
+
+        const statements = functionNode?.body?.body ?? [];
+        assert.strictEqual(statements.length, 4);
+
+        const totalDeclaration = statements[0];
+        assert.ok(totalDeclaration?.type === "VariableDeclaration");
+        assert.strictEqual(totalDeclaration.declarations?.[0]?.id?.name, "total");
+
+        const totalAssignment = statements[1];
+        assert.ok(totalAssignment?.type === "AssignmentExpression");
+        assert.strictEqual(totalAssignment.left?.name, "total");
+
+        const countDeclarations = statements.filter(
+            (node) => node?.type === "VariableDeclaration" && node.declarations?.[0]?.id?.name === "count"
+        );
+        assert.strictEqual(countDeclarations.length, 1);
+
+        const ifStatement = statements[3];
+        assert.strictEqual(ifStatement?.type, "IfStatement");
+
+        const innerStatements = ifStatement?.consequent?.body ?? [];
+        assert.strictEqual(innerStatements.length, 2);
+
+        const innerAssignment = innerStatements[1];
+        assert.ok(innerAssignment?.type === "AssignmentExpression");
+        assert.strictEqual(innerAssignment.left?.name, "temp");
+
+        const programDiagnostics = ast._appliedFeatherDiagnostics ?? [];
+        const gm2044Entries = programDiagnostics.filter((entry) => entry.id === "GM2044");
+
+        assert.ok(gm2044Entries.length >= 2, "Expected GM2044 metadata to be recorded at the program level.");
+        assert.strictEqual(gm2044Entries.every((entry) => entry.automatic === true), true);
+
+        const assignmentDiagnostics = innerAssignment._appliedFeatherDiagnostics ?? [];
+        assert.strictEqual(
+            assignmentDiagnostics.some((entry) => entry.id === "GM2044"),
+            true,
+            "Expected inserted assignment to record GM2044 metadata."
+        );
+    });
 });

--- a/src/plugin/tests/testGM2044.input.gml
+++ b/src/plugin/tests/testGM2044.input.gml
@@ -1,0 +1,10 @@
+function demo() {
+    var total = 1;
+    var total = total + 1;
+    var count;
+    var count;
+    if (true) {
+        var temp = 0;
+        var temp = temp + 1;
+    }
+}

--- a/src/plugin/tests/testGM2044.options.json
+++ b/src/plugin/tests/testGM2044.options.json
@@ -1,0 +1,3 @@
+{
+  "applyFeatherFixes": true
+}

--- a/src/plugin/tests/testGM2044.output.gml
+++ b/src/plugin/tests/testGM2044.output.gml
@@ -1,0 +1,10 @@
+/// @function demo
+function demo() {
+    var total = 1;
+    total = total + 1;
+    var count;
+    if (true) {
+        var temp = 0;
+        temp = temp + 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add an automatic GM2044 fixer that rewrites redundant local `var` declarations into assignments while tracking scope metadata
- add unit coverage for GM2044 metadata handling and provide matching formatter fixtures with `applyFeatherFixes`

## Testing
- npm run test:plugin

------
https://chatgpt.com/codex/tasks/task_e_68e821ff6370832f9bbe6158b5b9c44d