### PR TITLE
Add naming convention case reference and examples

### DIFF
--- a/docs/examples/naming-convention/tricky-identifiers.md
+++ b/docs/examples/naming-convention/tricky-identifiers.md
@@ -1,0 +1,20 @@
+# Naming convention conversion examples
+
+These fixtures illustrate how tricky identifiers normalize across the supported
+case styles. Each example shows the original source alongside camel, Pascal,
+snake lower, and snake upper conversions. Prefixes and structural delimiters are
+retained so implementers can validate tokenizer behaviour.
+
+| Original identifier | camel | pascal | snake-lower | snake-upper |
+| ------------------- | ----- | ------ | ----------- | ----------- |
+| `hp2D_max` | `hp2DMax` | `Hp2DMax` | `hp2d_max` | `HP2D_MAX` |
+| `argument[0]` | `argument[0]` | `argument[0]` | `argument[0]` | `argument[0]` |
+| `argument[0].hp_max` | `argument[0].hpMax` | `argument[0].HpMax` | `argument[0].hp_max` | `argument[0].HP_MAX` |
+| `global.__hpMax` | `global.__hpMax` | `global.__HpMax` | `global.__hp_max` | `global.__HP_MAX` |
+| `HTTPRequestURL` | `httpRequestUrl` | `HttpRequestUrl` | `http_request_url` | `HTTP_REQUEST_URL` |
+| `_privateValue` | `_privateValue` | `_PrivateValue` | `_private_value` | `_PRIVATE_VALUE` |
+| `__init__` | `__init__` | `__Init__` | `__init__` | `__INIT__` |
+| `pathFinder_state_2` | `pathFinderState2` | `PathFinderState2` | `path_finder_state_2` | `PATH_FINDER_STATE_2` |
+
+> **Note:** Identifiers that already satisfy the requested case (e.g.,
+> `argument[0]` for any style) remain unchanged.

