### PR TITLE
Add scope metadata support to parser identifiers

### DIFF
--- a/src/parser/src/gml-parser.js
+++ b/src/parser/src/gml-parser.js
@@ -17,7 +17,8 @@ export default class GMLParser {
     static optionDefaults = {
         getComments: true,
         getLocations: true,
-        simplifyLocations: true
+        simplifyLocations: true,
+        getIdentifierMetadata: false
     };
 
     static parse(
@@ -25,7 +26,8 @@ export default class GMLParser {
         options = {
             getComments: true,
             getLocations: true,
-            simplifyLocations: true
+            simplifyLocations: true,
+            getIdentifierMetadata: false
         }
     ) {
         return new this(text, options).parse();

--- a/src/parser/src/scope-tracker.js
+++ b/src/parser/src/scope-tracker.js
@@ -1,0 +1,202 @@
+import { cloneLocation } from "../../shared/ast-locations.js";
+
+class Scope {
+    constructor(id, kind) {
+        this.id = id;
+        this.kind = kind;
+        this.declarations = new Map();
+    }
+}
+
+function toArray(value) {
+    return Array.isArray(value) ? value.slice() : value != null ? [value] : [];
+}
+
+export default class ScopeTracker {
+    constructor({ enabled = false } = {}) {
+        this.enabled = Boolean(enabled);
+        this.scopeCounter = 0;
+        this.scopeStack = [];
+        this.rootScope = null;
+    }
+
+    isEnabled() {
+        return this.enabled;
+    }
+
+    enterScope(kind) {
+        if (!this.enabled) {
+            return null;
+        }
+
+        const scope = new Scope(`scope-${this.scopeCounter++}`, kind ?? "unknown");
+        this.scopeStack.push(scope);
+        if (!this.rootScope) {
+            this.rootScope = scope;
+        }
+        return scope;
+    }
+
+    exitScope() {
+        if (!this.enabled) {
+            return;
+        }
+
+        this.scopeStack.pop();
+    }
+
+    currentScope() {
+        if (!this.enabled) {
+            return null;
+        }
+
+        return this.scopeStack[this.scopeStack.length - 1] ?? null;
+    }
+
+    getRootScope() {
+        return this.rootScope;
+    }
+
+    resolveScopeOverride(scopeOverride) {
+        if (!this.enabled) {
+            return null;
+        }
+
+        if (!scopeOverride) {
+            return this.currentScope();
+        }
+
+        if (scopeOverride === "global") {
+            return this.rootScope ?? this.currentScope();
+        }
+
+        if (typeof scopeOverride === "object" && scopeOverride !== null) {
+            if (typeof scopeOverride.id === "string") {
+                return scopeOverride;
+            }
+        }
+
+        if (typeof scopeOverride === "string") {
+            const found = this.scopeStack.find((scope) => scope.id === scopeOverride);
+            if (found) {
+                return found;
+            }
+        }
+
+        return this.currentScope();
+    }
+
+    buildClassifications(role, isDeclaration) {
+        const tags = [];
+        const pushUnique = (tag) => {
+            if (tag && !tags.includes(tag)) {
+                tags.push(tag);
+            }
+        };
+
+        pushUnique("identifier");
+        pushUnique(isDeclaration ? "declaration" : "reference");
+
+        if (role && typeof role.kind === "string") {
+            pushUnique(role.kind);
+        }
+
+        const extraTags = toArray(role?.tags);
+        for (const tag of extraTags) {
+            pushUnique(tag);
+        }
+
+        return tags;
+    }
+
+    storeDeclaration(scope, name, metadata) {
+        if (!this.enabled || !scope || !name) {
+            return;
+        }
+
+        scope.declarations.set(name, metadata);
+    }
+
+    lookup(name) {
+        if (!this.enabled || !name) {
+            return null;
+        }
+
+        for (let i = this.scopeStack.length - 1; i >= 0; i--) {
+            const scope = this.scopeStack[i];
+            const metadata = scope.declarations.get(name);
+            if (metadata) {
+                return metadata;
+            }
+        }
+
+        return null;
+    }
+
+    declare(name, node, role = {}) {
+        if (!this.enabled || !name || !node) {
+            return;
+        }
+
+        const scope = this.resolveScopeOverride(role.scopeOverride);
+        const scopeId = scope?.id ?? null;
+        const start = cloneLocation(node.start);
+        const end = cloneLocation(node.end);
+        const classifications = this.buildClassifications(role, true);
+
+        const metadata = {
+            name,
+            scopeId,
+            start,
+            end,
+            classifications
+        };
+
+        this.storeDeclaration(scope, name, metadata);
+
+        node.scopeId = scopeId;
+        node.declaration = {
+            start: cloneLocation(start),
+            end: cloneLocation(end),
+            scopeId
+        };
+        node.classifications = classifications;
+    }
+
+    reference(name, node, role = {}) {
+        if (!this.enabled || !name || !node) {
+            return;
+        }
+
+        const scope = this.currentScope();
+        const scopeId = scope?.id ?? null;
+        const declaration = this.lookup(name);
+
+        let derivedTags = [];
+        if (declaration?.classifications) {
+            derivedTags = declaration.classifications.filter(
+                (tag) => tag !== "identifier" && tag !== "declaration"
+            );
+        }
+
+        const combinedRole = {
+            ...role,
+            tags: [...derivedTags, ...toArray(role?.tags)]
+        };
+
+        const classifications = this.buildClassifications(combinedRole, false);
+
+        node.scopeId = scopeId;
+        node.classifications = classifications;
+
+        if (declaration) {
+            node.declaration = {
+                start: cloneLocation(declaration.start),
+                end: cloneLocation(declaration.end),
+                scopeId: declaration.scopeId
+            };
+        } else {
+            node.declaration = null;
+        }
+    }
+}

--- a/src/parser/tests/parser.test.js
+++ b/src/parser/tests/parser.test.js
@@ -69,6 +69,69 @@ function parseFixture(source, { suppressErrors = false, options } = {}) {
   }
 }
 
+function collectIdentifiers(node) {
+  const identifiers = [];
+  const visited = new Set();
+
+  function visit(value) {
+    if (value === null || typeof value !== "object") {
+      return;
+    }
+
+    if (visited.has(value)) {
+      return;
+    }
+
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+
+    if (value.type === "Identifier") {
+      identifiers.push(value);
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      if (key === "start" || key === "end" || key === "declaration") {
+        continue;
+      }
+      visit(child);
+    }
+  }
+
+  visit(node);
+  return identifiers;
+}
+
+function groupIdentifiersByName(identifiers) {
+  const map = new Map();
+
+  for (const identifier of identifiers) {
+    if (!identifier || typeof identifier.name !== "string") {
+      continue;
+    }
+
+    if (!map.has(identifier.name)) {
+      map.set(identifier.name, []);
+    }
+
+    map.get(identifier.name).push(identifier);
+  }
+
+  return map;
+}
+
+function parseWithMetadata(source) {
+  return GMLParser.parse(source, {
+    getIdentifierMetadata: true,
+    simplifyLocations: false,
+  });
+}
+
 const fixtureNames = await loadFixtures();
 const expectedFailures = new Set([
   // Known parser gaps where the grammar currently rejects otherwise valid fixtures.
@@ -241,5 +304,382 @@ describe("GameMaker parser fixtures", () => {
       ["foo", "bar"],
       "Global declarations should retain their names.",
     );
+  });
+
+  describe("identifier metadata", () => {
+    it("annotates scopes for functions and loops", () => {
+      const source = `
+function demo(param) {
+  var counter = param;
+  for (var i = 0; i < 3; i += 1) {
+    counter += i;
+  }
+  return counter;
+}
+`;
+
+      const ast = parseWithMetadata(source);
+      assert.ok(
+        ast,
+        "Parser returned no AST when gathering identifier metadata.",
+      );
+
+      const identifiers = collectIdentifiers(ast);
+      const byName = groupIdentifiersByName(identifiers);
+
+      const counterNodes = byName.get("counter");
+      assert.ok(counterNodes, "Expected counter identifiers to be present.");
+      const counterDeclaration = counterNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(counterDeclaration, "Expected a declaration node for counter.");
+      assert.ok(
+        counterDeclaration.classifications.includes("variable"),
+        "Counter declaration should be classified as a variable.",
+      );
+      assert.ok(counterDeclaration.declaration);
+      assert.ok(counterDeclaration.scopeId);
+      assert.strictEqual(
+        counterDeclaration.scopeId,
+        counterDeclaration.declaration.scopeId,
+        "Declaration metadata should record the scope of the declaration itself.",
+      );
+
+      const counterReferences = counterNodes.filter((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.strictEqual(
+        counterReferences.length,
+        2,
+        "Expected two references to the counter variable.",
+      );
+      for (const reference of counterReferences) {
+        assert.strictEqual(
+          reference.scopeId,
+          counterDeclaration.scopeId,
+          "Counter references should share the function scope.",
+        );
+        assert.ok(
+          reference.declaration,
+          "References should record declaration metadata.",
+        );
+        assert.deepStrictEqual(
+          reference.declaration.start,
+          counterDeclaration.start,
+          "Reference metadata should point to the declaration start position.",
+        );
+        assert.deepStrictEqual(
+          reference.declaration.end,
+          counterDeclaration.end,
+          "Reference metadata should point to the declaration end position.",
+        );
+        assert.ok(
+          reference.classifications.includes("variable"),
+          "References should inherit variable classification tags.",
+        );
+      }
+
+      const iNodes = byName.get("i");
+      assert.ok(iNodes, "Expected loop identifiers to be present.");
+      const iDeclaration = iNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(
+        iDeclaration,
+        "Expected a declaration node for the loop variable.",
+      );
+      assert.ok(
+        iDeclaration.classifications.includes("variable"),
+        "Loop variable should be classified as a variable.",
+      );
+      assert.strictEqual(
+        iDeclaration.scopeId,
+        counterDeclaration.scopeId,
+        "Loop initializer should share the surrounding function scope.",
+      );
+
+      const iReferences = iNodes.filter((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.ok(
+        iReferences.length > 0,
+        "Expected references to the loop variable.",
+      );
+      for (const reference of iReferences) {
+        assert.ok(reference.declaration);
+        assert.strictEqual(
+          reference.declaration.scopeId,
+          iDeclaration.scopeId,
+          "Loop references should resolve to the loop declaration scope.",
+        );
+        assert.ok(
+          reference.classifications.includes("variable"),
+          "Loop references should inherit the variable classification.",
+        );
+      }
+    });
+
+    it("uses a distinct scope for with statements", () => {
+      const source = `
+var value = 1;
+with (target) {
+  var local = value;
+  local += local;
+}
+`;
+
+      const ast = parseWithMetadata(source);
+      assert.ok(
+        ast,
+        "Parser returned no AST when parsing with statement source.",
+      );
+
+      const identifiers = collectIdentifiers(ast);
+      const byName = groupIdentifiersByName(identifiers);
+
+      const valueNodes = byName.get("value");
+      assert.ok(valueNodes, "Expected value identifiers to be present.");
+      const valueDeclaration = valueNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(valueDeclaration, "Expected a declaration node for value.");
+
+      const localNodes = byName.get("local");
+      assert.ok(
+        localNodes,
+        "Expected local identifiers to be present inside with scope.",
+      );
+      const localDeclaration = localNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(
+        localDeclaration,
+        "Expected a declaration for the with-scoped variable.",
+      );
+      assert.notStrictEqual(
+        localDeclaration.scopeId,
+        valueDeclaration.scopeId,
+        "With-scoped declarations should not share the global scope.",
+      );
+
+      const localReferences = localNodes.filter((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.strictEqual(
+        localReferences.length,
+        2,
+        "Expected two references to the with-scoped variable.",
+      );
+      for (const reference of localReferences) {
+        assert.strictEqual(
+          reference.scopeId,
+          localDeclaration.scopeId,
+          "References inside the with block should share the with scope.",
+        );
+        assert.ok(reference.declaration);
+        assert.strictEqual(
+          reference.declaration.scopeId,
+          localDeclaration.scopeId,
+          "With references should resolve to the local declaration scope.",
+        );
+      }
+
+      const valueReferenceInWith = valueNodes.find(
+        (node) =>
+          node.classifications.includes("reference") &&
+          node.scopeId === localDeclaration.scopeId,
+      );
+      assert.ok(
+        valueReferenceInWith,
+        "Expected the with block to reference the outer scoped variable.",
+      );
+      assert.ok(valueReferenceInWith.declaration);
+      assert.strictEqual(
+        valueReferenceInWith.declaration.scopeId,
+        valueDeclaration.scopeId,
+        "Outer variable references should resolve to their original scope.",
+      );
+    });
+
+    it("marks macros as global declarations", () => {
+      const source = "#macro MAX_ENEMIES 8";
+      const ast = parseWithMetadata(source);
+
+      assert.ok(ast, "Parser returned no AST when parsing macro source.");
+
+      const identifiers = collectIdentifiers(ast);
+      assert.strictEqual(
+        identifiers.length,
+        1,
+        "Expected a single identifier representing the macro name.",
+      );
+      const [macro] = identifiers;
+
+      assert.strictEqual(macro.name, "MAX_ENEMIES");
+      assert.ok(macro.classifications.includes("macro"));
+      assert.ok(macro.classifications.includes("global"));
+      assert.ok(macro.classifications.includes("declaration"));
+      assert.ok(
+        macro.scopeId,
+        "Macro declarations should record a scope identifier.",
+      );
+      assert.ok(
+        macro.scopeId.startsWith("scope-"),
+        "Macro declarations should be assigned to the global scope.",
+      );
+    });
+
+    it("associates enum members with their declarations", () => {
+      const source = `
+enum Colors {
+  Red = 1,
+  Green
+}
+var shade = Colors.Green;
+`;
+
+      const ast = parseWithMetadata(source);
+      assert.ok(ast, "Parser returned no AST when parsing enum source.");
+
+      const identifiers = collectIdentifiers(ast);
+      const byName = groupIdentifiersByName(identifiers);
+
+      const colorsNodes = byName.get("Colors");
+      assert.ok(colorsNodes, "Expected enum identifiers to be present.");
+      const colorsDeclaration = colorsNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(colorsDeclaration, "Expected a declaration for the enum name.");
+      assert.ok(colorsDeclaration.classifications.includes("enum"));
+
+      const colorsReference = colorsNodes.find((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.ok(colorsReference, "Expected a reference to the enum name.");
+      assert.ok(colorsReference.declaration);
+      assert.deepStrictEqual(
+        colorsReference.declaration.start,
+        colorsDeclaration.start,
+        "Enum references should resolve to the enum declaration.",
+      );
+      assert.ok(colorsReference.classifications.includes("enum"));
+
+      const greenNodes = byName.get("Green");
+      assert.ok(greenNodes, "Expected enum member identifiers to be present.");
+      const greenDeclaration = greenNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(
+        greenDeclaration,
+        "Expected a declaration for the enum member.",
+      );
+      assert.ok(greenDeclaration.classifications.includes("enum-member"));
+
+      const greenReference = greenNodes.find((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.ok(greenReference, "Expected a reference to the enum member.");
+      assert.ok(greenReference.declaration);
+      assert.strictEqual(
+        greenReference.declaration.scopeId,
+        greenDeclaration.scopeId,
+        "Enum member references should resolve within the enum scope.",
+      );
+      assert.ok(greenReference.classifications.includes("enum-member"));
+      assert.ok(
+        greenReference.classifications.includes("property"),
+        "Member access should retain property classification tags.",
+      );
+    });
+
+    it("tracks struct member scopes independently from methods", () => {
+      const source = `
+function Player() constructor {
+  var health = 100;
+  function heal(amount) {
+    health += amount;
+  }
+}
+`;
+
+      const ast = parseWithMetadata(source);
+      assert.ok(
+        ast,
+        "Parser returned no AST when parsing struct constructor source.",
+      );
+
+      const identifiers = collectIdentifiers(ast);
+      const byName = groupIdentifiersByName(identifiers);
+
+      const healthNodes = byName.get("health");
+      assert.ok(
+        healthNodes,
+        "Expected struct member identifiers to be present.",
+      );
+      const healthDeclaration = healthNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(
+        healthDeclaration,
+        "Expected a declaration for the struct member.",
+      );
+
+      const amountNodes = byName.get("amount");
+      assert.ok(
+        amountNodes,
+        "Expected function parameter identifiers to be present.",
+      );
+      const amountDeclaration = amountNodes.find((node) =>
+        node.classifications.includes("declaration"),
+      );
+      assert.ok(
+        amountDeclaration,
+        "Expected a declaration for the method parameter.",
+      );
+      assert.notStrictEqual(
+        healthDeclaration.scopeId,
+        amountDeclaration.scopeId,
+        "Struct members should reside outside the method scope.",
+      );
+
+      const healthReferences = healthNodes.filter((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.ok(
+        healthReferences.length > 0,
+        "Expected references to the struct member.",
+      );
+      for (const reference of healthReferences) {
+        assert.ok(reference.declaration);
+        assert.strictEqual(
+          reference.declaration.scopeId,
+          healthDeclaration.scopeId,
+          "Struct member references should resolve to the constructor scope.",
+        );
+        assert.strictEqual(
+          reference.scopeId,
+          amountDeclaration.scopeId,
+          "Struct member references should occur within the method scope.",
+        );
+        assert.ok(reference.classifications.includes("variable"));
+      }
+
+      const amountReferences = amountNodes.filter((node) =>
+        node.classifications.includes("reference"),
+      );
+      assert.ok(
+        amountReferences.length > 0,
+        "Expected references to the parameter.",
+      );
+      for (const reference of amountReferences) {
+        assert.ok(reference.declaration);
+        assert.strictEqual(
+          reference.declaration.scopeId,
+          amountDeclaration.scopeId,
+          "Parameter references should resolve to the method scope.",
+        );
+        assert.ok(reference.classifications.includes("parameter"));
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a scope tracker to the AST builder so identifiers carry scope ids, declaration spans, and classification tags when requested
- surface the identifier metadata option through the public parser API and introduce a dedicated scope tracker helper
- add regression tests covering functions, loops, with statements, macros, enums, and struct constructors

## Testing
- npm run test:parser

------
https://chatgpt.com/codex/tasks/task_e_68eac806090c832f9ffa03982f23812a