### PR TITLE
Add shared identifier case normalization utilities

### DIFF
--- a/docs/identifier-case-reference.md
+++ b/docs/identifier-case-reference.md
@@ -1,0 +1,81 @@
+# Identifier Case Utility Reference
+
+This document records how the shared identifier case helpers normalise and
+reconstruct GML identifiers. The module is implemented in
+`src/shared/identifier-case.js` and centralises the tokenisation rules that case
+transformations rely upon.
+
+## Reserved prefixes
+
+The tokenizer preserves the prefixes below exactly as written. They are stripped
+from the identifier before case conversion and reattached verbatim afterwards.
+
+- `global.`
+- `other.`
+- `self.`
+- `local.`
+- `with.`
+- `noone.`
+- `argument` (optionally followed by a numeric index, such as `argument0`)
+- `argument_local` (optionally followed by a numeric index)
+- `argument_relative` (optionally followed by a numeric index)
+- `argument[<number>]` (array-style argument accessors)
+
+When the prefix ends with a dot (for example `global.` or `argument0.`) the dot
+is included in the preserved portion.
+
+## Normalisation steps
+
+1. **Prefix detection:** If a reserved prefix is detected it is separated from
+   the remainder and stored for later reattachment.
+2. **Numeric suffix capture:** A trailing run of digits, optionally prefixed by
+   a single underscore (e.g. `_12`), is removed from the working string and kept
+   as a numeric suffix so that counters stay attached to the identifier.
+3. **Edge underscores:** Leading and trailing underscores are removed from the
+   working string and stored so they can be re-applied verbatim in the final
+   result. This ensures identifiers like `__hp__` remain unchanged after
+   round-tripping.
+4. **Tokenisation:** The inner portion is split into tokens by underscores,
+   camel-case boundaries, and digit runs. Alphabetic tokens are lowercased for
+   consistent downstream handling while numeric tokens retain their original
+   digits.
+
+The resulting structure captures:
+
+```js
+{
+    original: "global.hp_max_2",
+    prefix: "global.",
+    leadingUnderscores: "",
+    trailingUnderscores: "",
+    suffixSeparator: "_",
+    suffixDigits: "2",
+    tokens: [
+        { normalized: "hp", type: "word" },
+        { normalized: "max", type: "word" }
+    ]
+}
+```
+
+## Case reconstruction
+
+Four reconstruction helpers are exposed:
+
+- `camel`: produces lower camel case (`hpMax`, `pathFinderState`).
+- `pascal`: produces Pascal case (`HpMax`, `PathFinderState`).
+- `snake-lower`: produces lower snake case (`hp_max`, `path_finder_state`).
+- `snake-upper`: produces upper snake case (`HP_MAX`, `PATH_FINDER_STATE`).
+
+During snake case reconstruction, numeric tokens fuse with adjacent alphabetic
+segments so counters remain inline (e.g. tokens `hp`, `2`, `d`, `max` become
+`hp2d_max`). Camel and Pascal case reconstruction capitalises alphabetic tokens
+beyond the first token (or every token for Pascal) while leaving numeric tokens
+unchanged. In every case the preserved prefix, leading/trailing underscores, and
+numeric suffix are re-applied at the end of the process.
+
+## Idempotence
+
+The `formatIdentifierCase` helper is idempotent. Identifiers that already match
+one of the supported case styles will round-trip without modification, which is
+verified by the exported `isIdentifierCase` convenience checks used in the test
+suite.