--- a/docs/naming-convention-case-reference.md
+++ b/docs/naming-convention-case-reference.md
@@ -1,0 +1,95 @@
+# Naming Convention Case Reference
+
+This guide standardizes how the Prettier GML plugin converts identifiers when
+`gmlIdentifierCase` is configured. It covers the supported case families—camel,
+Pascal, snake lower, and snake upper—and describes tokenization, numeric
+handling, underscores, and prefix retention rules that apply uniformly across
+identifier scopes.
+
+## Tokenization rules
+
+All case conversions rely on a shared tokenizer that splits an identifier into
+ordered segments. The tokenizer follows these rules:
+
+- **Letter boundaries:** Lower-to-upper or upper-to-lower transitions mark new
+  segments (`hpMax` → `hp` + `Max`). Acronyms are preserved by consuming
+  contiguous uppercase runs (`HTTPRequest` → `http` + `request`).
+- **Digits:** Numeric runs are treated as independent segments so they remain in
+  place across conversions (`hp2DMax` → `hp` + `2` + `d` + `max`).
+- **Existing separators:** `_`, `.`, and array-like brackets (`argument[0]`)
+  partition the identifier but are preserved verbatim in the final result.
+- **Prefixes:** Known prefixes such as `global.`, `other.`, and `argument` or
+  `argument[<index>]` are detected before tokenization and copied through
+  without modification.
+- **Leading/trailing underscores:** Sequences of underscores at either end of an
+  identifier are preserved exactly as written.
+
+The tokenizer is idempotent: identifiers that already satisfy the desired case
+style will round-trip without change.
+
+## Case styles
+
+### Camel case (`camel`)
+
+- **Shape:** Lower camelCase. The first alpha segment is lowercase, subsequent
+  segments are capitalized (`hpMax`, `pathFinderState`).
+- **Digits:** Numeric segments stay inline without capitalization changes
+  (`hp2DMax` → `hp2DMax`).
+- **Underscores:** Internal underscores are removed during conversion unless
+  part of a preserved prefix (`_hp_max` → `_hpMax`).
+- **Prefixes:** Prefixes such as `global.` or `argument[0]` remain untouched, and
+  camel casing is applied only to the trailing identifier
+  (`global.hp_max` → `global.hpMax`).
+
+### Pascal case (`pascal`)
+
+- **Shape:** Upper camelCase. Every segment starts with an uppercase letter
+  (`HpMax`, `PathFinderState`).
+- **Digits:** Numeric segments are unchanged and retain their position
+  (`hp2D_max` → `Hp2DMax`).
+- **Underscores:** Internal underscores are removed unless they belong to the
+  preserved prefix (`__hp_max` → `__HpMax`).
+- **Prefixes:** Prefix segments (e.g., `global.`) are preserved verbatim and the
+  Pascal conversion applies to the portion after the prefix
+  (`global.hp_max` → `global.HpMax`).
+
+### Snake lower (`snake-lower`)
+
+- **Shape:** Lower snake_case. All alphabetic characters become lowercase and
+  underscores separate segments (`hp_max`, `path_finder_state`).
+- **Digits:** Numeric segments are emitted without additional underscores unless
+  they border letters (`hp2DMax` → `hp2d_max`).
+- **Underscores:** Existing underscores collapse to single separators between
+  tokens. Leading/trailing underscores are preserved exactly.
+- **Prefixes:** Prefixes remain untouched, and snake casing is applied to the
+  suffix only (`global.hpMax` → `global.hp_max`).
+
+### Snake upper (`snake-upper`)
+
+- **Shape:** Upper snake_case. All alphabetic characters become uppercase, with
+  underscores inserted between segments (`HP_MAX`, `PATH_FINDER_STATE`).
+- **Digits:** Numeric segments are unchanged except for surrounding underscores
+  when adjacent to letters (`hp2DMax` → `HP2D_MAX`).
+- **Underscores:** Internal underscores normalize to single separators. Leading
+  or trailing underscores remain as written (`__hpMax` → `__HP_MAX`).
+- **Prefixes:** Prefixes such as `global.` or `argument[0]` are preserved; only
+  the post-prefix suffix is converted (`argument[0].hpMax` →
+  `argument[0].HP_MAX`).
+
+## Special considerations
+
+- **Invalid characters:** Case conversion never introduces characters that are
+  illegal in GML identifiers. If an input contains unsupported characters, the
+  converter must report an error instead of attempting a rewrite.
+- **Already formatted names:** Identifiers already matching the target style are
+  returned unchanged to avoid noisy diffs.
+- **Idempotence with prefixes:** Tokens following prefixes are processed
+  independently, ensuring `global.HP_MAX` converted to camel case becomes
+  `global.hpMax`, while the `global.` prefix remains untouched.
+- **Array accessors:** Index brackets are preserved (`argument[1]` stays
+  `argument[1]`), and only the property after the accessor is reformatted
+  (`argument[1].hp_max` → `argument[1].hpMax`).
+
+Use this reference during implementation and review to validate tokenizer and
+case-conversion behaviours before promoting naming transformations to new
+scopes.

--- a/docs/naming-convention-option-plan.md
+++ b/docs/naming-convention-option-plan.md
@@ -85,7 +85,7 @@ The following roadmap refines the high-level phases into discrete, testable work
    - *Actions:*
      - Document canonical examples for each supported case style (camel, Pascal, snake lower/upper) and how to handle numbers, underscores, and `global.` prefixes.
      - Capture findings in a shared spec (appendix to this plan) to guide implementation and review criteria.
-   - *Deliverables:* Reference doc + sample fixtures demonstrating expected conversions.
+   - *Deliverables:* Reference doc + sample fixtures demonstrating expected conversions. See [naming-convention-case-reference.md](./naming-convention-case-reference.md) and the example set under [examples/naming-convention](./examples/naming-convention/) (circulated for review).
    - *Validation:* Peer review of examples; optionally a lightweight script that exercises the proposed conversion helper API to confirm expectations.
 
 2. **Parser symbol table enhancement**


### PR DESCRIPTION
## Summary
- document tokenization and casing expectations for camel, Pascal, snake lower, and snake upper conversions in `docs/naming-convention-case-reference.md`
- add tricky identifier before/after examples under `docs/examples/naming-convention/` for implementation validation
- link the new reference and example set from the naming convention option plan to support review circulation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eac503acc8832fbfcd2a8bb01485cb