### PR TITLE
Add identifier-case dry-run reporting utilities

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -46,6 +46,7 @@ import {
     getSingleVariableDeclarator,
     isUndefinedLiteral
 } from "../../../shared/ast-node-helpers.js";
+import { maybeReportIdentifierCaseDryRun } from "../reporting/identifier-case-report.js";
 
 const LOGICAL_OPERATOR_STYLE_KEYWORDS = "keywords";
 const LOGICAL_OPERATOR_STYLE_SYMBOLS = "symbols";
@@ -85,6 +86,7 @@ export function print(path, options, print) {
 
     switch (node.type) {
         case "Program": {
+            maybeReportIdentifierCaseDryRun(options);
             if (node.body.length === 0) {
                 return concat(printDanglingCommentsAsGroup(path, options));
             }

--- a/src/plugin/src/reporting/identifier-case-context.js
+++ b/src/plugin/src/reporting/identifier-case-context.js
@@ -1,0 +1,48 @@
+const contextMap = new Map();
+
+function normaliseKey(filepath) {
+    if (typeof filepath !== "string" || filepath.length === 0) {
+        return "<default>";
+    }
+
+    return filepath;
+}
+
+export function setIdentifierCaseDryRunContext({
+    filepath = null,
+    renamePlan = null,
+    conflicts = [],
+    dryRun = true,
+    logFilePath = null,
+    logger = null,
+    diagnostics = null,
+    fsFacade = null,
+    now = null
+} = {}) {
+    const key = normaliseKey(filepath);
+    contextMap.set(key, {
+        renamePlan,
+        conflicts,
+        dryRun,
+        logFilePath,
+        logger,
+        diagnostics,
+        fsFacade,
+        now
+    });
+}
+
+export function consumeIdentifierCaseDryRunContext(filepath = null) {
+    const key = normaliseKey(filepath);
+    if (!contextMap.has(key)) {
+        return null;
+    }
+
+    const context = contextMap.get(key);
+    contextMap.delete(key);
+    return context;
+}
+
+export function clearIdentifierCaseDryRunContexts() {
+    contextMap.clear();
+}

--- a/src/plugin/src/reporting/identifier-case-report.js
+++ b/src/plugin/src/reporting/identifier-case-report.js
@@ -1,0 +1,617 @@
+// reporting/identifier-case-report.js
+
+import path from "node:path";
+import {
+    mkdirSync as nodeMkdirSync,
+    writeFileSync as nodeWriteFileSync
+} from "node:fs";
+
+import { consumeIdentifierCaseDryRunContext } from "./identifier-case-context.js";
+
+const REPORT_NAMESPACE = "gml-identifier-case";
+const LOG_VERSION = 1;
+
+const defaultFsFacade = Object.freeze({
+    mkdirSync(targetPath) {
+        nodeMkdirSync(targetPath, { recursive: true });
+    },
+    writeFileSync(targetPath, contents) {
+        nodeWriteFileSync(targetPath, contents, "utf8");
+    }
+});
+
+const defaultNow = () => Date.now();
+
+function normalizeString(value) {
+    if (typeof value !== "string") {
+        return "";
+    }
+
+    return value.trim();
+}
+
+function extractOperations(plan) {
+    if (!plan) {
+        return [];
+    }
+
+    if (Array.isArray(plan)) {
+        return plan;
+    }
+
+    if (Array.isArray(plan.operations)) {
+        return plan.operations;
+    }
+
+    if (Array.isArray(plan.renames)) {
+        return plan.renames;
+    }
+
+    return [];
+}
+
+function toArray(value) {
+    if (!value) {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        return value;
+    }
+
+    return [value];
+}
+
+function normalizeReference(reference) {
+    if (!reference || typeof reference !== "object") {
+        return null;
+    }
+
+    const filePath = normalizeString(
+        reference.filePath ?? reference.path ?? reference.file ?? ""
+    );
+
+    if (!filePath) {
+        return null;
+    }
+
+    const occurrenceCandidate =
+    reference.occurrences ?? reference.count ?? reference.references ?? 0;
+    const occurrences = Number.isFinite(occurrenceCandidate)
+        ? Number(occurrenceCandidate)
+        : 0;
+
+    return {
+        filePath,
+        occurrences: occurrences > 0 ? occurrences : 0
+    };
+}
+
+function normalizeScope(scope) {
+    if (!scope || typeof scope !== "object") {
+        return { id: null, displayName: null, name: null };
+    }
+
+    const displayName = normalizeString(
+        scope.displayName ?? scope.name ?? scope.scope ?? scope.path ?? ""
+    );
+    const id = normalizeString(scope.id ?? scope.scopeId ?? "");
+
+    return {
+        id: id || null,
+        displayName: displayName || null,
+        name: normalizeString(scope.name ?? "") || null
+    };
+}
+
+function normalizeOperation(rawOperation) {
+    if (!rawOperation || typeof rawOperation !== "object") {
+        return null;
+    }
+
+    const scope = normalizeScope(rawOperation.scope ?? {});
+
+    const fromName = normalizeString(
+        rawOperation.from?.name ??
+      rawOperation.source?.name ??
+      rawOperation.originalName ??
+      rawOperation.from ??
+      rawOperation.source ??
+      ""
+    );
+    const toName = normalizeString(
+        rawOperation.to?.name ??
+      rawOperation.target?.name ??
+      rawOperation.updatedName ??
+      rawOperation.to ??
+      rawOperation.target ??
+      ""
+    );
+
+    const references = toArray(rawOperation.references)
+        .map(normalizeReference)
+        .filter(Boolean)
+        .sort((a, b) => a.filePath.localeCompare(b.filePath));
+
+    const occurrenceCount = references.reduce(
+        (total, reference) => total + (reference.occurrences ?? 0),
+        0
+    );
+
+    const referenceFileCount = new Set(
+        references.map((reference) => reference.filePath)
+    ).size;
+
+    return {
+        id:
+      normalizeString(rawOperation.id ?? rawOperation.identifier ?? "") || null,
+        kind:
+      normalizeString(rawOperation.kind ?? rawOperation.type ?? "") ||
+      "identifier",
+        scopeId: scope.id,
+        scopeName: scope.displayName ?? scope.name ?? null,
+        fromName: fromName || null,
+        toName: toName || null,
+        references,
+        occurrenceCount,
+        referenceFileCount
+    };
+}
+
+function normalizeConflict(rawConflict) {
+    if (!rawConflict || typeof rawConflict !== "object") {
+        return null;
+    }
+
+    const scope = normalizeScope(rawConflict.scope ?? {});
+    const severityCandidate = normalizeString(rawConflict.severity ?? "");
+    const severity = severityCandidate
+        ? severityCandidate.toLowerCase()
+        : "error";
+
+    const suggestions = toArray(rawConflict.suggestions ?? rawConflict.hints)
+        .map((entry) => normalizeString(entry))
+        .filter(Boolean);
+
+    return {
+        code:
+      normalizeString(
+          rawConflict.code ?? rawConflict.identifier ?? rawConflict.type ?? ""
+      ) || null,
+        message:
+      normalizeString(rawConflict.message ?? rawConflict.reason ?? "") || "",
+        severity,
+        scope: {
+            id: scope.id,
+            displayName: scope.displayName ?? scope.name ?? null
+        },
+        identifier:
+      normalizeString(
+          rawConflict.identifier ??
+          rawConflict.name ??
+          rawConflict.originalName ??
+          ""
+      ) || null,
+        suggestions,
+        details:
+      rawConflict.details && typeof rawConflict.details === "object"
+          ? { ...rawConflict.details }
+          : null
+    };
+}
+
+function sortOperations(operations) {
+    return operations.slice().sort((left, right) => {
+        const scopeCompare = (left.scopeName ?? "").localeCompare(
+            right.scopeName ?? ""
+        );
+        if (scopeCompare !== 0) {
+            return scopeCompare;
+        }
+
+        const fromCompare = (left.fromName ?? "").localeCompare(
+            right.fromName ?? ""
+        );
+        if (fromCompare !== 0) {
+            return fromCompare;
+        }
+
+        return (left.toName ?? "").localeCompare(right.toName ?? "");
+    });
+}
+
+function sortConflicts(conflicts) {
+    const severityOrder = new Map([
+        ["error", 0],
+        ["warning", 1],
+        ["info", 2]
+    ]);
+
+    return conflicts.slice().sort((left, right) => {
+        const severityA = severityOrder.get(left.severity) ?? 99;
+        const severityB = severityOrder.get(right.severity) ?? 99;
+        if (severityA !== severityB) {
+            return severityA - severityB;
+        }
+
+        const scopeCompare = (left.scope.displayName ?? "").localeCompare(
+            right.scope.displayName ?? ""
+        );
+        if (scopeCompare !== 0) {
+            return scopeCompare;
+        }
+
+        return left.message.localeCompare(right.message);
+    });
+}
+
+function pluralize(value, suffix = "s") {
+    return value === 1 ? "" : suffix;
+}
+
+export function summarizeIdentifierCasePlan({
+    renamePlan,
+    conflicts = []
+} = {}) {
+    const normalizedOperations = sortOperations(
+        extractOperations(renamePlan).map(normalizeOperation).filter(Boolean)
+    );
+
+    const normalizedConflicts = sortConflicts(
+        toArray(conflicts).map(normalizeConflict).filter(Boolean)
+    );
+
+    const impactedFileSet = new Set();
+    let totalReferenceCount = 0;
+
+    for (const operation of normalizedOperations) {
+        for (const reference of operation.references) {
+            impactedFileSet.add(reference.filePath);
+            totalReferenceCount += reference.occurrences ?? 0;
+        }
+    }
+
+    const severityCounts = new Map();
+    for (const conflict of normalizedConflicts) {
+        const severity = conflict.severity ?? "info";
+        severityCounts.set(severity, (severityCounts.get(severity) ?? 0) + 1);
+    }
+
+    const summary = {
+        renameCount: normalizedOperations.length,
+        impactedFileCount: impactedFileSet.size,
+        totalReferenceCount,
+        conflictCount: normalizedConflicts.length,
+        severityCounts: Object.fromEntries(severityCounts.entries())
+    };
+
+    return {
+        summary,
+        operations: normalizedOperations,
+        conflicts: normalizedConflicts
+    };
+}
+
+export function formatIdentifierCaseSummaryText(report) {
+    if (!report) {
+        return [];
+    }
+
+    const { summary, operations, conflicts } = report;
+    const lines = [];
+
+    lines.push(`[${REPORT_NAMESPACE}] Identifier case dry-run summary:`);
+
+    const renameDetails =
+    summary.renameCount > 0
+        ? ` (${summary.totalReferenceCount} reference${pluralize(
+            summary.totalReferenceCount
+        )} across ${summary.impactedFileCount} file${pluralize(
+            summary.impactedFileCount
+        )})`
+        : "";
+    lines.push(`  Planned renames: ${summary.renameCount}${renameDetails}`);
+
+    if (summary.conflictCount > 0) {
+        const severityParts = Object.entries(summary.severityCounts)
+            .filter(([, count]) => count > 0)
+            .map(([severity, count]) => `${count} ${severity}${pluralize(count)}`);
+
+        const conflictSuffix =
+      severityParts.length > 0 ? ` (${severityParts.join(", ")})` : "";
+        lines.push(`  Conflicts: ${summary.conflictCount}${conflictSuffix}`);
+    } else {
+        lines.push("  Conflicts: none");
+    }
+
+    if (operations.length > 0) {
+        lines.push("");
+        lines.push("Rename plan:");
+
+        for (const operation of operations) {
+            const referenceSummary =
+        operation.occurrenceCount > 0
+            ? ` (${operation.occurrenceCount} reference${pluralize(
+                operation.occurrenceCount
+            )} across ${operation.referenceFileCount} file${pluralize(
+                operation.referenceFileCount
+            )})`
+            : "";
+
+            const scopeName =
+        operation.scopeName ?? operation.scopeId ?? "<unknown scope>";
+            const fromName = operation.fromName ?? "<unknown>";
+            const toName = operation.toName ?? "<unknown>";
+
+            lines.push(
+                `  - ${scopeName}: ${fromName} -> ${toName}${referenceSummary}`
+            );
+
+            for (const reference of operation.references) {
+                const referenceSuffix =
+          reference.occurrences > 0
+              ? ` (${reference.occurrences} reference${pluralize(
+                  reference.occurrences
+              )})`
+              : "";
+                lines.push(`      • ${reference.filePath}${referenceSuffix}`);
+            }
+        }
+    }
+
+    if (conflicts.length > 0) {
+        lines.push("");
+        lines.push("Conflicts:");
+
+        for (const conflict of conflicts) {
+            const scopeName =
+        conflict.scope.displayName ?? conflict.scope.id ?? "<unknown scope>";
+            const identifierSuffix = conflict.identifier
+                ? ` (${conflict.identifier})`
+                : "";
+            const codeSuffix = conflict.code ? ` [${conflict.code}]` : "";
+            lines.push(
+                `  - [${conflict.severity}]${codeSuffix} ${scopeName}${identifierSuffix}: ${conflict.message}`
+            );
+
+            if (conflict.suggestions.length > 0) {
+                lines.push(`      Suggestions: ${conflict.suggestions.join(", ")}`);
+            }
+        }
+    }
+
+    return lines;
+}
+
+function buildLogPayload(report, generatedAt) {
+    const { summary, operations, conflicts } = report;
+
+    return {
+        version: LOG_VERSION,
+        generatedAt,
+        summary: {
+            renameCount: summary.renameCount,
+            impactedFileCount: summary.impactedFileCount,
+            totalReferenceCount: summary.totalReferenceCount,
+            conflictCount: summary.conflictCount,
+            severityCounts: { ...summary.severityCounts }
+        },
+        renames: operations.map((operation) => ({
+            id: operation.id,
+            kind: operation.kind,
+            scope: {
+                id: operation.scopeId,
+                displayName: operation.scopeName
+            },
+            from: {
+                name: operation.fromName
+            },
+            to: {
+                name: operation.toName
+            },
+            referenceCount: operation.occurrenceCount,
+            references: operation.references.map((reference) => ({
+                filePath: reference.filePath,
+                occurrences: reference.occurrences
+            }))
+        })),
+        conflicts: conflicts.map((conflict) => ({
+            code: conflict.code,
+            message: conflict.message,
+            severity: conflict.severity,
+            scope: conflict.scope,
+            identifier: conflict.identifier,
+            suggestions: conflict.suggestions,
+            details: conflict.details
+        }))
+    };
+}
+
+function pushDiagnosticEntry({ diagnostics, report, text }) {
+    if (!Array.isArray(diagnostics)) {
+        return;
+    }
+
+    const severity = report.conflicts.some(
+        (conflict) => conflict.severity === "error"
+    )
+        ? "error"
+        : report.conflicts.some((conflict) => conflict.severity === "warning")
+            ? "warning"
+            : "info";
+
+    diagnostics.push({
+        code: `${REPORT_NAMESPACE}-summary`,
+        severity,
+        message: text,
+        summary: {
+            ...report.summary
+        },
+        renames: report.operations.map((operation) => ({
+            id: operation.id,
+            kind: operation.kind,
+            scopeId: operation.scopeId,
+            scopeName: operation.scopeName,
+            fromName: operation.fromName,
+            toName: operation.toName,
+            referenceCount: operation.occurrenceCount,
+            references: operation.references.map((reference) => ({
+                filePath: reference.filePath,
+                occurrences: reference.occurrences
+            }))
+        })),
+        conflicts: report.conflicts.map((conflict) => ({
+            code: conflict.code,
+            message: conflict.message,
+            severity: conflict.severity,
+            scope: conflict.scope,
+            identifier: conflict.identifier,
+            suggestions: conflict.suggestions,
+            details: conflict.details
+        }))
+    });
+}
+
+export function reportIdentifierCasePlan({
+    renamePlan,
+    conflicts = [],
+    logger = console,
+    diagnostics = null,
+    logFilePath = null,
+    fsFacade = defaultFsFacade,
+    now = defaultNow
+} = {}) {
+    const report = summarizeIdentifierCasePlan({
+        renamePlan,
+        conflicts
+    });
+
+    const lines = formatIdentifierCaseSummaryText(report);
+    const textBlock = lines.join("\n");
+
+    if (typeof logger?.log === "function") {
+        logger.log(textBlock);
+    } else {
+        console.log(textBlock);
+    }
+
+    pushDiagnosticEntry({ diagnostics, report, text: textBlock });
+
+    if (logFilePath) {
+        try {
+            const payload = buildLogPayload(report, new Date(now()).toISOString());
+            const directory = path.dirname(logFilePath);
+            if (fsFacade?.mkdirSync) {
+                fsFacade.mkdirSync(directory, { recursive: true });
+            }
+            if (fsFacade?.writeFileSync) {
+                fsFacade.writeFileSync(
+                    logFilePath,
+                    `${JSON.stringify(payload, null, 2)}\n`
+                );
+            }
+        } catch (error) {
+            if (typeof logger?.warn === "function") {
+                logger.warn(
+                    `[${REPORT_NAMESPACE}] Failed to write identifier case report: ${
+                        error?.message ?? error
+                    }`
+                );
+            }
+        }
+    }
+
+    return report;
+}
+
+export function maybeReportIdentifierCaseDryRun(options) {
+    if (!options || options.__identifierCaseReportEmitted) {
+        return null;
+    }
+
+    const planFromOptions =
+    options.__identifierCaseRenamePlan ??
+    options.identifierCaseRenamePlan ??
+    null;
+
+    let context;
+    if (planFromOptions) {
+        context = {
+            renamePlan: planFromOptions,
+            conflicts:
+        options.__identifierCaseConflicts ??
+        options.identifierCaseConflicts ??
+        [],
+            dryRun: options.__identifierCaseDryRun !== false,
+            logFilePath: options.__identifierCaseReportLogPath ?? null,
+            logger: options.logger ?? null,
+            diagnostics: Array.isArray(options.diagnostics)
+                ? options.diagnostics
+                : null,
+            fsFacade: options.__identifierCaseFs ?? options.identifierCaseFs ?? null,
+            now:
+        typeof options.__identifierCaseNow === "function"
+            ? options.__identifierCaseNow
+            : null
+        };
+    } else {
+        context = consumeIdentifierCaseDryRunContext(options.filepath ?? null);
+    }
+
+    if (!context) {
+        return null;
+    }
+
+    const {
+        renamePlan,
+        conflicts = [],
+        dryRun = options.__identifierCaseDryRun !== false,
+        logFilePath = null,
+        logger = null,
+        diagnostics = null,
+        fsFacade = null,
+        now = null
+    } = context;
+
+    if (!renamePlan) {
+        options.__identifierCaseReportEmitted = true;
+        return null;
+    }
+
+    if (dryRun === false) {
+        options.__identifierCaseReportEmitted = true;
+        return null;
+    }
+
+    const effectiveLogger = logger ?? options.logger ?? console;
+    const effectiveDiagnostics =
+    diagnostics ??
+    (Array.isArray(options.diagnostics) ? options.diagnostics : null);
+    const effectiveLogPath =
+    logFilePath ?? options.__identifierCaseReportLogPath ?? null;
+    const effectiveFs =
+    fsFacade ??
+    options.__identifierCaseFs ??
+    options.identifierCaseFs ??
+    defaultFsFacade;
+    const effectiveNow =
+    now ??
+    (typeof options.__identifierCaseNow === "function"
+        ? options.__identifierCaseNow
+        : defaultNow);
+
+    const result = reportIdentifierCasePlan({
+        renamePlan,
+        conflicts,
+        logger: effectiveLogger,
+        diagnostics: effectiveDiagnostics,
+        logFilePath: effectiveLogPath,
+        fsFacade: effectiveFs,
+        now: effectiveNow
+    });
+
+    options.__identifierCaseReportEmitted = true;
+    options.__identifierCaseReportResult = result;
+
+    return result;
+}

--- a/src/plugin/tests/identifier-case-report.test.js
+++ b/src/plugin/tests/identifier-case-report.test.js
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import prettier from "prettier";
+
+import {
+    setIdentifierCaseDryRunContext,
+    clearIdentifierCaseDryRunContexts
+} from "../src/reporting/identifier-case-context.js";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+
+function createSampleRenamePlan() {
+    return {
+        operations: [
+            {
+                id: "rename-calc-damage",
+                kind: "identifier",
+                scope: {
+                    id: "scope:script:attack",
+                    displayName: "script.attack"
+                },
+                from: { name: "calc_damage" },
+                to: { name: "calcDamage" },
+                references: [
+                    {
+                        filePath: "scripts/attack/attack.gml",
+                        occurrences: 1
+                    },
+                    {
+                        filePath: "objects/obj_enemy/obj_enemy_Create_0.gml",
+                        occurrences: 2
+                    }
+                ]
+            },
+            {
+                id: "rename-macro-cap",
+                kind: "macro",
+                scope: {
+                    id: "scope:macro:damage_cap",
+                    displayName: "macro.damage_cap"
+                },
+                from: { name: "damage_cap" },
+                to: { name: "DAMAGE_CAP" },
+                references: [
+                    {
+                        filePath: "scripts/attack/attack.gml",
+                        occurrences: 1
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+function createSampleConflicts() {
+    return [
+        {
+            code: "collision",
+            severity: "error",
+            message: "calcDamage already exists in script.attack",
+            scope: {
+                id: "scope:script:attack",
+                displayName: "script.attack"
+            },
+            identifier: "calc_damage",
+            suggestions: ["calcDamageAlt"]
+        },
+        {
+            code: "ignored",
+            severity: "warning",
+            message: "damage_cap preserved by configuration",
+            scope: {
+                id: "scope:macro:damage_cap",
+                displayName: "macro.damage_cap"
+            },
+            identifier: "damage_cap"
+        }
+    ];
+}
+
+async function formatWithReporter({
+    source,
+    renamePlan,
+    conflicts,
+    dryRun,
+    diagnostics,
+    logPath,
+    logger,
+    filepath
+}) {
+    setIdentifierCaseDryRunContext({
+        filepath,
+        renamePlan,
+        conflicts,
+        dryRun,
+        logFilePath: logPath,
+        logger,
+        diagnostics
+    });
+
+    return prettier.format(source, {
+        parser: "gml-parse",
+        plugins: [pluginPath],
+        filepath,
+        diagnostics,
+        logger
+    });
+}
+
+describe("identifier case reporting", () => {
+    it("emits a dry-run summary and diagnostic report", async () => {
+        const renamePlan = createSampleRenamePlan();
+        const conflicts = createSampleConflicts();
+        const diagnostics = [];
+        const messages = [];
+        const logger = {
+            log(message) {
+                messages.push(message);
+            },
+            warn(message) {
+                messages.push(`WARN: ${message}`);
+            }
+        };
+
+        const tempRoot = await fs.mkdtemp(
+            path.join(os.tmpdir(), "gml-identifier-report-")
+        );
+        const logPath = path.join(tempRoot, "logs", "identifier-case.json");
+        const filePath = path.join(tempRoot, "scripts", "attack", "attack.gml");
+
+        try {
+            const formatted = await formatWithReporter({
+                source:
+          "function attack(target) {\n    return calc_damage(target);\n}\n",
+                renamePlan,
+                conflicts,
+                dryRun: true,
+                diagnostics,
+                logPath,
+                logger,
+                filepath: filePath
+            });
+
+            assert.match(formatted, /function attack\(target\)/);
+            assert.ok(
+                messages.length > 0,
+                "expected dry-run reporter to emit console output"
+            );
+
+            const joinedMessages = messages.join("\n");
+            assert.match(joinedMessages, /Identifier case dry-run summary/);
+            assert.match(
+                joinedMessages,
+                /Planned renames: 2 \(4 references across 2 files\)/i
+            );
+            assert.match(joinedMessages, /Conflicts: 2 \(1 error, 1 warning\)/i);
+            assert.match(joinedMessages, /script\.attack: calc_damage -> calcDamage/);
+            assert.match(
+                joinedMessages,
+                /macro\.damage_cap: damage_cap -> DAMAGE_CAP/
+            );
+            assert.match(joinedMessages, /\[error\]\s*\[collision\]/i);
+
+            assert.equal(diagnostics.length, 1);
+            const diagnostic = diagnostics[0];
+            assert.equal(
+                diagnostic.code,
+                "gml-identifier-case-summary",
+                "expected diagnostic code to be namespaced"
+            );
+            assert.equal(diagnostic.summary.renameCount, 2);
+            assert.equal(diagnostic.summary.conflictCount, 2);
+            assert.equal(diagnostic.renames.length, 2);
+            assert.equal(diagnostic.conflicts.length, 2);
+
+            const logContents = await fs.readFile(logPath, "utf8");
+            const parsedLog = JSON.parse(logContents);
+
+            assert.equal(parsedLog.version, 1);
+            assert.equal(parsedLog.summary.renameCount, 2);
+            assert.equal(parsedLog.summary.conflictCount, 2);
+            assert.equal(parsedLog.renames.length, 2);
+            assert.equal(parsedLog.conflicts.length, 2);
+            assert.ok(
+                Array.isArray(parsedLog.renames[0].references),
+                "expected log to include reference metadata"
+            );
+        } finally {
+            clearIdentifierCaseDryRunContexts();
+            await fs.rm(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    it("skips reporting when write mode is enabled", async () => {
+        const renamePlan = createSampleRenamePlan();
+        const conflicts = createSampleConflicts();
+        const diagnostics = [];
+        const messages = [];
+        const logger = {
+            log(message) {
+                messages.push(message);
+            }
+        };
+
+        try {
+            const formatted = await formatWithReporter({
+                source:
+          "function attack(target) {\n    return calc_damage(target);\n}\n",
+                renamePlan,
+                conflicts,
+                dryRun: false,
+                diagnostics,
+                logPath: null,
+                logger,
+                filepath: path.join(os.tmpdir(), "dry-run-write-mode", "attack.gml")
+            });
+
+            assert.match(formatted, /function attack\(target\)/);
+            assert.equal(messages.length, 0, "did not expect dry-run summary");
+            assert.equal(diagnostics.length, 0);
+        } finally {
+            clearIdentifierCaseDryRunContexts();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add a dry-run context helper to capture identifier-case rename plans for each file
- implement a reporter that summarizes renames/conflicts, emits diagnostics, and can write JSON logs
- invoke the reporter during Program printing and cover the flow with targeted unit tests

## Testing
- node --test src/plugin/tests/identifier-case-report.test.js

------
https://chatgpt.com/codex/tasks/task_e_68eadc4fe7d0832fb4b3a478c2a87f7d