### PR TITLE
Add project index traversal and integration tests

### DIFF
--- a/src/shared/project-index/index.js
+++ b/src/shared/project-index/index.js
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import GMLParser from "../../parser/gml-parser.js";
+import { cloneLocation } from "../ast-locations.js";
 
 export const PROJECT_MANIFEST_EXTENSION = ".yyp";
 
@@ -10,6 +14,9 @@ const defaultFsFacade = {
     },
     async stat(targetPath) {
         return fs.stat(targetPath);
+    },
+    async readFile(targetPath, encoding = "utf8") {
+        return fs.readFile(targetPath, encoding);
     }
 };
 
@@ -139,5 +146,764 @@ export function createProjectIndexCoordinator() {
         async ensureReady(/* projectRoot */) {
             // TODO: Implement coordination once the cache lifecycle is defined.
         }
+    };
+}
+
+const GML_IDENTIFIER_FILE_PATH = fileURLToPath(
+    new URL("../../../resources/gml-identifiers.json", import.meta.url)
+);
+
+let cachedBuiltInIdentifiers = null;
+
+async function loadBuiltInIdentifiers(fsFacade = defaultFsFacade) {
+    if (cachedBuiltInIdentifiers) {
+        return cachedBuiltInIdentifiers;
+    }
+
+    try {
+        const rawContents = await fsFacade.readFile(
+            GML_IDENTIFIER_FILE_PATH,
+            "utf8"
+        );
+        const parsed = JSON.parse(rawContents);
+        const identifiers = parsed?.identifiers ?? {};
+
+        const names = new Set();
+        for (const name of Object.keys(identifiers)) {
+            names.add(name);
+        }
+
+        cachedBuiltInIdentifiers = {
+            metadata: identifiers,
+            names
+        };
+    } catch {
+        cachedBuiltInIdentifiers = {
+            metadata: {},
+            names: new Set()
+        };
+    }
+
+    return cachedBuiltInIdentifiers;
+}
+
+function toPosixPath(inputPath) {
+    if (!inputPath) {
+        return "";
+    }
+
+    return inputPath.replace(/\\+/g, "/");
+}
+
+function toProjectRelativePath(projectRoot, absolutePath) {
+    const relative = path.relative(projectRoot, absolutePath);
+    return toPosixPath(relative);
+}
+
+function normaliseResourcePath(rawPath, { projectRoot } = {}) {
+    if (typeof rawPath !== "string" || rawPath.length === 0) {
+        return null;
+    }
+
+    const normalised = toPosixPath(rawPath).replace(/^\.\//, "");
+    if (!projectRoot) {
+        return normalised;
+    }
+
+    const absoluteCandidate = path.isAbsolute(normalised)
+        ? normalised
+        : path.join(projectRoot, normalised);
+    return toProjectRelativePath(projectRoot, absoluteCandidate);
+}
+
+async function scanProjectTree(projectRoot, fsFacade) {
+    const yyFiles = [];
+    const gmlFiles = [];
+    const pending = ["."];
+
+    while (pending.length > 0) {
+        const relativeDir = pending.pop();
+        const absoluteDir = path.join(projectRoot, relativeDir);
+        const entries = await listDirectory(fsFacade, absoluteDir);
+
+        for (const entry of entries) {
+            const relativePath = path.join(relativeDir, entry);
+            const absolutePath = path.join(projectRoot, relativePath);
+            let stats;
+            try {
+                stats = await fsFacade.stat(absolutePath);
+            } catch (error) {
+                if (error && error.code === "ENOENT") {
+                    continue;
+                }
+                throw error;
+            }
+
+            if (typeof stats?.isDirectory === "function" && stats.isDirectory()) {
+                pending.push(relativePath);
+                continue;
+            }
+
+            const relativePosix = toPosixPath(relativePath);
+            if (relativePosix.toLowerCase().endsWith(".yy")) {
+                yyFiles.push({
+                    absolutePath,
+                    relativePath: relativePosix
+                });
+            } else if (relativePosix.toLowerCase().endsWith(".gml")) {
+                gmlFiles.push({
+                    absolutePath,
+                    relativePath: relativePosix
+                });
+            }
+        }
+    }
+
+    yyFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+    gmlFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+    return { yyFiles, gmlFiles };
+}
+
+function ensureResourceRecord(resourcesMap, resourcePath, resourceData = {}) {
+    let record = resourcesMap.get(resourcePath);
+    if (!record) {
+        record = {
+            path: resourcePath,
+            name: resourceData.name ?? path.posix.basename(resourcePath, ".yy"),
+            resourceType: resourceData.resourceType ?? "unknown",
+            scopes: [],
+            gmlFiles: [],
+            assetReferences: []
+        };
+        resourcesMap.set(resourcePath, record);
+    } else {
+        if (resourceData.name && record.name !== resourceData.name) {
+            record.name = resourceData.name;
+        }
+        if (
+            resourceData.resourceType &&
+      record.resourceType !== resourceData.resourceType
+        ) {
+            record.resourceType = resourceData.resourceType;
+        }
+    }
+
+    return record;
+}
+
+function pushUnique(array, value) {
+    if (!array.includes(value)) {
+        array.push(value);
+    }
+}
+
+function deriveScopeId(kind, parts) {
+    const suffix = Array.isArray(parts) ? parts.join("::") : String(parts ?? "");
+    return `scope:${kind}:${suffix}`;
+}
+
+function createScriptScopeDescriptor(resourceRecord, gmlRelativePath) {
+    const scopeId = deriveScopeId("script", [resourceRecord.name]);
+    return {
+        id: scopeId,
+        kind: "script",
+        name: resourceRecord.name,
+        displayName: `script.${resourceRecord.name}`,
+        resourcePath: resourceRecord.path,
+        gmlFile: gmlRelativePath
+    };
+}
+
+function deriveEventDisplayName(event) {
+    if (event && typeof event.name === "string" && event.name.trim()) {
+        return event.name;
+    }
+
+    const eventType =
+    typeof event?.eventType === "number"
+        ? event.eventType
+        : typeof event?.eventtype === "number"
+            ? event.eventtype
+            : null;
+    const eventNum =
+    typeof event?.eventNum === "number"
+        ? event.eventNum
+        : typeof event?.enumb === "number"
+            ? event.enumb
+            : null;
+
+    if (eventType == null && eventNum == null) {
+        return "event";
+    }
+
+    if (eventNum == null) {
+        return String(eventType);
+    }
+
+    return `${eventType}_${eventNum}`;
+}
+
+function createObjectEventScopeDescriptor(
+    resourceRecord,
+    event,
+    gmlRelativePath
+) {
+    const displayName = deriveEventDisplayName(event);
+    const scopeId = deriveScopeId("object", [resourceRecord.name, displayName]);
+    return {
+        id: scopeId,
+        kind: "objectEvent",
+        name: `${resourceRecord.name}.${displayName}`,
+        displayName: `object.${resourceRecord.name}.${displayName}`,
+        resourcePath: resourceRecord.path,
+        gmlFile: gmlRelativePath,
+        event: {
+            name: displayName,
+            eventType:
+        typeof event?.eventType === "number"
+            ? event.eventType
+            : typeof event?.eventtype === "number"
+                ? event.eventtype
+                : null,
+            eventNum:
+        typeof event?.eventNum === "number"
+            ? event.eventNum
+            : typeof event?.enumb === "number"
+                ? event.enumb
+                : null
+        }
+    };
+}
+
+function createFileScopeDescriptor(relativePath) {
+    const fileBaseName = path.posix.basename(
+        relativePath,
+        path.extname(relativePath)
+    );
+    const scopeId = deriveScopeId("file", [relativePath]);
+    return {
+        id: scopeId,
+        kind: "file",
+        name: fileBaseName,
+        displayName: `file.${relativePath}`,
+        resourcePath: null,
+        gmlFile: relativePath
+    };
+}
+
+function extractEventGmlPath(event, resourceRecord, resourceRelativeDir) {
+    if (!event) {
+        return null;
+    }
+
+    const candidatePaths = [];
+    if (typeof event.eventContents === "string") {
+        candidatePaths.push(event.eventContents);
+    }
+    if (typeof event.event === "string") {
+        candidatePaths.push(event.event);
+    }
+    if (event.event && typeof event.event.path === "string") {
+        candidatePaths.push(event.event.path);
+    }
+    if (event.eventId && typeof event.eventId.path === "string") {
+        candidatePaths.push(event.eventId.path);
+    }
+    if (event.code && typeof event.code === "string") {
+        candidatePaths.push(event.code);
+    }
+
+    for (const candidate of candidatePaths) {
+        const normalised = normaliseResourcePath(candidate);
+        if (normalised) {
+            return normalised;
+        }
+    }
+
+    if (!resourceRecord?.name) {
+        return null;
+    }
+
+    const displayName = deriveEventDisplayName(event);
+    const guessed = path.posix.join(
+        resourceRelativeDir,
+        `${resourceRecord.name}_${displayName}.gml`
+    );
+    return guessed;
+}
+
+function collectAssetReferences(json, callback, pathStack = []) {
+    if (Array.isArray(json)) {
+        json.forEach((entry, index) => {
+            collectAssetReferences(entry, callback, pathStack.concat(String(index)));
+        });
+        return;
+    }
+
+    if (!json || typeof json !== "object") {
+        return;
+    }
+
+    if (typeof json.path === "string") {
+        const propertyPath = pathStack.join(".");
+        callback({
+            propertyPath,
+            targetPath: json.path,
+            targetName: typeof json.name === "string" ? json.name : null
+        });
+    }
+
+    for (const key of Object.keys(json)) {
+        collectAssetReferences(json[key], callback, pathStack.concat(key));
+    }
+}
+
+async function analyseResourceFiles({ projectRoot, yyFiles, fsFacade }) {
+    const resourcesMap = new Map();
+    const gmlScopeMap = new Map();
+    const assetReferences = [];
+    const scriptNameToScopeId = new Map();
+    const scriptNameToResourcePath = new Map();
+
+    for (const file of yyFiles) {
+        let rawContents;
+        try {
+            rawContents = await fsFacade.readFile(file.absolutePath, "utf8");
+        } catch (error) {
+            if (error && error.code === "ENOENT") {
+                continue;
+            }
+            throw error;
+        }
+
+        let parsed;
+        try {
+            parsed = JSON.parse(rawContents);
+        } catch {
+            // Skip invalid JSON entries but continue scanning.
+            continue;
+        }
+
+        const resourceRecord = ensureResourceRecord(
+            resourcesMap,
+            file.relativePath,
+            {
+                name: parsed?.name,
+                resourceType: parsed?.resourceType
+            }
+        );
+
+        const resourceDir = path.posix.dirname(file.relativePath);
+
+        if (parsed?.resourceType === "GMScript") {
+            const gmlRelativePath = path.posix.join(
+                resourceDir,
+                `${resourceRecord.name}.gml`
+            );
+            pushUnique(resourceRecord.gmlFiles, gmlRelativePath);
+
+            const descriptor = createScriptScopeDescriptor(
+                resourceRecord,
+                gmlRelativePath
+            );
+            gmlScopeMap.set(gmlRelativePath, descriptor);
+            pushUnique(resourceRecord.scopes, descriptor.id);
+
+            scriptNameToScopeId.set(resourceRecord.name, descriptor.id);
+            scriptNameToResourcePath.set(resourceRecord.name, resourceRecord.path);
+        }
+
+        if (Array.isArray(parsed?.eventList) && parsed.eventList.length > 0) {
+            for (const event of parsed.eventList) {
+                const eventGmlPath = extractEventGmlPath(
+                    event,
+                    resourceRecord,
+                    resourceDir
+                );
+                if (!eventGmlPath) {
+                    continue;
+                }
+
+                pushUnique(resourceRecord.gmlFiles, eventGmlPath);
+                const descriptor = createObjectEventScopeDescriptor(
+                    resourceRecord,
+                    event,
+                    eventGmlPath
+                );
+
+                gmlScopeMap.set(eventGmlPath, descriptor);
+                pushUnique(resourceRecord.scopes, descriptor.id);
+            }
+        }
+
+        collectAssetReferences(
+            parsed,
+            ({ propertyPath, targetPath, targetName }) => {
+                const normalisedTarget = normaliseResourcePath(targetPath, {
+                    projectRoot
+                });
+                if (!normalisedTarget) {
+                    return;
+                }
+
+                const referenceRecord = {
+                    fromResourcePath: file.relativePath,
+                    fromResourceName: resourceRecord.name,
+                    propertyPath,
+                    targetPath: normalisedTarget,
+                    targetName: targetName ?? null,
+                    targetResourceType: null
+                };
+                assetReferences.push(referenceRecord);
+                resourceRecord.assetReferences.push(referenceRecord);
+            }
+        );
+    }
+
+    for (const reference of assetReferences) {
+        const targetResource = resourcesMap.get(reference.targetPath);
+        if (targetResource) {
+            reference.targetResourceType = targetResource.resourceType;
+            if (!reference.targetName && targetResource.name) {
+                reference.targetName = targetResource.name;
+            }
+        }
+    }
+
+    return {
+        resourcesMap,
+        gmlScopeMap,
+        assetReferences,
+        scriptNameToScopeId,
+        scriptNameToResourcePath
+    };
+}
+
+function createIdentifierRecord(node) {
+    return {
+        name: node?.name ?? null,
+        start: cloneLocation(node?.start),
+        end: cloneLocation(node?.end),
+        scopeId: node?.scopeId ?? null,
+        classifications: Array.isArray(node?.classifications)
+            ? [...node.classifications]
+            : []
+    };
+}
+
+function ensureScopeRecord(scopeMap, descriptor) {
+    let scopeRecord = scopeMap.get(descriptor.id);
+    if (!scopeRecord) {
+        scopeRecord = {
+            id: descriptor.id,
+            kind: descriptor.kind,
+            name: descriptor.name,
+            displayName: descriptor.displayName,
+            resourcePath: descriptor.resourcePath,
+            event: descriptor.event ?? null,
+            filePaths: [],
+            declarations: [],
+            references: [],
+            ignoredIdentifiers: [],
+            scriptCalls: []
+        };
+        scopeMap.set(descriptor.id, scopeRecord);
+    }
+    return scopeRecord;
+}
+
+function ensureFileRecord(filesMap, relativePath, scopeId) {
+    let fileRecord = filesMap.get(relativePath);
+    if (!fileRecord) {
+        fileRecord = {
+            filePath: relativePath,
+            scopeId,
+            declarations: [],
+            references: [],
+            ignoredIdentifiers: [],
+            scriptCalls: []
+        };
+        filesMap.set(relativePath, fileRecord);
+    }
+    return fileRecord;
+}
+
+function traverseAst(root, visitor) {
+    if (!root || typeof root !== "object") {
+        return;
+    }
+
+    const stack = [root];
+    const seen = new Set();
+
+    while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node || typeof node !== "object") {
+            continue;
+        }
+
+        if (seen.has(node)) {
+            continue;
+        }
+        seen.add(node);
+
+        visitor(node);
+
+        const values = Object.values(node);
+        for (const value of values) {
+            if (Array.isArray(value)) {
+                for (let i = value.length - 1; i >= 0; i--) {
+                    const child = value[i];
+                    if (child && typeof child === "object") {
+                        stack.push(child);
+                    }
+                }
+            } else if (value && typeof value === "object") {
+                stack.push(value);
+            }
+        }
+    }
+}
+
+function analyseGmlAst({
+    ast,
+    builtInNames,
+    scopeRecord,
+    fileRecord,
+    relationships,
+    scriptNameToScopeId,
+    scriptNameToResourcePath
+}) {
+    traverseAst(ast, (node) => {
+        if (node?.type === "Identifier" && Array.isArray(node.classifications)) {
+            const identifierRecord = createIdentifierRecord(node);
+            const isBuiltIn = builtInNames.has(identifierRecord.name);
+            identifierRecord.isBuiltIn = isBuiltIn;
+
+            if (isBuiltIn) {
+                identifierRecord.reason = "built-in";
+                fileRecord.ignoredIdentifiers.push(identifierRecord);
+                scopeRecord.ignoredIdentifiers.push(identifierRecord);
+                return;
+            }
+
+            const isDeclaration =
+        identifierRecord.classifications.includes("declaration");
+            const isReference =
+        identifierRecord.classifications.includes("reference");
+
+            if (isDeclaration) {
+                fileRecord.declarations.push(identifierRecord);
+                scopeRecord.declarations.push(identifierRecord);
+            }
+
+            if (isReference) {
+                fileRecord.references.push(identifierRecord);
+                scopeRecord.references.push(identifierRecord);
+            }
+        }
+
+        if (node?.type === "CallExpression" && node.object?.type === "Identifier") {
+            const callee = node.object;
+            const calleeName = callee.name;
+            if (typeof calleeName !== "string") {
+                return;
+            }
+
+            if (builtInNames.has(calleeName)) {
+                return;
+            }
+
+            const targetScopeId = scriptNameToScopeId.get(calleeName) ?? null;
+            const targetResourcePath = targetScopeId
+                ? (scriptNameToResourcePath.get(calleeName) ?? null)
+                : null;
+
+            const callRecord = {
+                kind: "script",
+                from: {
+                    filePath: fileRecord.filePath,
+                    scopeId: scopeRecord.id
+                },
+                target: {
+                    name: calleeName,
+                    scopeId: targetScopeId,
+                    resourcePath: targetResourcePath
+                },
+                isResolved: Boolean(targetScopeId),
+                location: {
+                    start: cloneLocation(callee.start),
+                    end: cloneLocation(callee.end)
+                }
+            };
+
+            fileRecord.scriptCalls.push(callRecord);
+            scopeRecord.scriptCalls.push(callRecord);
+            relationships.scriptCalls.push(callRecord);
+        }
+    });
+}
+
+function cloneAssetReference(reference) {
+    return {
+        fromResourcePath: reference.fromResourcePath,
+        fromResourceName: reference.fromResourceName,
+        propertyPath: reference.propertyPath,
+        targetPath: reference.targetPath,
+        targetName: reference.targetName ?? null,
+        targetResourceType: reference.targetResourceType ?? null
+    };
+}
+
+export async function buildProjectIndex(
+    projectRoot,
+    fsFacade = defaultFsFacade
+) {
+    if (!projectRoot) {
+        throw new Error("projectRoot must be provided to buildProjectIndex");
+    }
+
+    const resolvedRoot = path.resolve(projectRoot);
+    const builtInIdentifiers = await loadBuiltInIdentifiers(fsFacade);
+    const builtInNames = builtInIdentifiers.names ?? new Set();
+
+    const { yyFiles, gmlFiles } = await scanProjectTree(resolvedRoot, fsFacade);
+    const resourceAnalysis = await analyseResourceFiles({
+        projectRoot: resolvedRoot,
+        yyFiles,
+        fsFacade
+    });
+
+    const scopeMap = new Map();
+    const filesMap = new Map();
+    const relationships = {
+        scriptCalls: [],
+        assetReferences: resourceAnalysis.assetReferences.map((reference) =>
+            cloneAssetReference(reference)
+        )
+    };
+
+    for (const file of gmlFiles) {
+        let contents;
+        try {
+            contents = await fsFacade.readFile(file.absolutePath, "utf8");
+        } catch (error) {
+            if (error && error.code === "ENOENT") {
+                continue;
+            }
+            throw error;
+        }
+
+        const scopeDescriptor =
+      resourceAnalysis.gmlScopeMap.get(file.relativePath) ??
+      createFileScopeDescriptor(file.relativePath);
+
+        const scopeRecord = ensureScopeRecord(scopeMap, scopeDescriptor);
+        pushUnique(scopeRecord.filePaths, file.relativePath);
+
+        const fileRecord = ensureFileRecord(
+            filesMap,
+            file.relativePath,
+            scopeRecord.id
+        );
+
+        if (
+            scopeDescriptor.kind === "script" &&
+      !fileRecord.hasSyntheticDeclaration
+        ) {
+            const syntheticDeclaration = {
+                name: scopeDescriptor.name,
+                start: null,
+                end: null,
+                scopeId: scopeRecord.id,
+                classifications: ["identifier", "declaration", "script"],
+                isBuiltIn: false,
+                isSynthetic: true
+            };
+            fileRecord.declarations.push({ ...syntheticDeclaration });
+            scopeRecord.declarations.push({ ...syntheticDeclaration });
+            fileRecord.hasSyntheticDeclaration = true;
+        }
+
+        const ast = GMLParser.parse(contents, {
+            getComments: false,
+            getLocations: true,
+            simplifyLocations: false,
+            getIdentifierMetadata: true
+        });
+
+        analyseGmlAst({
+            ast,
+            builtInNames,
+            scopeRecord,
+            fileRecord,
+            relationships,
+            scriptNameToScopeId: resourceAnalysis.scriptNameToScopeId,
+            scriptNameToResourcePath: resourceAnalysis.scriptNameToResourcePath
+        });
+    }
+
+    const resources = Object.fromEntries(
+        Array.from(resourceAnalysis.resourcesMap.entries()).map(
+            ([resourcePath, record]) => [
+                resourcePath,
+                {
+                    path: record.path,
+                    name: record.name,
+                    resourceType: record.resourceType,
+                    scopes: record.scopes.slice(),
+                    gmlFiles: record.gmlFiles.slice(),
+                    assetReferences: record.assetReferences.map((reference) =>
+                        cloneAssetReference(reference)
+                    )
+                }
+            ]
+        )
+    );
+
+    const scopes = Object.fromEntries(
+        Array.from(scopeMap.entries()).map(([scopeId, record]) => [
+            scopeId,
+            {
+                id: record.id,
+                kind: record.kind,
+                name: record.name,
+                displayName: record.displayName,
+                resourcePath: record.resourcePath,
+                event: record.event ? { ...record.event } : null,
+                filePaths: record.filePaths.slice(),
+                declarations: record.declarations.map((item) => ({ ...item })),
+                references: record.references.map((item) => ({ ...item })),
+                ignoredIdentifiers: record.ignoredIdentifiers.map((item) => ({
+                    ...item
+                })),
+                scriptCalls: record.scriptCalls.map((call) => ({ ...call }))
+            }
+        ])
+    );
+
+    const files = Object.fromEntries(
+        Array.from(filesMap.entries()).map(([filePath, record]) => [
+            filePath,
+            {
+                filePath: record.filePath,
+                scopeId: record.scopeId,
+                declarations: record.declarations.map((item) => ({ ...item })),
+                references: record.references.map((item) => ({ ...item })),
+                ignoredIdentifiers: record.ignoredIdentifiers.map((item) => ({
+                    ...item
+                })),
+                scriptCalls: record.scriptCalls.map((call) => ({ ...call }))
+            }
+        ])
+    );
+
+    return {
+        projectRoot: resolvedRoot,
+        resources,
+        scopes,
+        files,
+        relationships
     };
 }

