### PR TITLE
Add project index cache scaffolding and helpers

### DIFF
--- a/docs/project-index-cache-design.md
+++ b/docs/project-index-cache-design.md
@@ -1,0 +1,43 @@
+# Project index cache design
+
+This note outlines the initial direction for the project-index cache that will
+back upcoming formatter concurrency features.
+
+## Locating the GameMaker project root
+
+The cache needs to be keyed by the GameMaker project that a formatted file
+belongs to.  Prettier exposes the current file path via `options.filepath`, so
+we treat it as the starting point for discovery.
+
+1. Normalize the path with `path.resolve` to collapse relative segments and to
+   give us a stable anchor that works across invocations.
+2. Walk up the directory tree from `dirname(options.filepath)` until either a
+   `.yyp` manifest is found or we reach the filesystem root.
+3. Treat the first directory that contains a `.yyp` file as the project root.
+   GameMaker places exactly one manifest in the root, so the nearest manifest
+   matches the user's expectation even when nested project folders exist.
+4. Bail out (return `null`) if no manifest is discovered.  This covers
+   formatting loose scripts or running Prettier on a subset of files that do not
+   belong to a full project checkout.
+
+The lookup uses `fs.promises.readdir` by default but accepts an injected file
+system facade so tests and callers with virtual file systems can reuse the
+logic.
+
+## Cache key shape and modification times
+
+Cache entries must be invalidated when any project metadata that influences the
+formatter changes.  The key therefore includes the following components:
+
+- The formatter build identifier (for now a version string passed in by the
+  caller).
+- The canonical project root path detected by the heuristic above.
+- A stable digest that captures the modification times (`mtimeMs`) for the
+  `.yyp` manifest and the formatted source file.
+
+To keep the implementation deterministic we sort manifest names and stringify
+all numeric values before mixing them into a SHA-256 digest.  Any time either
+file changes on disk, its `mtimeMs` shifts, producing a new hash and therefore a
+new cache entry.  This keeps cache coordination simple while still allowing the
+system to reuse work across parallel Prettier runs when nothing relevant has
+changed.

--- a/src/shared/project-index/index.js
+++ b/src/shared/project-index/index.js
@@ -1,0 +1,143 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
+
+export const PROJECT_MANIFEST_EXTENSION = ".yyp";
+
+const defaultFsFacade = {
+    async readDir(targetPath) {
+        return fs.readdir(targetPath);
+    },
+    async stat(targetPath) {
+        return fs.stat(targetPath);
+    }
+};
+
+export function getDefaultFsFacade() {
+    return defaultFsFacade;
+}
+
+function isManifestEntry(entry) {
+    return (
+        typeof entry === "string" &&
+    entry.toLowerCase().endsWith(PROJECT_MANIFEST_EXTENSION)
+    );
+}
+
+async function listDirectory(fsFacade, directoryPath) {
+    try {
+        return await fsFacade.readDir(directoryPath);
+    } catch (error) {
+        if (error && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+            return [];
+        }
+        throw error;
+    }
+}
+
+async function getFileMtime(fsFacade, filePath) {
+    try {
+        const stats = await fsFacade.stat(filePath);
+        return typeof stats.mtimeMs === "number" ? stats.mtimeMs : null;
+    } catch (error) {
+        if (error && error.code === "ENOENT") {
+            return null;
+        }
+        throw error;
+    }
+}
+
+export async function findProjectRoot(options, fsFacade = defaultFsFacade) {
+    const filepath = options?.filepath;
+    if (!filepath) {
+        return null;
+    }
+
+    let current = path.dirname(path.resolve(filepath));
+    const visited = new Set();
+
+    while (!visited.has(current)) {
+        visited.add(current);
+        const entries = await listDirectory(fsFacade, current);
+        const hasManifest = entries.some(isManifestEntry);
+        if (hasManifest) {
+            return current;
+        }
+
+        const parent = path.dirname(current);
+        if (parent === current) {
+            break;
+        }
+        current = parent;
+    }
+
+    return null;
+}
+
+export async function deriveCacheKey(
+    { filepath, projectRoot, formatterVersion = "dev" },
+    fsFacade = defaultFsFacade
+) {
+    const hash = createHash("sha256");
+    hash.update(String(formatterVersion));
+    hash.update("\0");
+
+    const resolvedRoot = projectRoot ? path.resolve(projectRoot) : "";
+    hash.update(resolvedRoot);
+    hash.update("\0");
+
+    if (resolvedRoot) {
+        const entries = await listDirectory(fsFacade, resolvedRoot);
+        const manifestNames = entries
+            .filter(isManifestEntry)
+            .sort((a, b) => a.localeCompare(b));
+
+        for (const manifestName of manifestNames) {
+            const manifestPath = path.join(resolvedRoot, manifestName);
+            const mtime = await getFileMtime(fsFacade, manifestPath);
+            if (mtime !== null) {
+                hash.update(manifestName);
+                hash.update("\0");
+                hash.update(String(mtime));
+                hash.update("\0");
+            }
+        }
+    }
+
+    if (filepath) {
+        const resolvedFile = path.resolve(filepath);
+        const mtime = await getFileMtime(fsFacade, resolvedFile);
+        if (mtime !== null) {
+            hash.update(
+                path.relative(
+                    resolvedRoot || path.parse(resolvedFile).root,
+                    resolvedFile
+                )
+            );
+            hash.update("\0");
+            hash.update(String(mtime));
+            hash.update("\0");
+        }
+    }
+
+    return hash.digest("hex");
+}
+
+export async function loadProjectIndexCache(/* projectRoot, fsFacade = defaultFsFacade */) {
+    // TODO: Load previously persisted project index metadata from disk.
+    return null;
+}
+
+export async function saveProjectIndexCache(/* projectRoot, cacheData, fsFacade = defaultFsFacade */) {
+    // TODO: Persist project index metadata so later formatter runs can reuse it.
+}
+
+export function createProjectIndexCoordinator() {
+    // TODO: Track in-flight formatter runs so that multiple invocations can share
+    // a single project index load.
+    return {
+        async ensureReady(/* projectRoot */) {
+            // TODO: Implement coordination once the cache lifecycle is defined.
+        }
+    };
+}