--- a/src/shared/identifier-case.js
+++ b/src/shared/identifier-case.js
@@ -1,0 +1,232 @@
+const RESERVED_PREFIX_PATTERN =
+    /^(?<prefix>(?:global|other|self|local|with|noone)\.|argument(?:_(?:local|relative))?(?:\[\d+\]|\d+)?\.?)/;
+
+function extractReservedPrefix(identifier) {
+    const match = identifier.match(RESERVED_PREFIX_PATTERN);
+    if (!match) {
+        return { prefix: "", remainder: identifier };
+    }
+
+    const { prefix } = match.groups;
+    return { prefix, remainder: identifier.slice(prefix.length) };
+}
+
+function splitNumericSuffix(text) {
+    const match = text.match(/(_?\d+)$/);
+    if (!match) {
+        return { core: text, suffixSeparator: "", suffixDigits: "" };
+    }
+
+    const [fullMatch] = match;
+    const suffixDigits = fullMatch.replace(/^_/, "");
+    const suffixSeparator = fullMatch.startsWith("_") ? "_" : "";
+    return {
+        core: text.slice(0, -fullMatch.length),
+        suffixSeparator,
+        suffixDigits
+    };
+}
+
+function stripEdgeUnderscores(text) {
+    const leadingMatch = text.match(/^_+/);
+    const trailingMatch = text.match(/_+$/);
+
+    const leading = leadingMatch ? leadingMatch[0] : "";
+    const trailing = trailingMatch ? trailingMatch[0] : "";
+
+    const core = text.slice(leading.length, text.length - trailing.length);
+    return { core, leading, trailing };
+}
+
+function tokenizeCore(core) {
+    if (!core) {
+        return [];
+    }
+
+    const rawSegments = core
+        .split(/_+/)
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+
+    const tokens = [];
+    for (const segment of rawSegments) {
+        const caseSegments =
+            segment.match(/[A-Z]+(?=[A-Z][a-z0-9])|[A-Z]?[a-z0-9]+|[0-9]+|[A-Z]+/g) || [];
+        for (const caseSegment of caseSegments) {
+            const parts = caseSegment.match(/[A-Za-z]+|[0-9]+/g) || [];
+            for (const part of parts) {
+                const isNumber = /^\d+$/.test(part);
+                const normalized = isNumber ? part : part.toLowerCase();
+                tokens.push({ normalized, type: isNumber ? "number" : "word" });
+            }
+        }
+    }
+
+    return tokens;
+}
+
+function capitalize(value) {
+    if (!value) {
+        return value;
+    }
+
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function finalizeIdentifier(normalized, base) {
+    const suffix = normalized.suffixDigits
+        ? normalized.suffixSeparator + normalized.suffixDigits
+        : "";
+    return (
+        normalized.prefix +
+        normalized.leadingUnderscores +
+        base +
+        normalized.trailingUnderscores +
+        suffix
+    );
+}
+
+function buildCamelCase(normalized) {
+    const { tokens } = normalized;
+    if (tokens.length === 0) {
+        return finalizeIdentifier(normalized, "");
+    }
+
+    let base = "";
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        if (token.type === "number") {
+            base += token.normalized;
+            continue;
+        }
+
+        if (index === 0) {
+            base += token.normalized;
+        } else {
+            base += capitalize(token.normalized);
+        }
+    }
+
+    return finalizeIdentifier(normalized, base);
+}
+
+function buildPascalCase(normalized) {
+    const { tokens } = normalized;
+    if (tokens.length === 0) {
+        return finalizeIdentifier(normalized, "");
+    }
+
+    let base = "";
+    for (const token of tokens) {
+        if (token.type === "number") {
+            base += token.normalized;
+        } else {
+            base += capitalize(token.normalized);
+        }
+    }
+
+    return finalizeIdentifier(normalized, base);
+}
+
+function shouldJoinForSnake(previousToken, currentToken) {
+    return (
+        (previousToken.type === "word" && currentToken.type === "number") ||
+        (previousToken.type === "number" && currentToken.type === "word")
+    );
+}
+
+function buildSnakeCase(normalized, transform) {
+    const { tokens } = normalized;
+    if (tokens.length === 0) {
+        return finalizeIdentifier(normalized, "");
+    }
+
+    let base = transform(tokens[0]);
+    for (let index = 1; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        const previous = tokens[index - 1];
+        const text = transform(token);
+
+        if (shouldJoinForSnake(previous, token)) {
+            base += text;
+        } else {
+            base += `_${text}`;
+        }
+    }
+
+    return finalizeIdentifier(normalized, base);
+}
+
+function transformSnakeLower(token) {
+    if (token.type === "word") {
+        return token.normalized;
+    }
+
+    return token.normalized;
+}
+
+function transformSnakeUpper(token) {
+    if (token.type === "word") {
+        return token.normalized.toUpperCase();
+    }
+
+    return token.normalized;
+}
+
+export function normalizeIdentifierCase(identifier) {
+    if (typeof identifier !== "string") {
+        throw new TypeError("Identifier must be a string");
+    }
+
+    const { prefix, remainder: withoutPrefix } = extractReservedPrefix(identifier);
+    const { core: withoutNumericSuffix, suffixSeparator, suffixDigits } =
+        splitNumericSuffix(withoutPrefix);
+    const { core, leading, trailing } = stripEdgeUnderscores(withoutNumericSuffix);
+
+    const tokens = tokenizeCore(core);
+
+    return {
+        original: identifier,
+        prefix,
+        leadingUnderscores: leading,
+        trailingUnderscores: trailing,
+        suffixSeparator,
+        suffixDigits,
+        tokens
+    };
+}
+
+export function formatIdentifierCase(input, style) {
+    const normalized =
+        typeof input === "string" ? normalizeIdentifierCase(input) : input;
+
+    switch (style) {
+        case "camel":
+            return buildCamelCase(normalized);
+        case "pascal":
+            return buildPascalCase(normalized);
+        case "snake-lower":
+            return buildSnakeCase(normalized, transformSnakeLower);
+        case "snake-upper":
+            return buildSnakeCase(normalized, transformSnakeUpper);
+        default:
+            throw new Error(`Unsupported identifier case: ${style}`);
+    }
+}
+
+export function isIdentifierCase(identifier, style) {
+    const normalized = normalizeIdentifierCase(identifier);
+    return formatIdentifierCase(normalized, style) === identifier;
+}
+
+export const RESERVED_IDENTIFIER_PREFIXES = Object.freeze([
+    "global.",
+    "other.",
+    "self.",
+    "local.",
+    "with.",
+    "noone.",
+    "argument",
+    "argument_local",
+    "argument_relative"
+]);