--- a/src/shared/tests/project-index-integration.test.js
+++ b/src/shared/tests/project-index-integration.test.js
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildProjectIndex } from "../project-index/index.js";
+
+async function writeFile(rootDir, relativePath, contents) {
+    const absolutePath = path.join(rootDir, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents, "utf8");
+}
+
+test("buildProjectIndex collects symbols and relationships across project files", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gml-project-"));
+
+    try {
+        await writeFile(
+            tempRoot,
+            "MyGame.yyp",
+            JSON.stringify({ name: "MyGame", resourceType: "GMProject" })
+        );
+
+        await writeFile(
+            tempRoot,
+            "sprites/spr_enemy/spr_enemy.yy",
+            JSON.stringify({
+                resourceType: "GMSprite",
+                name: "spr_enemy"
+            })
+        );
+
+        await writeFile(
+            tempRoot,
+            "scripts/calc_damage/calc_damage.yy",
+            JSON.stringify({
+                resourceType: "GMScript",
+                name: "calc_damage"
+            })
+        );
+        await writeFile(
+            tempRoot,
+            "scripts/calc_damage/calc_damage.gml",
+            "function calc_damage(target) {\n    return max(0, target.hp - target.armor);\n}\n"
+        );
+
+        await writeFile(
+            tempRoot,
+            "scripts/attack/attack.yy",
+            JSON.stringify({
+                resourceType: "GMScript",
+                name: "attack"
+            })
+        );
+        await writeFile(
+            tempRoot,
+            "scripts/attack/attack.gml",
+            [
+                "function attack(target) {",
+                "    var damage = calc_damage(target);",
+                "    return damage;",
+                "}",
+                ""
+            ].join("\n")
+        );
+
+        await writeFile(
+            tempRoot,
+            "objects/obj_enemy/obj_enemy.yy",
+            JSON.stringify({
+                resourceType: "GMObject",
+                name: "obj_enemy",
+                spriteId: {
+                    name: "spr_enemy",
+                    path: "sprites/spr_enemy/spr_enemy.yy"
+                },
+                eventList: [
+                    {
+                        name: "Create_0",
+                        eventType: 0,
+                        eventNum: 0,
+                        eventId: {
+                            name: "Create_0",
+                            path: "objects/obj_enemy/obj_enemy_Create_0.gml"
+                        }
+                    },
+                    {
+                        name: "Step_0",
+                        eventType: 3,
+                        eventNum: 0,
+                        eventId: {
+                            name: "Step_0",
+                            path: "objects/obj_enemy/obj_enemy_Step_0.gml"
+                        }
+                    }
+                ]
+            })
+        );
+
+        await writeFile(
+            tempRoot,
+            "objects/obj_enemy/obj_enemy_Create_0.gml",
+            ["hp = 100;", "attack(other);", "sprite_index = spr_enemy;"].join("\n")
+        );
+
+        await writeFile(
+            tempRoot,
+            "objects/obj_enemy/obj_enemy_Step_0.gml",
+            ["if (hp <= 0) {", "    instance_destroy();", "}"].join("\n")
+        );
+
+        const index = await buildProjectIndex(tempRoot);
+
+        assert.ok(
+            index.resources["scripts/attack/attack.yy"],
+            "expected attack resource to be indexed"
+        );
+        assert.ok(
+            index.resources["objects/obj_enemy/obj_enemy.yy"],
+            "expected object resource to be indexed"
+        );
+
+        const attackScope = index.scopes["scope:script:attack"];
+        assert.ok(attackScope, "expected attack scope to be present");
+        assert.ok(
+            attackScope.declarations.some((decl) => decl.name === "attack"),
+            "expected attack declaration to be captured"
+        );
+
+        const attackCalls = attackScope.scriptCalls.map((call) => call.target.name);
+        assert.ok(
+            attackCalls.includes("calc_damage"),
+            "expected attack scope to record calc_damage call"
+        );
+
+        const createFile = index.files["objects/obj_enemy/obj_enemy_Create_0.gml"];
+        assert.ok(createFile, "expected create event file to be indexed");
+        assert.equal(createFile.scriptCalls.length, 1);
+        assert.equal(createFile.scriptCalls[0].target.name, "attack");
+        assert.equal(createFile.scriptCalls[0].isResolved, true);
+
+        const stepFile = index.files["objects/obj_enemy/obj_enemy_Step_0.gml"];
+        assert.ok(stepFile, "expected step event file to be indexed");
+        assert.equal(
+            stepFile.scriptCalls.length,
+            0,
+            "expected built-in instance_destroy to be excluded from script calls"
+        );
+
+        const calcFile = index.files["scripts/calc_damage/calc_damage.gml"];
+        assert.ok(calcFile, "expected calc_damage file to be indexed");
+        assert.ok(
+            calcFile.ignoredIdentifiers.some(
+                (entry) => entry.name === "max" && entry.reason === "built-in"
+            ),
+            "expected built-in max to be ignored"
+        );
+
+        const scriptCallTargets = index.relationships.scriptCalls.map(
+            (call) => call.target.name
+        );
+        assert.deepEqual(scriptCallTargets.sort(), ["attack", "calc_damage"]);
+
+        const spriteReference = index.relationships.assetReferences.find(
+            (reference) => reference.targetPath === "sprites/spr_enemy/spr_enemy.yy"
+        );
+        assert.ok(
+            spriteReference,
+            "expected sprite asset reference to be recorded"
+        );
+        assert.equal(
+            spriteReference.fromResourcePath,
+            "objects/obj_enemy/obj_enemy.yy"
+        );
+    } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary
- implement project index traversal that loads GameMaker identifiers, scans .yy/.gml resources, and captures per-scope symbol metadata
- record script calls and asset references while excluding built-in identifiers from rename candidates
- add an integration test fixture exercising cross-file relationships within a synthetic GameMaker project

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_68eacf67baa8832f93974b86923e58c6