### PR TITLE
Avoid blank lines between sequential macros

### DIFF
--- a/src/plugin/tests/plugin.test.js
+++ b/src/plugin/tests/plugin.test.js
@@ -398,7 +398,6 @@ describe("Prettier GameMaker plugin fixtures", () => {
 
         const expected = [
             "#macro FOO(value) (value + 1)",
-            "",
             "#macro BAR 100",
             "",
             "var result = FOO(1) + BAR;"
@@ -421,7 +420,6 @@ describe("Prettier GameMaker plugin fixtures", () => {
 
         const expected = [
             "#macro FOO(value) (value + 1) // comment",
-            "",
             "#macro BAR value + 2",
             "",
             "var result = FOO(3) + BAR;"

--- a/src/plugin/tests/testGM1038.output.gml
+++ b/src/plugin/tests/testGM1038.output.gml
@@ -1,5 +1,4 @@
 #macro dbg show_debug_message
-
 #macro other value
 
 var message = "Feather";

--- a/src/plugin/tests/testGM1051.output.gml
+++ b/src/plugin/tests/testGM1051.output.gml
@@ -1,16 +1,12 @@
 #macro FOO_SIMPLE 1
-
 #macro BAR_SIMPLE (value + 1)
 
 var answer_simple = FOO_SIMPLE + BAR_SIMPLE;
 
 #macro FOO(value) (value + 1) // increments input
-
 #macro BAR script_call()/* block comment ; sentinel */
-
 #macro BAZ array_pop(stack) /* multi-line
     comment with ; inside */
-
 #macro KEEP value;value // ensure this macro still retains its inline semicolon usage
 
 var total = ((FOO(2) + BAR) + BAZ) + KEEP;


### PR DESCRIPTION
## Summary
- skip automatically inserting extra hardlines between consecutive macro declarations
- update macro-focused fixtures and expectations to match the collapsed output

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ea7b8966ec832f9f7abff431f3aac9