### PR TITLE
Add local identifier renaming pipeline and tests

### DIFF
--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -1,0 +1,500 @@
+import path from "node:path";
+
+import { formatIdentifierCase } from "../../../shared/identifier-case.js";
+import { normalizeIdentifierCaseOptions } from "../options/identifier-case.js";
+import { peekIdentifierCaseDryRunContext } from "../reporting/identifier-case-context.js";
+
+const COLLISION_CONFLICT_CODE = "collision";
+const PRESERVE_CONFLICT_CODE = "preserve";
+const IGNORE_CONFLICT_CODE = "ignored";
+
+function toPosixPath(filePath) {
+    if (typeof filePath !== "string" || filePath.length === 0) {
+        return "";
+    }
+
+    return filePath.replace(/\\+/g, "/");
+}
+
+function resolveRelativeFilePath(projectRoot, absoluteFilePath) {
+    if (typeof absoluteFilePath !== "string" || absoluteFilePath.length === 0) {
+        return null;
+    }
+
+    const resolvedFile = path.resolve(absoluteFilePath);
+
+    if (typeof projectRoot === "string" && projectRoot.length > 0) {
+        const resolvedRoot = path.resolve(projectRoot);
+        return toPosixPath(path.relative(resolvedRoot, resolvedFile));
+    }
+
+    return toPosixPath(resolvedFile);
+}
+
+function buildLocationKey(location) {
+    if (!location || typeof location !== "object") {
+        return null;
+    }
+
+    const line = location.line ?? location.row ?? location.start ?? null;
+    const column =
+    location.column ?? location.col ?? location.columnStart ?? null;
+    const index = location.index ?? location.offset ?? null;
+
+    if (line == null && column == null && index == null) {
+        return null;
+    }
+
+    return [line ?? "", column ?? "", index ?? ""].join(":");
+}
+
+function buildRenameKey(_scopeId, location) {
+    const locationKey = buildLocationKey(location);
+    if (!locationKey) {
+        return null;
+    }
+
+    return locationKey;
+}
+
+function createScopeGroupingKey(scopeId, fallback) {
+    if (scopeId && typeof scopeId === "string") {
+        return scopeId;
+    }
+
+    return fallback ?? "<unknown>";
+}
+
+function createScopeDescriptor(projectIndex, fileRecord, scopeId) {
+    const fileScopeId = fileRecord?.scopeId ?? null;
+    const scopeMap = projectIndex?.scopes ?? {};
+
+    if (scopeId && scopeMap[scopeId]) {
+        const scopeRecord = scopeMap[scopeId];
+        return {
+            id: scopeRecord.id,
+            displayName:
+        scopeRecord.displayName ?? scopeRecord.name ?? scopeRecord.id
+        };
+    }
+
+    if (fileScopeId && scopeMap[fileScopeId]) {
+        const parentScope = scopeMap[fileScopeId];
+        return {
+            id:
+        scopeId ??
+        parentScope.id ??
+        `locals:${fileRecord?.filePath ?? "<unknown>"}`,
+            displayName: `${parentScope.displayName ?? parentScope.name ?? fileRecord?.filePath ?? "<locals>"} (locals)`
+        };
+    }
+
+    const filePath = fileRecord?.filePath ?? "<unknown>";
+    return {
+        id: scopeId ?? `locals:${filePath}`,
+        displayName: `locals@${filePath}`
+    };
+}
+
+function escapeForRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function createPatternRegExp(pattern) {
+    if (typeof pattern !== "string" || pattern.length === 0) {
+        return null;
+    }
+
+    const escaped = escapeForRegExp(pattern.trim());
+    if (!escaped) {
+        return null;
+    }
+
+    const wildcardExpanded = escaped.replace(/\\\*/g, ".*").replace(/\\\?/g, ".");
+
+    return new RegExp(`^${wildcardExpanded}$`, "i");
+}
+
+function buildPatternMatchers(patterns) {
+    const matchers = [];
+
+    for (const pattern of patterns ?? []) {
+        const regexp = createPatternRegExp(pattern);
+        if (!regexp) {
+            continue;
+        }
+
+        matchers.push({ raw: pattern, regexp });
+    }
+
+    return matchers;
+}
+
+function matchesIgnorePattern(matchers, identifierName, filePath) {
+    if (!Array.isArray(matchers) || matchers.length === 0) {
+        return null;
+    }
+
+    const name = identifierName ?? "";
+    const file = filePath ?? "";
+
+    for (const matcher of matchers) {
+        if (matcher.regexp.test(name) || matcher.regexp.test(file)) {
+            return matcher.raw;
+        }
+    }
+
+    return null;
+}
+
+function createConflict({
+    code,
+    severity,
+    message,
+    scope,
+    identifier,
+    suggestions = []
+}) {
+    return {
+        code,
+        severity,
+        message,
+        scope,
+        identifier,
+        suggestions
+    };
+}
+
+function summarizeReferencesByFile(relativeFilePath, references) {
+    const counts = new Map();
+
+    for (const reference of references ?? []) {
+        const filePath = reference?.filePath ?? relativeFilePath;
+        const key = filePath ?? "<unknown>";
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    return Array.from(counts.entries()).map(([filePath, occurrences]) => ({
+        filePath,
+        occurrences
+    }));
+}
+
+export function prepareIdentifierCasePlan(options) {
+    if (!options) {
+        return;
+    }
+
+    if (options.__identifierCasePlanGeneratedInternally === true) {
+        return;
+    }
+
+    if (
+        options.__identifierCaseRenamePlan &&
+    options.__identifierCasePlanGeneratedInternally !== true
+    ) {
+        return;
+    }
+
+    const context = peekIdentifierCaseDryRunContext(options.filepath ?? null);
+    if (
+        options.__identifierCaseDryRun === undefined &&
+    context &&
+    typeof context.dryRun === "boolean"
+    ) {
+        options.__identifierCaseDryRun = context.dryRun;
+    }
+    const projectIndex =
+    options.__identifierCaseProjectIndex ??
+    options.identifierCaseProjectIndex ??
+    context?.projectIndex ??
+    null;
+
+    const normalizedOptions = normalizeIdentifierCaseOptions(options);
+    const localStyle = normalizedOptions.scopeStyles?.locals ?? "off";
+
+    if (!projectIndex || !projectIndex.files || localStyle === "off") {
+        return;
+    }
+
+    const relativeFilePath = resolveRelativeFilePath(
+        projectIndex.projectRoot,
+        options.filepath ?? null
+    );
+
+    if (!relativeFilePath || !projectIndex.files[relativeFilePath]) {
+        return;
+    }
+
+    const fileRecord = projectIndex.files[relativeFilePath];
+    const preservedSet = new Set(normalizedOptions.preservedIdentifiers ?? []);
+    const ignoreMatchers = buildPatternMatchers(
+        normalizedOptions.ignorePatterns ?? []
+    );
+
+    const renameMap = new Map();
+    const operations = [];
+    const conflicts = [];
+
+    const existingNamesByScope = new Map();
+    for (const declaration of fileRecord.declarations ?? []) {
+        if (!declaration || !declaration.name) {
+            continue;
+        }
+
+        const scopeKey = createScopeGroupingKey(
+            declaration.scopeId,
+            fileRecord.scopeId
+        );
+        const existing = existingNamesByScope.get(scopeKey) ?? new Set();
+        existing.add(declaration.name);
+        existingNamesByScope.set(scopeKey, existing);
+    }
+
+    const referencesByScopeAndName = new Map();
+    for (const reference of fileRecord.references ?? []) {
+        if (!reference || reference.isBuiltIn) {
+            continue;
+        }
+
+        const classifications = Array.isArray(reference.classifications)
+            ? reference.classifications
+            : [];
+
+        if (!classifications.includes("variable")) {
+            continue;
+        }
+
+        const scopeKey = createScopeGroupingKey(
+            reference.scopeId,
+            fileRecord.scopeId
+        );
+        const key = `${scopeKey}|${reference.name}`;
+        const list = referencesByScopeAndName.get(key) ?? [];
+        list.push({
+            ...reference,
+            filePath: relativeFilePath
+        });
+        referencesByScopeAndName.set(key, list);
+    }
+
+    const activeCandidates = [];
+
+    for (const declaration of fileRecord.declarations ?? []) {
+        if (!declaration || declaration.isBuiltIn) {
+            continue;
+        }
+
+        const classifications = Array.isArray(declaration.classifications)
+            ? declaration.classifications
+            : [];
+
+        if (!classifications.includes("variable")) {
+            continue;
+        }
+
+        if (classifications.includes("global")) {
+            continue;
+        }
+
+        const renameKey = buildRenameKey(declaration.scopeId, declaration.start);
+        if (!renameKey) {
+            continue;
+        }
+
+        const convertedName = formatIdentifierCase(declaration.name, localStyle);
+
+        if (convertedName === declaration.name) {
+            continue;
+        }
+
+        if (preservedSet.has(declaration.name)) {
+            const scopeDescriptor = createScopeDescriptor(
+                projectIndex,
+                fileRecord,
+                declaration.scopeId
+            );
+            conflicts.push(
+                createConflict({
+                    code: PRESERVE_CONFLICT_CODE,
+                    severity: "info",
+                    message: `Identifier '${declaration.name}' is preserved by configuration.`,
+                    scope: scopeDescriptor,
+                    identifier: declaration.name
+                })
+            );
+            continue;
+        }
+
+        const ignoreMatch = matchesIgnorePattern(
+            ignoreMatchers,
+            declaration.name,
+            relativeFilePath
+        );
+        if (ignoreMatch) {
+            const scopeDescriptor = createScopeDescriptor(
+                projectIndex,
+                fileRecord,
+                declaration.scopeId
+            );
+            conflicts.push(
+                createConflict({
+                    code: IGNORE_CONFLICT_CODE,
+                    severity: "info",
+                    message: `Identifier '${declaration.name}' matches ignore pattern '${ignoreMatch}'.`,
+                    scope: scopeDescriptor,
+                    identifier: declaration.name
+                })
+            );
+            continue;
+        }
+
+        const scopeGroupKey = createScopeGroupingKey(
+            declaration.scopeId,
+            fileRecord.scopeId
+        );
+        const existingNames = existingNamesByScope.get(scopeGroupKey) ?? new Set();
+
+        if (
+            existingNames.has(convertedName) &&
+      convertedName !== declaration.name
+        ) {
+            const scopeDescriptor = createScopeDescriptor(
+                projectIndex,
+                fileRecord,
+                declaration.scopeId
+            );
+            conflicts.push(
+                createConflict({
+                    code: COLLISION_CONFLICT_CODE,
+                    severity: "error",
+                    message: `Renaming '${declaration.name}' to '${convertedName}' collides with existing identifier '${convertedName}'.`,
+                    scope: scopeDescriptor,
+                    identifier: declaration.name
+                })
+            );
+            continue;
+        }
+        const referenceKey = `${scopeGroupKey}|${declaration.name}`;
+        const relatedReferences = referencesByScopeAndName.get(referenceKey) ?? [];
+
+        activeCandidates.push({
+            declaration,
+            convertedName,
+            references: relatedReferences,
+            scopeGroupKey
+        });
+    }
+
+    const candidatesByScope = new Map();
+    for (const candidate of activeCandidates) {
+        const scopeCandidates =
+      candidatesByScope.get(candidate.scopeGroupKey) ?? new Map();
+        const existing = scopeCandidates.get(candidate.convertedName) ?? [];
+        existing.push(candidate);
+        scopeCandidates.set(candidate.convertedName, existing);
+        candidatesByScope.set(candidate.scopeGroupKey, scopeCandidates);
+    }
+
+    const appliedCandidates = [];
+    for (const [, nameMap] of candidatesByScope.entries()) {
+        for (const [convertedName, groupedCandidates] of nameMap.entries()) {
+            if (groupedCandidates.length > 1) {
+                for (const candidate of groupedCandidates) {
+                    const scopeDescriptor = createScopeDescriptor(
+                        projectIndex,
+                        fileRecord,
+                        candidate.declaration.scopeId
+                    );
+                    const otherNames = groupedCandidates
+                        .filter((other) => other !== candidate)
+                        .map((other) => other.declaration.name);
+                    conflicts.push(
+                        createConflict({
+                            code: COLLISION_CONFLICT_CODE,
+                            severity: "error",
+                            message: `Renaming '${candidate.declaration.name}' to '${convertedName}' collides with ${otherNames
+                                .map((name) => `'${name}'`)
+                                .join(", ")}.`,
+                            scope: scopeDescriptor,
+                            identifier: candidate.declaration.name
+                        })
+                    );
+                }
+                continue;
+            }
+
+            appliedCandidates.push(groupedCandidates[0]);
+        }
+    }
+
+    for (const candidate of appliedCandidates) {
+        const { declaration, convertedName, references } = candidate;
+        const scopeDescriptor = createScopeDescriptor(
+            projectIndex,
+            fileRecord,
+            declaration.scopeId
+        );
+
+        const referenceSummaries = summarizeReferencesByFile(
+            relativeFilePath,
+            references
+        );
+
+        operations.push({
+            id: `local:${scopeDescriptor.id ?? candidate.scopeGroupKey}:${declaration.name}`,
+            kind: "identifier",
+            scope: {
+                id: scopeDescriptor.id,
+                displayName: scopeDescriptor.displayName
+            },
+            from: { name: declaration.name },
+            to: { name: convertedName },
+            references: referenceSummaries
+        });
+
+        const declarationKey = buildRenameKey(
+            declaration.scopeId,
+            declaration.start
+        );
+        if (declarationKey) {
+            renameMap.set(declarationKey, convertedName);
+        }
+
+        for (const reference of references) {
+            const referenceKey = buildRenameKey(reference.scopeId, reference.start);
+            if (referenceKey) {
+                renameMap.set(referenceKey, convertedName);
+            }
+        }
+    }
+
+    if (operations.length === 0 && conflicts.length === 0) {
+        options.__identifierCaseRenameMap = renameMap;
+        options.__identifierCasePlanGeneratedInternally = true;
+        return;
+    }
+
+    options.__identifierCaseRenamePlan = { operations };
+    options.__identifierCaseConflicts = conflicts;
+    options.__identifierCaseRenameMap = renameMap;
+    options.__identifierCasePlanGeneratedInternally = true;
+}
+
+export function getIdentifierCaseRenameForNode(node, options) {
+    if (!node || !options) {
+        return null;
+    }
+
+    const renameMap = options.__identifierCaseRenameMap;
+    if (!(renameMap instanceof Map)) {
+        return null;
+    }
+
+    const key = buildRenameKey(node.scopeId ?? null, node.start ?? null);
+    if (!key) {
+        return null;
+    }
+
+    return renameMap.get(key) ?? null;
+}

--- a/src/plugin/src/reporting/identifier-case-context.js
+++ b/src/plugin/src/reporting/identifier-case-context.js
@@ -17,7 +17,8 @@ export function setIdentifierCaseDryRunContext({
     logger = null,
     diagnostics = null,
     fsFacade = null,
-    now = null
+    now = null,
+    projectIndex = null
 } = {}) {
     const key = normaliseKey(filepath);
     contextMap.set(key, {
@@ -28,7 +29,8 @@ export function setIdentifierCaseDryRunContext({
         logger,
         diagnostics,
         fsFacade,
-        now
+        now,
+        projectIndex
     });
 }
 
@@ -41,6 +43,15 @@ export function consumeIdentifierCaseDryRunContext(filepath = null) {
     const context = contextMap.get(key);
     contextMap.delete(key);
     return context;
+}
+
+export function peekIdentifierCaseDryRunContext(filepath = null) {
+    const key = normaliseKey(filepath);
+    if (!contextMap.has(key)) {
+        return null;
+    }
+
+    return contextMap.get(key);
 }
 
 export function clearIdentifierCaseDryRunContexts() {

--- a/src/plugin/tests/identifier-case-fixtures/locals.gml
+++ b/src/plugin/tests/identifier-case-fixtures/locals.gml
@@ -1,0 +1,14 @@
+function demo(target) {
+    var counter_value = 1;
+    var preserve_me = 2;
+    var ignore_temp = 3;
+    var foo_bar = target;
+    var fooBar = target + counter_value;
+
+    counter_value += preserve_me;
+    counter_value += ignore_temp;
+    counter_value += foo_bar;
+    counter_value += fooBar;
+
+    return counter_value;
+}

--- a/src/plugin/tests/identifier-case-locals.integration.test.js
+++ b/src/plugin/tests/identifier-case-locals.integration.test.js
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import prettier from "prettier";
+
+import { buildProjectIndex } from "../../shared/project-index/index.js";
+import {
+    setIdentifierCaseDryRunContext,
+    clearIdentifierCaseDryRunContexts
+} from "../src/reporting/identifier-case-context.js";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+const fixturesDirectory = path.join(
+    currentDirectory,
+    "identifier-case-fixtures"
+);
+const localsFixturePath = path.join(fixturesDirectory, "locals.gml");
+
+async function createTempProject() {
+    const tempRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "gml-identifier-case-")
+    );
+
+    const writeFile = async (relativePath, contents) => {
+        const absolutePath = path.join(tempRoot, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, contents, "utf8");
+        return absolutePath;
+    };
+
+    await writeFile(
+        "MyGame.yyp",
+        JSON.stringify({ name: "MyGame", resourceType: "GMProject" })
+    );
+
+    await writeFile(
+        "scripts/demo/demo.yy",
+        JSON.stringify({
+            resourceType: "GMScript",
+            name: "demo"
+        })
+    );
+
+    const fixtureSource = await fs.readFile(localsFixturePath, "utf8");
+    const gmlPath = await writeFile("scripts/demo/demo.gml", fixtureSource);
+
+    const projectIndex = await buildProjectIndex(tempRoot);
+
+    return {
+        projectRoot: tempRoot,
+        fixtureSource,
+        gmlPath,
+        projectIndex
+    };
+}
+
+describe("identifier case local renaming", () => {
+    it("reports planned renames and conflicts during dry-run", async () => {
+        const { projectRoot, fixtureSource, gmlPath, projectIndex } =
+      await createTempProject();
+
+        const consoleMessages = [];
+        const originalConsoleLog = console.log;
+
+        try {
+            clearIdentifierCaseDryRunContexts();
+            setIdentifierCaseDryRunContext({
+                filepath: gmlPath,
+                projectIndex,
+                dryRun: true
+            });
+            const diagnostics = [];
+            const messages = [];
+            const logger = {
+                log(message) {
+                    messages.push(message);
+                }
+            };
+            console.log = function (...args) {
+                consoleMessages.push(args.join(" "));
+                return originalConsoleLog.apply(this, args);
+            };
+
+            const formatOptions = {
+                plugins: [pluginPath],
+                parser: "gml-parse",
+                filepath: gmlPath,
+                gmlIdentifierCase: "camel",
+                gmlIdentifierCaseAssets: "off",
+                gmlIdentifierCaseIgnore: "ignore*",
+                gmlIdentifierCasePreserve: "preserve_me",
+                __identifierCaseProjectIndex: projectIndex,
+                __identifierCaseDryRun: true,
+                diagnostics,
+                logger
+            };
+
+            const formatted = await prettier.format(fixtureSource, formatOptions);
+
+            assert.ok(
+                formatted.includes("counter_value"),
+                "Dry-run should not rewrite identifiers in the source"
+            );
+            assert.ok(
+                !formatted.includes("counterValue"),
+                "Dry-run should not apply rename targets"
+            );
+
+            const combinedMessages = messages.length > 0 ? messages : consoleMessages;
+            assert.ok(
+                combinedMessages.length > 0,
+                "Expected reporting output to be logged"
+            );
+            const summaryText = combinedMessages.join("\n");
+            assert.match(summaryText, /Planned renames: 1/);
+            assert.match(summaryText, /Conflicts: 3/);
+            assert.match(summaryText, /counter_value -> counterValue/);
+
+            const codes = new Set();
+            if (Array.isArray(diagnostics) && diagnostics.length > 0) {
+                const summaryDiagnostic = diagnostics.find(
+                    (entry) => entry?.code === "gml-identifier-case-summary"
+                );
+                if (summaryDiagnostic) {
+                    assert.strictEqual(summaryDiagnostic.summary.renameCount, 1);
+                    assert.strictEqual(summaryDiagnostic.summary.conflictCount, 3);
+
+                    const renamePlan = summaryDiagnostic.renames ?? [];
+                    assert.strictEqual(renamePlan.length, 1);
+                    const [operation] = renamePlan;
+                    assert.strictEqual(operation.fromName, "counter_value");
+                    assert.strictEqual(operation.toName, "counterValue");
+
+                    const conflicts = summaryDiagnostic.conflicts ?? [];
+                    conflicts.forEach((conflict) => {
+                        if (conflict?.code) {
+                            codes.add(conflict.code);
+                        }
+                    });
+                }
+            }
+
+            if (codes.size === 0) {
+                summaryText.split("\n").forEach((line) => {
+                    if (line.includes("[preserve]")) {
+                        codes.add("preserve");
+                    }
+                    if (line.includes("[ignored]")) {
+                        codes.add("ignored");
+                    }
+                    if (line.includes("[collision]")) {
+                        codes.add("collision");
+                    }
+                });
+            }
+
+            assert.ok(codes.has("preserve"));
+            assert.ok(codes.has("ignored"));
+            assert.ok(codes.has("collision"));
+        } finally {
+            console.log = originalConsoleLog;
+            clearIdentifierCaseDryRunContexts();
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+
+    it("applies local identifier renames when write mode is enabled", async () => {
+        const { projectRoot, fixtureSource, gmlPath, projectIndex } =
+      await createTempProject();
+
+        try {
+            clearIdentifierCaseDryRunContexts();
+            setIdentifierCaseDryRunContext({
+                filepath: gmlPath,
+                projectIndex,
+                dryRun: false
+            });
+            const diagnostics = [];
+            const formatOptions = {
+                plugins: [pluginPath],
+                parser: "gml-parse",
+                filepath: gmlPath,
+                gmlIdentifierCase: "camel",
+                gmlIdentifierCaseAssets: "off",
+                gmlIdentifierCaseIgnore: "ignore*",
+                gmlIdentifierCasePreserve: "preserve_me",
+                __identifierCaseProjectIndex: projectIndex,
+                __identifierCaseDryRun: false,
+                diagnostics
+            };
+
+            const formatted = await prettier.format(fixtureSource, formatOptions);
+
+            assert.match(formatted, /counterValue/);
+            assert.match(formatted, /preserve_me/);
+            assert.match(formatted, /ignore_temp/);
+            assert.match(formatted, /foo_bar/);
+            assert.match(formatted, /fooBar/);
+
+            assert.ok(
+                !formatted.includes("counter_value"),
+                "Write mode should update declaration references"
+            );
+            assert.strictEqual(diagnostics.length, 0);
+        } finally {
+            clearIdentifierCaseDryRunContexts();
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- build a local identifier rename planner that gathers eligible declarations, records conflicts, and exposes rename lookups for printers
- invoke the identifier renaming plan from the printer so write mode can substitute converted identifiers while keeping dry-run intact
- extend the identifier-case reporting context and add integration coverage with new fixtures that validate dry-run reporting vs. write mode renames

## Testing
- node --test tests/identifier-case-locals.integration.test.js


------
https://chatgpt.com/codex/tasks/task_e_68eae2d93404832f8ed3f0ba23297e93