### PR TITLE
Preserve indentation for doc comment continuation lines

### DIFF
--- a/src/plugin/src/printer/comment-utils.js
+++ b/src/plugin/src/printer/comment-utils.js
@@ -127,6 +127,15 @@ function formatLineComment(
         return applyInlinePadding(comment, trimmedOriginal);
     }
 
+    const docContinuationMatch = trimmedValue.match(/^\/\s*(\S.*)$/);
+    if (
+        docContinuationMatch &&
+    trimmedOriginal.startsWith("///") &&
+    !trimmedOriginal.includes("@")
+    ) {
+        return applyInlinePadding(comment, trimmedOriginal);
+    }
+
     const docLikeMatch = trimmedValue.match(/^\/\s*(.*)$/);
     if (docLikeMatch) {
         const remainder = docLikeMatch[1] ?? "";


### PR DESCRIPTION
## Summary
- keep multi-line doc comment continuation lines without tags verbatim so description text stays aligned

## Testing
- node --test --test-name-pattern "testFunctions" tests/plugin.test.js
- npm run test:plugin *(fails: formats testLogical)*

------
https://chatgpt.com/codex/tasks/task_e_68eab048cb0c832f8d74b6346e7ef9d2