--- a/src/shared/tests/identifier-case.test.js
+++ b/src/shared/tests/identifier-case.test.js
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    RESERVED_IDENTIFIER_PREFIXES,
+    formatIdentifierCase,
+    isIdentifierCase,
+    normalizeIdentifierCase
+} from "../identifier-case.js";
+
+test("normalisation preserves prefixes and numeric suffixes", () => {
+    const normalized = normalizeIdentifierCase("global.hp_max_2");
+
+    assert.equal(normalized.prefix, "global.");
+    assert.equal(normalized.suffixSeparator, "_");
+    assert.equal(normalized.suffixDigits, "2");
+    assert.deepEqual(
+        normalized.tokens.map((token) => ({ ...token })),
+        [
+            { normalized: "hp", type: "word" },
+            { normalized: "max", type: "word" }
+        ]
+    );
+
+    const rebuilt = formatIdentifierCase(normalized, "camel");
+    assert.equal(rebuilt, "global.hpMax_2");
+});
+
+test("leading and trailing underscores are stable across conversions", () => {
+    const source = "__hpMax__";
+    const normalized = normalizeIdentifierCase(source);
+
+    assert.equal(normalized.leadingUnderscores, "__");
+    assert.equal(normalized.trailingUnderscores, "__");
+    const camel = formatIdentifierCase(normalized, "camel");
+    assert.equal(camel, source);
+
+    const pascal = formatIdentifierCase(normalized, "pascal");
+    assert.equal(pascal.startsWith(normalized.leadingUnderscores), true);
+    assert.equal(pascal.endsWith(normalized.trailingUnderscores), true);
+    assert.equal(
+        pascal.slice(
+            normalized.leadingUnderscores.length,
+            pascal.length - normalized.trailingUnderscores.length
+        ),
+        "HpMax"
+    );
+});
+
+test("mixed alphanumeric identifiers join digits intelligently in snake cases", () => {
+    const normalized = normalizeIdentifierCase("hp2DMax");
+
+    assert.equal(formatIdentifierCase(normalized, "camel"), "hp2DMax");
+    assert.equal(formatIdentifierCase(normalized, "pascal"), "Hp2DMax");
+    assert.equal(formatIdentifierCase(normalized, "snake-lower"), "hp2d_max");
+    assert.equal(formatIdentifierCase(normalized, "snake-upper"), "HP2D_MAX");
+});
+
+test("reserved prefixes from the reference list remain untouched", () => {
+    for (const prefix of RESERVED_IDENTIFIER_PREFIXES) {
+        const identifier = `${prefix}exampleValue`;
+        const camel = formatIdentifierCase(identifier, "camel");
+        assert.equal(camel.startsWith(prefix), true);
+    }
+
+    const bracketed = formatIdentifierCase("argument[1].hp_max", "camel");
+    assert.equal(bracketed, "argument[1].hpMax");
+});
+
+test("idempotence checks report already compliant identifiers", () => {
+    assert.equal(isIdentifierCase("hpMax", "camel"), true);
+    assert.equal(isIdentifierCase("HpMax", "pascal"), true);
+    assert.equal(isIdentifierCase("hp_max", "snake-lower"), true);
+    assert.equal(isIdentifierCase("HP_MAX", "snake-upper"), true);
+
+    assert.equal(isIdentifierCase("hp_max", "camel"), false);
+});
+
+test("numeric suffixes remain attached regardless of case", () => {
+    const normalized = normalizeIdentifierCase("self.hp_value99");
+
+    assert.equal(normalized.prefix, "self.");
+    assert.equal(formatIdentifierCase(normalized, "camel"), "self.hpValue99");
+    assert.equal(formatIdentifierCase(normalized, "pascal"), "self.HpValue99");
+    assert.equal(formatIdentifierCase(normalized, "snake-lower"), "self.hp_value99");
+});


### PR DESCRIPTION
## Summary
- add a shared identifier-case normalizer that preserves prefixes, underscores, and numeric suffixes while emitting camel, pascal, and snake variants
- document the reserved prefixes and normalisation workflow for the new utility
- cover the helper with unit tests spanning underscores, digits, reserved prefixes, and idempotence checks

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_68ead45bf210832faa5dfc04421036b9