--- a/src/shared/tests/project-index.test.js
+++ b/src/shared/tests/project-index.test.js
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import {
+    deriveCacheKey,
+    findProjectRoot,
+    PROJECT_MANIFEST_EXTENSION
+} from "../project-index/index.js";
+
+function createMockFs(entries) {
+    const normalizedEntries = new Map();
+    for (const [rawPath, value] of Object.entries(entries)) {
+        normalizedEntries.set(path.resolve(rawPath), value);
+    }
+
+    return {
+        async readDir(targetPath) {
+            const normalizedPath = path.resolve(targetPath);
+            const node = normalizedEntries.get(normalizedPath);
+            if (!node) {
+                const error = new Error(`No such directory: ${normalizedPath}`);
+                error.code = "ENOENT";
+                throw error;
+            }
+            if (node.type !== "dir") {
+                const error = new Error(`Not a directory: ${normalizedPath}`);
+                error.code = "ENOTDIR";
+                throw error;
+            }
+            return node.entries.slice();
+        },
+        async stat(targetPath) {
+            const normalizedPath = path.resolve(targetPath);
+            const node = normalizedEntries.get(normalizedPath);
+            if (!node) {
+                const error = new Error(`No such file: ${normalizedPath}`);
+                error.code = "ENOENT";
+                throw error;
+            }
+            return { mtimeMs: node.mtimeMs ?? 0 };
+        }
+    };
+}
+
+test("findProjectRoot returns nearest directory containing a manifest", async () => {
+    const projectRoot = path.resolve("/workspace/project");
+    const filePath = path.join(projectRoot, "scripts", "enemy", "attack.gml");
+    const mockFs = createMockFs({
+        [projectRoot]: {
+            type: "dir",
+            entries: ["project.yyp", "scripts"]
+        },
+        [path.join(projectRoot, "project.yyp")]: {
+            type: "file",
+            mtimeMs: 10
+        },
+        [path.join(projectRoot, "scripts")]: {
+            type: "dir",
+            entries: ["enemy"]
+        },
+        [path.join(projectRoot, "scripts", "enemy")]: {
+            type: "dir",
+            entries: ["attack.gml"]
+        },
+        [filePath]: {
+            type: "file",
+            mtimeMs: 20
+        }
+    });
+
+    const result = await findProjectRoot({ filepath: filePath }, mockFs);
+    assert.equal(result, projectRoot);
+});
+
+test("findProjectRoot returns null when no manifest is discovered", async () => {
+    const workingDir = path.resolve("/workspace/random");
+    const filePath = path.join(workingDir, "scratch", "notes.gml");
+    const mockFs = createMockFs({
+        [workingDir]: { type: "dir", entries: ["scratch"] },
+        [path.join(workingDir, "scratch")]: { type: "dir", entries: ["notes.gml"] },
+        [filePath]: { type: "file", mtimeMs: 5 }
+    });
+
+    const result = await findProjectRoot({ filepath: filePath }, mockFs);
+    assert.equal(result, null);
+});
+
+test("deriveCacheKey changes when manifest mtime changes", async () => {
+    const projectRoot = path.resolve("/workspace/project");
+    const manifestName = `project${PROJECT_MANIFEST_EXTENSION}`;
+    const filePath = path.join(projectRoot, "scripts", "hero.gml");
+
+    const initialFs = createMockFs({
+        [projectRoot]: { type: "dir", entries: [manifestName, "scripts"] },
+        [path.join(projectRoot, manifestName)]: { type: "file", mtimeMs: 100 },
+        [path.join(projectRoot, "scripts")]: { type: "dir", entries: ["hero.gml"] },
+        [filePath]: { type: "file", mtimeMs: 200 }
+    });
+
+    const updatedFs = createMockFs({
+        [projectRoot]: { type: "dir", entries: [manifestName, "scripts"] },
+        [path.join(projectRoot, manifestName)]: { type: "file", mtimeMs: 150 },
+        [path.join(projectRoot, "scripts")]: { type: "dir", entries: ["hero.gml"] },
+        [filePath]: { type: "file", mtimeMs: 200 }
+    });
+
+    const firstKey = await deriveCacheKey(
+        { filepath: filePath, projectRoot, formatterVersion: "1.0.0" },
+        initialFs
+    );
+    const secondKey = await deriveCacheKey(
+        { filepath: filePath, projectRoot, formatterVersion: "1.0.0" },
+        updatedFs
+    );
+
+    assert.notEqual(firstKey, secondKey);
+});
+
+test("deriveCacheKey is stable across manifest ordering", async () => {
+    const projectRoot = path.resolve("/workspace/project");
+    const filePath = path.join(projectRoot, "scripts", "hero.gml");
+    const manifestA = `main${PROJECT_MANIFEST_EXTENSION}`;
+    const manifestB = `tools${PROJECT_MANIFEST_EXTENSION}`;
+
+    const fsVariantA = createMockFs({
+        [projectRoot]: { type: "dir", entries: [manifestA, manifestB, "scripts"] },
+        [path.join(projectRoot, manifestA)]: { type: "file", mtimeMs: 100 },
+        [path.join(projectRoot, manifestB)]: { type: "file", mtimeMs: 200 },
+        [path.join(projectRoot, "scripts")]: { type: "dir", entries: ["hero.gml"] },
+        [filePath]: { type: "file", mtimeMs: 300 }
+    });
+
+    const fsVariantB = createMockFs({
+        [projectRoot]: { type: "dir", entries: [manifestB, manifestA, "scripts"] },
+        [path.join(projectRoot, manifestA)]: { type: "file", mtimeMs: 100 },
+        [path.join(projectRoot, manifestB)]: { type: "file", mtimeMs: 200 },
+        [path.join(projectRoot, "scripts")]: { type: "dir", entries: ["hero.gml"] },
+        [filePath]: { type: "file", mtimeMs: 300 }
+    });
+
+    const firstKey = await deriveCacheKey(
+        { filepath: filePath, projectRoot, formatterVersion: "1.0.0" },
+        fsVariantA
+    );
+    const secondKey = await deriveCacheKey(
+        { filepath: filePath, projectRoot, formatterVersion: "1.0.0" },
+        fsVariantB
+    );
+
+    assert.equal(firstKey, secondKey);
+});


### PR DESCRIPTION
## Summary
- document the planned heuristics for GameMaker project root detection and cache invalidation
- add a shared project-index module skeleton with helpers for locating manifests and building cache keys
- cover the new helpers with unit tests exercising root discovery and cache key stability

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_68eacd2d6588832fa4b4c12520982a76