### PR TITLE
Preserve ds_grid indexing when applying Feather fixes

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -1304,6 +1304,13 @@ function convertMultidimensionalMemberIndex(
 
     const indices = Array.isArray(node.property) ? node.property : null;
 
+    if (node.accessor && node.accessor !== "[") {
+        // Non-standard accessors such as '[#' (ds_grid) use comma-separated
+        // coordinates rather than nested lookups. Leave them unchanged so the
+        // grid access semantics remain intact.
+        return null;
+    }
+
     if (!indices || indices.length <= 1) {
         return null;
     }


### PR DESCRIPTION
## Summary
- skip the multidimensional index normalization for member expressions that use non-array accessors like ds_grid's `[#`
- document why these accessors must remain comma-based to preserve grid semantics

## Testing
- node --test --test-name-pattern="testGM1036" src/plugin/tests/plugin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68eab3ad816c832fa50ceac43e7239d2