### PR TITLE
Refactor comment helper utilities

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -3,6 +3,7 @@ import {
     getNodeStartIndex,
     cloneLocation
 } from "../../../shared/ast-locations.js";
+import { collectCommentNodes } from "../../../shared/comments.js";
 import {
     getFeatherDiagnostics,
     getFeatherMetadata
@@ -5157,49 +5158,6 @@ function sanitizeMalformedJsDocTypes({ ast, diagnostic, typeSystemInfo }) {
     }
 
     return fixes;
-}
-
-function collectCommentNodes(root) {
-    if (!root || typeof root !== "object") {
-        return [];
-    }
-
-    const comments = [];
-    const stack = [root];
-    const visited = new WeakSet();
-
-    while (stack.length > 0) {
-        const current = stack.pop();
-
-        if (!current || typeof current !== "object") {
-            continue;
-        }
-
-        if (visited.has(current)) {
-            continue;
-        }
-
-        visited.add(current);
-
-        if (Array.isArray(current)) {
-            for (const item of current) {
-                stack.push(item);
-            }
-            continue;
-        }
-
-        if (current.type === "CommentLine" || current.type === "CommentBlock") {
-            comments.push(current);
-        }
-
-        for (const value of Object.values(current)) {
-            if (value && typeof value === "object") {
-                stack.push(value);
-            }
-        }
-    }
-
-    return comments;
 }
 
 function sanitizeDocCommentType(comment, typeSystemInfo) {

--- a/src/plugin/src/ast-transforms/condense-logical-expressions.js
+++ b/src/plugin/src/ast-transforms/condense-logical-expressions.js
@@ -1,4 +1,7 @@
-import { hasComment as sharedHasComment } from "../../../shared/comments.js";
+import {
+    hasComment as sharedHasComment,
+    isDocCommentLine
+} from "../../../shared/comments.js";
 import {
     cloneLocation,
     getNodeStartIndex
@@ -301,14 +304,6 @@ function collectFunctionNodes(ast) {
 
     traverse(ast);
     return functions;
-}
-
-function isDocCommentLine(comment) {
-    return (
-        comment?.type === "CommentLine" &&
-    typeof comment.value === "string" &&
-    comment.value.startsWith("/ @")
-    );
 }
 
 function extractFunctionDescription(ast, functionNode) {

--- a/src/plugin/src/printer/comment-utils.js
+++ b/src/plugin/src/printer/comment-utils.js
@@ -1,3 +1,4 @@
+import { isCommentNode } from "../../../shared/comments.js";
 import { DEFAULT_LINE_COMMENT_OPTIONS } from "./line-comment-options.js";
 
 const BOILERPLATE_COMMENTS = [
@@ -87,14 +88,6 @@ const COMMENTED_OUT_CODE_PATTERNS = [
     /^#/,
     /^@/
 ];
-
-function isCommentNode(node) {
-    return (
-        node &&
-    typeof node === "object" &&
-    (node.type === "CommentBlock" || node.type === "CommentLine")
-    );
-}
 
 function formatLineComment(
     comment,

--- a/src/shared/comments.js
+++ b/src/shared/comments.js
@@ -1,8 +1,78 @@
+export function isCommentNode(node) {
+    return (
+        !!node &&
+    typeof node === "object" &&
+    (node.type === "CommentBlock" || node.type === "CommentLine")
+    );
+}
+
+export function isLineComment(node) {
+    return isCommentNode(node) && node.type === "CommentLine";
+}
+
+export function isBlockComment(node) {
+    return isCommentNode(node) && node.type === "CommentBlock";
+}
+
 export function hasComment(node) {
     if (!node) {
         return false;
     }
 
     const comments = node.comments ?? null;
-    return Array.isArray(comments) && comments.length > 0;
+    if (!Array.isArray(comments) || comments.length === 0) {
+        return false;
+    }
+
+    return comments.some(isCommentNode);
+}
+
+export function collectCommentNodes(root) {
+    if (!root || typeof root !== "object") {
+        return [];
+    }
+
+    const results = [];
+    const stack = [root];
+    const visited = new WeakSet();
+
+    while (stack.length > 0) {
+        const current = stack.pop();
+        if (!current || typeof current !== "object") {
+            continue;
+        }
+
+        if (visited.has(current)) {
+            continue;
+        }
+
+        visited.add(current);
+
+        if (Array.isArray(current)) {
+            for (const item of current) {
+                stack.push(item);
+            }
+            continue;
+        }
+
+        if (isCommentNode(current)) {
+            results.push(current);
+        }
+
+        for (const value of Object.values(current)) {
+            if (value && typeof value === "object") {
+                stack.push(value);
+            }
+        }
+    }
+
+    return results;
+}
+
+export function isDocCommentLine(comment) {
+    return (
+        isLineComment(comment) &&
+    typeof comment.value === "string" &&
+    comment.value.startsWith("/ @")
+    );
 }

--- a/src/shared/tests/comments.test.js
+++ b/src/shared/tests/comments.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    collectCommentNodes,
+    hasComment,
+    isBlockComment,
+    isCommentNode,
+    isDocCommentLine,
+    isLineComment
+} from "../comments.js";
+
+test("isCommentNode differentiates comment nodes", () => {
+    assert.equal(isCommentNode(null), false);
+    assert.equal(isCommentNode({ type: "Program" }), false);
+    assert.equal(isCommentNode({ type: "CommentLine", value: "example" }), true);
+    assert.equal(isCommentNode({ type: "CommentBlock" }), true);
+});
+
+test("line and block helpers classify comment nodes", () => {
+    const line = { type: "CommentLine", value: "// comment" };
+    const block = { type: "CommentBlock", value: "/* comment */" };
+
+    assert.equal(isLineComment(line), true);
+    assert.equal(isLineComment(block), false);
+    assert.equal(isBlockComment(block), true);
+    assert.equal(isBlockComment(line), false);
+});
+
+test("hasComment reports when nodes contain comments", () => {
+    const nodeWithComment = {
+        comments: [{ type: "CommentLine", value: "// comment" }]
+    };
+    const nodeWithoutComment = { comments: [] };
+    const nodeWithoutCommentsProperty = {};
+
+    assert.equal(hasComment(nodeWithComment), true);
+    assert.equal(hasComment(nodeWithoutComment), false);
+    assert.equal(hasComment(nodeWithoutCommentsProperty), false);
+});
+
+test("collectCommentNodes finds nested comment nodes", () => {
+    const lineComment = { type: "CommentLine", value: "root" };
+    const blockComment = { type: "CommentBlock", value: "nested" };
+    const functionComment = { type: "CommentLine", value: "function" };
+
+    const ast = {
+        type: "Program",
+        comments: [lineComment],
+        body: [
+            {
+                type: "FunctionDeclaration",
+                comments: [functionComment, null],
+                body: {
+                    type: "BlockStatement",
+                    comments: [blockComment],
+                    body: []
+                }
+            }
+        ]
+    };
+
+    const collected = collectCommentNodes(ast);
+    assert.equal(collected.length, 3);
+    assert.ok(collected.includes(lineComment));
+    assert.ok(collected.includes(blockComment));
+    assert.ok(collected.includes(functionComment));
+});
+
+test("isDocCommentLine recognises doc-style comments", () => {
+    assert.equal(
+        isDocCommentLine({ type: "CommentLine", value: "/ @description" }),
+        true
+    );
+    assert.equal(
+        isDocCommentLine({ type: "CommentLine", value: "// regular" }),
+        false
+    );
+    assert.equal(
+        isDocCommentLine({ type: "CommentBlock", value: "/* */" }),
+        false
+    );
+});


### PR DESCRIPTION
## Summary
- centralize comment node helpers in `src/shared/comments.js`
- update printer and AST transforms to consume the shared comment helpers
- add targeted unit tests covering the shared comment utilities

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_68eab5d31f40832f86b3186ff87520e0