### PR TITLE
Add identifier case option scaffolding and tests

### DIFF
--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -3,6 +3,7 @@
 import { gmlParserAdapter } from "./parsers/gml-parser-adapter.js";
 import { print } from "./printer/print.js";
 import { handleComments, printComment } from "./printer/comments.js";
+import { identifierCaseOptions } from "./options/identifier-case.js";
 
 export const languages = [
     {
@@ -164,6 +165,7 @@ export const options = {
         description:
       "Apply safe auto-fixes derived from GameMaker Feather diagnostics (e.g. remove trailing semicolons from macro declarations flagged by GM1051)."
     },
+    ...identifierCaseOptions,
     useStringInterpolation: {
         since: "0.0.0",
         type: "boolean",

--- a/src/plugin/src/options/identifier-case.js
+++ b/src/plugin/src/options/identifier-case.js
@@ -1,0 +1,241 @@
+// options/identifier-case.js
+
+const IDENTIFIER_CASE_DESCRIPTION =
+  "Sets the preferred casing style to apply when renaming identifiers.";
+
+export const IDENTIFIER_CASE_STYLES = Object.freeze([
+    "off",
+    "camel",
+    "pascal",
+    "snake-lower",
+    "snake-upper"
+]);
+
+export const IDENTIFIER_CASE_INHERIT_VALUE = "inherit";
+
+export const IDENTIFIER_CASE_SCOPE_NAMES = Object.freeze([
+    "functions",
+    "structs",
+    "locals",
+    "instance",
+    "globals",
+    "assets",
+    "macros"
+]);
+
+export const IDENTIFIER_CASE_BASE_OPTION_NAME = "gmlIdentifierCase";
+export const IDENTIFIER_CASE_IGNORE_OPTION_NAME = "gmlIdentifierCaseIgnore";
+export const IDENTIFIER_CASE_PRESERVE_OPTION_NAME = "gmlIdentifierCasePreserve";
+export const IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME =
+  "gmlIdentifierCaseAcknowledgeAssetRenames";
+
+const IDENTIFIER_CASE_SCOPE_OPTION_PREFIX = "gmlIdentifierCase";
+
+const BASE_IDENTIFIER_CASE_SINCE = "0.0.0";
+
+function createChoice(value, description) {
+    return { value, description };
+}
+
+export const IDENTIFIER_CASE_STYLE_CHOICES = IDENTIFIER_CASE_STYLES.map(
+    (style) => {
+        switch (style) {
+            case "off":
+                return createChoice(
+                    style,
+                    "Disable automatic identifier case rewriting."
+                );
+            case "camel":
+                return createChoice(
+                    style,
+                    "Convert identifiers to lower camelCase (e.g. `exampleName`)."
+                );
+            case "pascal":
+                return createChoice(
+                    style,
+                    "Convert identifiers to Upper PascalCase (e.g. `ExampleName`)."
+                );
+            case "snake-lower":
+                return createChoice(
+                    style,
+                    "Convert identifiers to lower snake_case (e.g. `example_name`)."
+                );
+            case "snake-upper":
+                return createChoice(
+                    style,
+                    "Convert identifiers to UPPER_SNAKE_CASE (e.g. `EXAMPLE_NAME`)."
+                );
+            default:
+                return createChoice(style, IDENTIFIER_CASE_DESCRIPTION);
+        }
+    }
+);
+
+function capitalize(value) {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function getScopeOptionName(scope) {
+    return `${IDENTIFIER_CASE_SCOPE_OPTION_PREFIX}${capitalize(scope)}`;
+}
+
+function createScopeChoiceEntries() {
+    const inheritChoice = createChoice(
+        IDENTIFIER_CASE_INHERIT_VALUE,
+        "Inherit the default gmlIdentifierCase value."
+    );
+
+    return [inheritChoice, ...IDENTIFIER_CASE_STYLE_CHOICES];
+}
+
+function createScopeOptionConfig(scope) {
+    return {
+        since: BASE_IDENTIFIER_CASE_SINCE,
+        type: "choice",
+        category: "gml",
+        default: IDENTIFIER_CASE_INHERIT_VALUE,
+        description: `Overrides the base identifier case for ${scope} declarations.`,
+        choices: createScopeChoiceEntries()
+    };
+}
+
+export const identifierCaseOptions = {
+    [IDENTIFIER_CASE_BASE_OPTION_NAME]: {
+        since: BASE_IDENTIFIER_CASE_SINCE,
+        type: "choice",
+        category: "gml",
+        default: "off",
+        description:
+      "Configures the default identifier case conversion style applied to eligible declarations.",
+        choices: IDENTIFIER_CASE_STYLE_CHOICES
+    },
+    [IDENTIFIER_CASE_IGNORE_OPTION_NAME]: {
+        since: BASE_IDENTIFIER_CASE_SINCE,
+        type: "string",
+        category: "gml",
+        default: "",
+        description:
+      "Comma- or newline-separated patterns describing identifiers or files to ignore while renaming."
+    },
+    [IDENTIFIER_CASE_PRESERVE_OPTION_NAME]: {
+        since: BASE_IDENTIFIER_CASE_SINCE,
+        type: "string",
+        category: "gml",
+        default: "",
+        description:
+      "Comma- or newline-separated list of identifier names that must be preserved without renaming."
+    },
+    [IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME]: {
+        since: BASE_IDENTIFIER_CASE_SINCE,
+        type: "boolean",
+        category: "gml",
+        default: false,
+        description:
+      "Acknowledges that enabling asset renames may rename files on disk and updates related metadata."
+    }
+};
+
+for (const scope of IDENTIFIER_CASE_SCOPE_NAMES) {
+    const optionName = getScopeOptionName(scope);
+    identifierCaseOptions[optionName] = createScopeOptionConfig(scope);
+}
+
+function normalizeList(optionName, value) {
+    if (value == null) {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        const normalized = value
+            .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+            .filter(Boolean);
+
+        return [...new Set(normalized)];
+    }
+
+    if (typeof value === "string") {
+        const pieces = value
+            .split(/[\n,]/)
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+
+        return [...new Set(pieces)];
+    }
+
+    throw new TypeError(
+        `${optionName} must be provided as a string or array of strings.`
+    );
+}
+
+function resolveScopeSettings(options, baseStyle) {
+    const scopeSettings = {};
+    const scopeStyles = {};
+
+    for (const scope of IDENTIFIER_CASE_SCOPE_NAMES) {
+        const optionName = getScopeOptionName(scope);
+        const configuredValue = options?.[optionName];
+
+        const normalizedValue =
+      configuredValue === undefined
+          ? IDENTIFIER_CASE_INHERIT_VALUE
+          : configuredValue;
+
+        scopeSettings[scope] = normalizedValue;
+
+        scopeStyles[scope] =
+      normalizedValue === IDENTIFIER_CASE_INHERIT_VALUE
+          ? baseStyle
+          : normalizedValue;
+    }
+
+    return { scopeSettings, scopeStyles };
+}
+
+export function normalizeIdentifierCaseOptions(options = {}) {
+    const baseStyle = options?.[IDENTIFIER_CASE_BASE_OPTION_NAME] ?? "off";
+
+    const { scopeSettings, scopeStyles } = resolveScopeSettings(
+        options,
+        baseStyle
+    );
+
+    const ignorePatterns = normalizeList(
+        IDENTIFIER_CASE_IGNORE_OPTION_NAME,
+        options?.[IDENTIFIER_CASE_IGNORE_OPTION_NAME]
+    );
+    const preservedIdentifiers = normalizeList(
+        IDENTIFIER_CASE_PRESERVE_OPTION_NAME,
+        options?.[IDENTIFIER_CASE_PRESERVE_OPTION_NAME]
+    );
+
+    const assetRenamesAcknowledged = Boolean(
+        options?.[IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME]
+    );
+
+    const effectiveAssetStyle = scopeStyles.assets;
+    const assetRenamesEnabled =
+    effectiveAssetStyle && effectiveAssetStyle !== "off";
+
+    if (assetRenamesEnabled && !assetRenamesAcknowledged) {
+        throw new Error(
+            "Enabling gmlIdentifierCaseAssets requires acknowledging asset renames via gmlIdentifierCaseAcknowledgeAssetRenames."
+        );
+    }
+
+    return {
+        baseStyle,
+        scopeSettings,
+        scopeStyles,
+        ignorePatterns,
+        preservedIdentifiers,
+        assetRenamesAcknowledged
+    };
+}
+
+export function getIdentifierCaseScopeOptionName(scope) {
+    if (!IDENTIFIER_CASE_SCOPE_NAMES.includes(scope)) {
+        throw new RangeError(`Unknown identifier case scope: ${scope}`);
+    }
+
+    return getScopeOptionName(scope);
+}

--- a/src/plugin/tests/identifier-case-options.test.js
+++ b/src/plugin/tests/identifier-case-options.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    IDENTIFIER_CASE_BASE_OPTION_NAME,
+    IDENTIFIER_CASE_SCOPE_NAMES,
+    IDENTIFIER_CASE_INHERIT_VALUE,
+    IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME,
+    normalizeIdentifierCaseOptions,
+    getIdentifierCaseScopeOptionName,
+    IDENTIFIER_CASE_IGNORE_OPTION_NAME,
+    IDENTIFIER_CASE_PRESERVE_OPTION_NAME
+} from "../src/options/identifier-case.js";
+
+describe("gml identifier case option normalization", () => {
+    it("defaults to disabled renaming when options are omitted", () => {
+        const normalized = normalizeIdentifierCaseOptions({});
+
+        assert.strictEqual(normalized.baseStyle, "off");
+        for (const scope of IDENTIFIER_CASE_SCOPE_NAMES) {
+            assert.strictEqual(
+                normalized.scopeSettings[scope],
+                IDENTIFIER_CASE_INHERIT_VALUE
+            );
+            assert.strictEqual(normalized.scopeStyles[scope], "off");
+        }
+        assert.deepStrictEqual(normalized.ignorePatterns, []);
+        assert.deepStrictEqual(normalized.preservedIdentifiers, []);
+        assert.strictEqual(normalized.assetRenamesAcknowledged, false);
+    });
+
+    it("allows scope overrides while inheriting the base style", () => {
+        const normalized = normalizeIdentifierCaseOptions({
+            [IDENTIFIER_CASE_BASE_OPTION_NAME]: "pascal",
+            [getIdentifierCaseScopeOptionName("globals")]: "snake-upper",
+            [getIdentifierCaseScopeOptionName("locals")]:
+        IDENTIFIER_CASE_INHERIT_VALUE,
+            [getIdentifierCaseScopeOptionName("functions")]: "camel",
+            [IDENTIFIER_CASE_IGNORE_OPTION_NAME]: "temp_, debug",
+            [IDENTIFIER_CASE_PRESERVE_OPTION_NAME]: ["hp", "PlayerScore"],
+            [IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME]: true,
+            [getIdentifierCaseScopeOptionName("assets")]: "snake-upper"
+        });
+
+        assert.strictEqual(normalized.baseStyle, "pascal");
+        assert.strictEqual(normalized.scopeStyles.functions, "camel");
+        assert.strictEqual(normalized.scopeStyles.globals, "snake-upper");
+        assert.strictEqual(normalized.scopeStyles.locals, "pascal");
+        assert.ok(normalized.ignorePatterns.includes("temp_"));
+        assert.ok(normalized.ignorePatterns.includes("debug"));
+        assert.deepStrictEqual(normalized.preservedIdentifiers, [
+            "hp",
+            "PlayerScore"
+        ]);
+        assert.strictEqual(normalized.assetRenamesAcknowledged, true);
+    });
+
+    it("rejects enabling asset renames without acknowledgment", () => {
+        assert.throws(
+            () =>
+                normalizeIdentifierCaseOptions({
+                    [IDENTIFIER_CASE_BASE_OPTION_NAME]: "camel",
+                    [getIdentifierCaseScopeOptionName("assets")]:
+            IDENTIFIER_CASE_INHERIT_VALUE
+                }),
+            /acknowledging asset renames/i
+        );
+    });
+
+    it("allows asset renames when explicitly acknowledged", () => {
+        const normalized = normalizeIdentifierCaseOptions({
+            [IDENTIFIER_CASE_BASE_OPTION_NAME]: "snake-lower",
+            [IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME]: true
+        });
+
+        assert.strictEqual(normalized.scopeStyles.assets, "snake-lower");
+        assert.strictEqual(normalized.assetRenamesAcknowledged, true);
+    });
+});


### PR DESCRIPTION
## Summary
- add the identifier case configuration bundle (base option, per-scope overrides, ignore/preserve lists, and asset rename acknowledgement) to the plugin options map so defaults remain a no-op.  
- implement identifier-case option normalization helpers that parse scopes, build ignore/preserve sets, and reject asset renames without explicit acknowledgement.  
- cover the identifier case parsing helpers with unit tests to confirm default behaviour, overrides, and validation errors.

## Testing
- npm run test:plugin *(fails: fixture mismatches for testFunctions and testPreserve surfaced during the run)*
- node --test src/plugin/tests/identifier-case-options.test.js


------
https://chatgpt.com/codex/tasks/task_e_68ead4cfee34832f8af6f1552a53deba