### PR TITLE
Track scoped identifiers in project index

### DIFF
--- a/docs/naming-convention-option-plan.md
+++ b/docs/naming-convention-option-plan.md
@@ -151,6 +151,7 @@ The following roadmap refines the high-level phases into discrete, testable work
    - *Prerequisites:* Step 8 foundation working reliably.
    - *Actions:*
      - Sequentially enable renaming for scripts/functions, macros, enums, and instance/global variables.
+     - Leverage the `ProjectIndex.identifiers` buckets for each scope to surface potential collisions before conversion.
      - For each scope, add dedicated tests and conflict scenarios; adjust project index to track new reference types as needed.
    - *Deliverables:* Incremental PRs per scope, expanded documentation describing scope-specific toggles.
    - *Validation:* Scope-specific integration suites; regression pass on previous tests.

--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -209,6 +209,9 @@ export function prepareIdentifierCasePlan(options) {
     options.identifierCaseProjectIndex ??
     context?.projectIndex ??
     null;
+    // Scripts, macros, enums, globals, and instance assignments are now tracked via
+    // `projectIndex.identifiers`. Local-scope renaming remains the only executed
+    // transformation here until per-scope toggles are wired through.
 
     const normalizedOptions = normalizeIdentifierCaseOptions(options);
     const localStyle = normalizedOptions.scopeStyles?.locals ?? "off";

--- a/src/plugin/tests/identifier-case-fixtures/scope-collisions.gml
+++ b/src/plugin/tests/identifier-case-fixtures/scope-collisions.gml
@@ -1,0 +1,22 @@
+#macro MAX_COUNT 3
+#macro max_count 4
+
+globalvar global_score, GLOBAL_SCORE;
+
+enum Difficulty {
+    Easy,
+    Hard
+}
+
+enum DifficultyCopy {
+    Easy,
+    Normal
+}
+
+function scopeTester() {
+    hp = 1;
+    global_score = MAX_COUNT;
+    GLOBAL_SCORE = max_count;
+    var local_value = Difficulty.Easy;
+    return DifficultyCopy.Normal;
+}

--- a/src/plugin/tests/identifier-case-scopes.integration.test.js
+++ b/src/plugin/tests/identifier-case-scopes.integration.test.js
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildProjectIndex } from "../../shared/project-index/index.js";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const fixturesDirectory = path.join(
+    currentDirectory,
+    "identifier-case-fixtures"
+);
+const scopeFixturePath = path.join(fixturesDirectory, "scope-collisions.gml");
+
+async function createScopeFixtureProject() {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gml-scope-tests-"));
+    const writeFile = async (relativePath, contents) => {
+        const absolutePath = path.join(tempRoot, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, contents, "utf8");
+        return absolutePath;
+    };
+
+    await writeFile(
+        "MyGame.yyp",
+        JSON.stringify({ name: "MyGame", resourceType: "GMProject" })
+    );
+
+    await writeFile(
+        "scripts/scopeTester/scopeTester.yy",
+        JSON.stringify({ resourceType: "GMScript", name: "scopeTester" })
+    );
+
+    const fixtureSource = await fs.readFile(scopeFixturePath, "utf8");
+    await writeFile("scripts/scopeTester/scopeTester.gml", fixtureSource);
+
+    return { projectRoot: tempRoot, fixtureSource };
+}
+
+describe("project index scope tracking", () => {
+    it("collects identifiers across macros, enums, and globals", async () => {
+        const { projectRoot } = await createScopeFixtureProject();
+
+        try {
+            const index = await buildProjectIndex(projectRoot);
+
+            const macros = index.identifiers.macros;
+            assert.ok(macros.MAX_COUNT, "expected MAX_COUNT macro to be indexed");
+            assert.ok(macros.max_count, "expected max_count macro to be indexed");
+            assert.equal(macros.MAX_COUNT.declarations.length, 1);
+            assert.equal(macros.max_count.declarations.length, 1);
+
+            const globalVars = index.identifiers.globalVariables;
+            assert.ok(
+                globalVars.global_score,
+                "expected global_score declaration to be tracked"
+            );
+            assert.ok(
+                globalVars.GLOBAL_SCORE,
+                "expected GLOBAL_SCORE declaration to be tracked"
+            );
+
+            const enumEntries = Object.values(index.identifiers.enums);
+            const difficultyEnum = enumEntries.find(
+                (entry) => entry.name === "Difficulty"
+            );
+            const difficultyCopyEnum = enumEntries.find(
+                (entry) => entry.name === "DifficultyCopy"
+            );
+            assert.ok(difficultyEnum, "expected Difficulty enum to be present");
+            assert.ok(
+                difficultyCopyEnum,
+                "expected DifficultyCopy enum to be present"
+            );
+
+            const enumMembers = Object.values(index.identifiers.enumMembers);
+            const hasEasyMember = enumMembers.filter(
+                (entry) => entry.name === "Easy"
+            );
+            assert.ok(
+                hasEasyMember.length >= 2,
+                "expected both Easy members to be tracked"
+            );
+
+            const scriptEntry = index.identifiers.scripts["scope:script:scopeTester"];
+            assert.ok(scriptEntry, "expected script entry for scopeTester");
+            assert.equal(scriptEntry.declarations.length >= 1, true);
+        } finally {
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- collect per-scope identifier buckets (scripts, macros, enums, globals, instance assignments) in the shared project index API and surface them via a new `identifiers` property, including script call references
- add integration coverage for the new buckets (shared test updates plus a plugin fixture exercising collisions) and note the new tracking in identifier-case planning
- document the new index buckets in the naming convention rollout plan for future per-scope toggles

## Testing
- `npm test --silent` *(fails: existing Prettier golden fixture assertions now differ from current formatter output)*


------
https://chatgpt.com/codex/tasks/task_e_68eb0cf78630832fb8376430522ee1ab