### PR TITLE
Add asset rename utilities and tests

### DIFF
--- a/docs/naming-convention-option-plan.md
+++ b/docs/naming-convention-option-plan.md
@@ -201,3 +201,4 @@ The following roadmap refines the high-level phases into discrete, testable work
 - **Collision risk:** Always compute rename plans globally before mutating. Abort formatting for files tied to unresolved conflicts and instruct the user to resolve duplicates or adjust ignore lists.
 - **Performance regression:** Cache project analysis, debounce rebuilds based on file mtimes, and expose metrics (e.g. number of identifiers processed) for profiling.
 - **Data corruption:** Wrap asset writes in atomic operations (temp file + rename) and create backups when altering `.yy` files. If the process fails, restore from backup.
+- **Operational precautions:** Before running automated asset renames, create a clean VCS checkpoint or manual backup of the project tree. Capture the generated rename summary so that file moves can be rolled back quickly, and verify filesystem permissions (write access to `.yy`/`.gml` files and their parent directories) prior to formatting.

--- a/src/plugin/src/assets/rename.js
+++ b/src/plugin/src/assets/rename.js
@@ -1,0 +1,562 @@
+import path from "node:path";
+import {
+    readFileSync as nodeReadFileSync,
+    writeFileSync as nodeWriteFileSync,
+    renameSync as nodeRenameSync,
+    accessSync as nodeAccessSync,
+    statSync as nodeStatSync,
+    mkdirSync as nodeMkdirSync,
+    existsSync as nodeExistsSync
+} from "node:fs";
+
+import { formatIdentifierCase } from "../../../shared/identifier-case.js";
+import {
+    COLLISION_CONFLICT_CODE,
+    PRESERVE_CONFLICT_CODE,
+    IGNORE_CONFLICT_CODE,
+    createConflict,
+    matchesIgnorePattern,
+    DEFAULT_WRITE_ACCESS_MODE
+} from "../identifier-case/common.js";
+
+const defaultFsFacade = Object.freeze({
+    readFileSync(targetPath, encoding = "utf8") {
+        return nodeReadFileSync(targetPath, encoding);
+    },
+    writeFileSync(targetPath, contents) {
+        nodeWriteFileSync(targetPath, contents, "utf8");
+    },
+    renameSync(fromPath, toPath) {
+        nodeRenameSync(fromPath, toPath);
+    },
+    accessSync(targetPath, mode = DEFAULT_WRITE_ACCESS_MODE) {
+        if (mode != null) {
+            nodeAccessSync(targetPath, mode);
+        } else {
+            nodeAccessSync(targetPath);
+        }
+    },
+    statSync(targetPath) {
+        return nodeStatSync(targetPath);
+    },
+    mkdirSync(targetPath) {
+        nodeMkdirSync(targetPath, { recursive: true });
+    },
+    existsSync(targetPath) {
+        return nodeExistsSync(targetPath);
+    }
+});
+
+function toSystemPath(relativePath) {
+    if (typeof relativePath !== "string") {
+        return relativePath ?? "";
+    }
+
+    return relativePath.replace(/\//g, path.sep);
+}
+
+function resolveAbsolutePath(projectRoot, relativePath) {
+    if (!relativePath) {
+        return projectRoot;
+    }
+
+    if (path.isAbsolute(relativePath)) {
+        return relativePath;
+    }
+
+    const systemRelative = toSystemPath(relativePath);
+    return path.join(projectRoot, systemRelative);
+}
+
+function stringifyJson(json) {
+    return `${JSON.stringify(json, null, 4)}\n`;
+}
+
+function readJsonFile(fsFacade, absolutePath, cache) {
+    if (cache && cache.has(absolutePath)) {
+        return cache.get(absolutePath);
+    }
+
+    const raw = fsFacade.readFileSync(absolutePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (cache) {
+        cache.set(absolutePath, parsed);
+    }
+    return parsed;
+}
+
+function getObjectAtPath(json, propertyPath) {
+    if (!propertyPath) {
+        return json;
+    }
+
+    const segments = propertyPath
+        .split(".")
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0);
+
+    let current = json;
+    for (const segment of segments) {
+        if (Array.isArray(current)) {
+            const index = Number(segment);
+            if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+                return null;
+            }
+            current = current[index];
+            continue;
+        }
+
+        if (!current || typeof current !== "object") {
+            return null;
+        }
+
+        if (!Object.hasOwn(current, segment)) {
+            return null;
+        }
+
+        current = current[segment];
+    }
+
+    return current;
+}
+
+function updateReferenceObject(json, propertyPath, newResourcePath, newName) {
+    if (!json) {
+        return false;
+    }
+
+    const target = getObjectAtPath(json, propertyPath);
+    if (!target || typeof target !== "object") {
+        return false;
+    }
+
+    let changed = false;
+
+    if (
+        typeof newResourcePath === "string" &&
+        newResourcePath.length > 0 &&
+        target.path !== newResourcePath
+    ) {
+        target.path = newResourcePath;
+        changed = true;
+    }
+
+    if (
+        typeof newName === "string" &&
+        newName.length > 0 &&
+        target.name !== newName
+    ) {
+        target.name = newName;
+        changed = true;
+    }
+
+    return changed;
+}
+
+function ensureWritableDirectory(fsFacade, directoryPath) {
+    if (!directoryPath) {
+        return;
+    }
+
+    try {
+        if (typeof fsFacade.accessSync === "function") {
+            fsFacade.accessSync(directoryPath, DEFAULT_WRITE_ACCESS_MODE);
+            return;
+        }
+
+        if (typeof fsFacade.existsSync === "function") {
+            if (fsFacade.existsSync(directoryPath)) {
+                return;
+            }
+        }
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+
+    if (typeof fsFacade.mkdirSync === "function") {
+        fsFacade.mkdirSync(directoryPath);
+    }
+}
+
+function ensureWritableFile(fsFacade, filePath) {
+    try {
+        if (typeof fsFacade.accessSync === "function") {
+            fsFacade.accessSync(filePath, DEFAULT_WRITE_ACCESS_MODE);
+            return;
+        }
+
+        if (typeof fsFacade.statSync === "function") {
+            fsFacade.statSync(filePath);
+            return;
+        }
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+
+    ensureWritableDirectory(fsFacade, path.dirname(filePath));
+}
+
+function summarizeReferences(referenceMutations, resourcePath) {
+    const counts = new Map();
+    if (resourcePath) {
+        counts.set(resourcePath, 1);
+    }
+
+    for (const mutation of referenceMutations ?? []) {
+        if (!mutation?.filePath) {
+            continue;
+        }
+        const current = counts.get(mutation.filePath) ?? 0;
+        counts.set(mutation.filePath, current + 1);
+    }
+
+    return Array.from(counts.entries()).map(([filePath, occurrences]) => ({
+        filePath,
+        occurrences
+    }));
+}
+
+export function planAssetRenames({
+    projectIndex,
+    assetStyle,
+    preservedSet = new Set(),
+    ignoreMatchers = []
+} = {}) {
+    if (!projectIndex || !projectIndex.resources || assetStyle === "off") {
+        return { operations: [], conflicts: [], renames: [] };
+    }
+
+    const resources = projectIndex.resources;
+    const assetReferences = projectIndex.relationships?.assetReferences ?? [];
+    const referencesByTargetPath = new Map();
+
+    for (const reference of assetReferences) {
+        if (!reference || typeof reference.targetPath !== "string") {
+            continue;
+        }
+
+        const existing = referencesByTargetPath.get(reference.targetPath) ?? [];
+        existing.push(reference);
+        referencesByTargetPath.set(reference.targetPath, existing);
+    }
+
+    const operations = [];
+    const conflicts = [];
+    const renames = [];
+    const namesByDirectory = new Map();
+
+    for (const [resourcePath, resourceRecord] of Object.entries(resources)) {
+        if (!resourceRecord || !resourceRecord.name) {
+            continue;
+        }
+
+        if (resourceRecord.resourceType !== "GMScript") {
+            continue;
+        }
+
+        const originalName = resourceRecord.name;
+        const convertedName = formatIdentifierCase(originalName, assetStyle);
+
+        if (!convertedName || convertedName === originalName) {
+            continue;
+        }
+
+        if (preservedSet.has(originalName)) {
+            const scopeDescriptor = {
+                id: resourcePath,
+                displayName: `${resourceRecord.resourceType}.${originalName}`
+            };
+            conflicts.push(
+                createConflict({
+                    code: PRESERVE_CONFLICT_CODE,
+                    severity: "info",
+                    message: `Asset '${originalName}' is preserved by configuration.`,
+                    scope: scopeDescriptor,
+                    identifier: originalName
+                })
+            );
+            continue;
+        }
+
+        const ignoreMatch = matchesIgnorePattern(
+            ignoreMatchers,
+            originalName,
+            resourcePath
+        );
+        if (ignoreMatch) {
+            const scopeDescriptor = {
+                id: resourcePath,
+                displayName: `${resourceRecord.resourceType}.${originalName}`
+            };
+            conflicts.push(
+                createConflict({
+                    code: IGNORE_CONFLICT_CODE,
+                    severity: "info",
+                    message: `Asset '${originalName}' matches ignore pattern '${ignoreMatch}'.`,
+                    scope: scopeDescriptor,
+                    identifier: originalName
+                })
+            );
+            continue;
+        }
+
+        const directory = path.posix.dirname(resourcePath);
+        const collisionKey = `${directory}|${convertedName.toLowerCase()}`;
+        if (namesByDirectory.has(collisionKey)) {
+            const scopeDescriptor = {
+                id: resourcePath,
+                displayName: `${resourceRecord.resourceType}.${originalName}`
+            };
+            conflicts.push(
+                createConflict({
+                    code: COLLISION_CONFLICT_CODE,
+                    severity: "error",
+                    message: `Renaming '${originalName}' to '${convertedName}' collides with existing asset '${namesByDirectory.get(
+                        collisionKey
+                    ).name}'.`,
+                    scope: scopeDescriptor,
+                    identifier: originalName
+                })
+            );
+            continue;
+        }
+        namesByDirectory.set(collisionKey, {
+            name: originalName,
+            path: resourcePath
+        });
+
+        const inboundReferences = referencesByTargetPath.get(resourcePath) ?? [];
+        const referenceMutations = inboundReferences
+            .filter((reference) => typeof reference.fromResourcePath === "string")
+            .map((reference) => ({
+                filePath: reference.fromResourcePath,
+                propertyPath: reference.propertyPath ?? "",
+                originalName: reference.targetName ?? originalName
+            }));
+
+        const newResourcePath = path.posix.join(
+            directory,
+            `${convertedName}.yy`
+        );
+
+        const gmlRenames = [];
+        for (const gmlFile of resourceRecord.gmlFiles ?? []) {
+            const extension = path.posix.extname(gmlFile);
+            const baseName = path.posix.basename(gmlFile, extension);
+            if (baseName !== originalName) {
+                continue;
+            }
+
+            const renamedPath = path.posix.join(
+                path.posix.dirname(gmlFile),
+                `${convertedName}${extension}`
+            );
+            gmlRenames.push({ from: gmlFile, to: renamedPath });
+        }
+
+        renames.push({
+            resourcePath,
+            resourceType: resourceRecord.resourceType,
+            fromName: originalName,
+            toName: convertedName,
+            newResourcePath,
+            gmlRenames,
+            referenceMutations
+        });
+
+        operations.push({
+            id: `asset:${resourceRecord.resourceType}:${resourcePath}`,
+            kind: "asset",
+            scope: {
+                id: resourcePath,
+                displayName: `${resourceRecord.resourceType}.${originalName}`
+            },
+            from: { name: originalName },
+            to: { name: convertedName },
+            references: summarizeReferences(referenceMutations, resourcePath)
+        });
+    }
+
+    return { operations, conflicts, renames };
+}
+
+export function applyAssetRenames({
+    projectIndex,
+    renames,
+    fsFacade = null,
+    logger = null
+} = {}) {
+    if (!projectIndex || !Array.isArray(renames) || renames.length === 0) {
+        return { writes: [], renames: [] };
+    }
+
+    const effectiveFs = fsFacade
+        ? { ...defaultFsFacade, ...fsFacade }
+        : defaultFsFacade;
+    const root = projectIndex.projectRoot;
+
+    const jsonCache = new Map();
+    const pendingWrites = new Map();
+    const renameActions = [];
+
+    for (const rename of renames) {
+        if (!rename?.resourcePath || !rename?.toName) {
+            continue;
+        }
+
+        const resourceAbsolute = resolveAbsolutePath(
+            root,
+            rename.resourcePath
+        );
+        const resourceJson = readJsonFile(
+            effectiveFs,
+            resourceAbsolute,
+            jsonCache
+        );
+
+        if (!resourceJson || typeof resourceJson !== "object") {
+            throw new Error(
+                `Unable to parse resource metadata at '${rename.resourcePath}'.`
+            );
+        }
+
+        let resourceChanged = false;
+        if (resourceJson.name !== rename.toName) {
+            resourceJson.name = rename.toName;
+            resourceChanged = true;
+        }
+
+        if (
+            typeof rename.newResourcePath === "string" &&
+            resourceJson.resourcePath !== rename.newResourcePath
+        ) {
+            resourceJson.resourcePath = rename.newResourcePath;
+            resourceChanged = true;
+        }
+
+        if (resourceChanged) {
+            pendingWrites.set(resourceAbsolute, resourceJson);
+        }
+
+        const groupedReferences = new Map();
+        for (const mutation of rename.referenceMutations ?? []) {
+            if (!mutation?.filePath) {
+                continue;
+            }
+            const entries = groupedReferences.get(mutation.filePath) ?? [];
+            entries.push(mutation);
+            groupedReferences.set(mutation.filePath, entries);
+        }
+
+        for (const [filePath, mutations] of groupedReferences.entries()) {
+            const absolutePath = resolveAbsolutePath(root, filePath);
+            let targetJson;
+            try {
+                targetJson = readJsonFile(
+                    effectiveFs,
+                    absolutePath,
+                    jsonCache
+                );
+            } catch (error) {
+                if (logger && typeof logger.warn === "function") {
+                    logger.warn(
+                        `Skipping asset reference update for '${filePath}': ${error.message}`
+                    );
+                }
+                continue;
+            }
+
+            if (!targetJson || typeof targetJson !== "object") {
+                continue;
+            }
+
+            let updated = false;
+            for (const mutation of mutations) {
+                const changed = updateReferenceObject(
+                    targetJson,
+                    mutation.propertyPath,
+                    rename.newResourcePath,
+                    rename.toName
+                );
+                if (changed) {
+                    updated = true;
+                }
+            }
+
+            if (updated) {
+                pendingWrites.set(absolutePath, targetJson);
+            }
+        }
+
+        const newResourceAbsolute = resolveAbsolutePath(
+            root,
+            rename.newResourcePath
+        );
+
+        if (newResourceAbsolute !== resourceAbsolute) {
+            renameActions.push({
+                from: resourceAbsolute,
+                to: newResourceAbsolute
+            });
+        }
+
+        for (const gmlRename of rename.gmlRenames ?? []) {
+            if (!gmlRename?.from || !gmlRename?.to) {
+                continue;
+            }
+
+            const fromAbsolute = resolveAbsolutePath(root, gmlRename.from);
+            const toAbsolute = resolveAbsolutePath(root, gmlRename.to);
+
+            if (fromAbsolute === toAbsolute) {
+                continue;
+            }
+
+            renameActions.push({ from: fromAbsolute, to: toAbsolute });
+        }
+    }
+
+    const writeActions = Array.from(pendingWrites.entries()).map(
+        ([filePath, jsonData]) => ({
+            filePath,
+            contents: stringifyJson(jsonData)
+        })
+    );
+
+    if (writeActions.length === 0 && renameActions.length === 0) {
+        return { writes: [], renames: [] };
+    }
+
+    for (const action of writeActions) {
+        ensureWritableFile(effectiveFs, action.filePath);
+    }
+
+    for (const action of renameActions) {
+        ensureWritableFile(effectiveFs, action.from);
+        ensureWritableDirectory(effectiveFs, path.dirname(action.to));
+        if (
+            typeof effectiveFs.existsSync === "function" &&
+            effectiveFs.existsSync(action.to)
+        ) {
+            throw new Error(
+                `Cannot rename '${action.from}' to existing path '${action.to}'.`
+            );
+        }
+    }
+
+    for (const action of writeActions) {
+        ensureWritableDirectory(effectiveFs, path.dirname(action.filePath));
+        effectiveFs.writeFileSync(action.filePath, action.contents);
+    }
+
+    for (const action of renameActions) {
+        ensureWritableDirectory(effectiveFs, path.dirname(action.to));
+        effectiveFs.renameSync(action.from, action.to);
+    }
+
+    return { writes: writeActions, renames: renameActions };
+}

--- a/src/plugin/src/identifier-case/common.js
+++ b/src/plugin/src/identifier-case/common.js
@@ -1,0 +1,77 @@
+import { constants as fsConstants } from "node:fs";
+
+export const COLLISION_CONFLICT_CODE = "collision";
+export const PRESERVE_CONFLICT_CODE = "preserve";
+export const IGNORE_CONFLICT_CODE = "ignored";
+
+export function escapeForRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function createPatternRegExp(pattern) {
+    if (typeof pattern !== "string" || pattern.length === 0) {
+        return null;
+    }
+
+    const escaped = escapeForRegExp(pattern.trim());
+    if (!escaped) {
+        return null;
+    }
+
+    const wildcardExpanded = escaped.replace(/\\\*/g, ".*").replace(/\\\?/g, ".");
+
+    return new RegExp(`^${wildcardExpanded}$`, "i");
+}
+
+export function buildPatternMatchers(patterns) {
+    const matchers = [];
+
+    for (const pattern of patterns ?? []) {
+        const regexp = createPatternRegExp(pattern);
+        if (!regexp) {
+            continue;
+        }
+
+        matchers.push({ raw: pattern, regexp });
+    }
+
+    return matchers;
+}
+
+export function matchesIgnorePattern(matchers, identifierName, filePath) {
+    if (!Array.isArray(matchers) || matchers.length === 0) {
+        return null;
+    }
+
+    const name = identifierName ?? "";
+    const file = filePath ?? "";
+
+    for (const matcher of matchers) {
+        if (matcher.regexp.test(name) || matcher.regexp.test(file)) {
+            return matcher.raw;
+        }
+    }
+
+    return null;
+}
+
+export function createConflict({
+    code,
+    severity,
+    message,
+    scope,
+    identifier,
+    suggestions = []
+}) {
+    return {
+        code,
+        severity,
+        message,
+        scope,
+        identifier,
+        suggestions
+    };
+}
+
+export const DEFAULT_WRITE_ACCESS_MODE =
+    typeof fsConstants?.W_OK === "number" ? fsConstants.W_OK : undefined;

--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -3,10 +3,18 @@ import path from "node:path";
 import { formatIdentifierCase } from "../../../shared/identifier-case.js";
 import { normalizeIdentifierCaseOptions } from "../options/identifier-case.js";
 import { peekIdentifierCaseDryRunContext } from "../reporting/identifier-case-context.js";
-
-const COLLISION_CONFLICT_CODE = "collision";
-const PRESERVE_CONFLICT_CODE = "preserve";
-const IGNORE_CONFLICT_CODE = "ignored";
+import {
+    COLLISION_CONFLICT_CODE,
+    PRESERVE_CONFLICT_CODE,
+    IGNORE_CONFLICT_CODE,
+    buildPatternMatchers,
+    matchesIgnorePattern,
+    createConflict
+} from "./common.js";
+import {
+    planAssetRenames,
+    applyAssetRenames
+} from "../assets/rename.js";
 
 function toPosixPath(filePath) {
     if (typeof filePath !== "string" || filePath.length === 0) {
@@ -96,75 +104,6 @@ function createScopeDescriptor(projectIndex, fileRecord, scopeId) {
     };
 }
 
-function escapeForRegExp(value) {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function createPatternRegExp(pattern) {
-    if (typeof pattern !== "string" || pattern.length === 0) {
-        return null;
-    }
-
-    const escaped = escapeForRegExp(pattern.trim());
-    if (!escaped) {
-        return null;
-    }
-
-    const wildcardExpanded = escaped.replace(/\\\*/g, ".*").replace(/\\\?/g, ".");
-
-    return new RegExp(`^${wildcardExpanded}$`, "i");
-}
-
-function buildPatternMatchers(patterns) {
-    const matchers = [];
-
-    for (const pattern of patterns ?? []) {
-        const regexp = createPatternRegExp(pattern);
-        if (!regexp) {
-            continue;
-        }
-
-        matchers.push({ raw: pattern, regexp });
-    }
-
-    return matchers;
-}
-
-function matchesIgnorePattern(matchers, identifierName, filePath) {
-    if (!Array.isArray(matchers) || matchers.length === 0) {
-        return null;
-    }
-
-    const name = identifierName ?? "";
-    const file = filePath ?? "";
-
-    for (const matcher of matchers) {
-        if (matcher.regexp.test(name) || matcher.regexp.test(file)) {
-            return matcher.raw;
-        }
-    }
-
-    return null;
-}
-
-function createConflict({
-    code,
-    severity,
-    message,
-    scope,
-    identifier,
-    suggestions = []
-}) {
-    return {
-        code,
-        severity,
-        message,
-        scope,
-        identifier,
-        suggestions
-    };
-}
-
 function summarizeReferencesByFile(relativeFilePath, references) {
     const counts = new Map();
 
@@ -215,21 +154,8 @@ export function prepareIdentifierCasePlan(options) {
 
     const normalizedOptions = normalizeIdentifierCaseOptions(options);
     const localStyle = normalizedOptions.scopeStyles?.locals ?? "off";
+    const assetStyle = normalizedOptions.scopeStyles?.assets ?? "off";
 
-    if (!projectIndex || !projectIndex.files || localStyle === "off") {
-        return;
-    }
-
-    const relativeFilePath = resolveRelativeFilePath(
-        projectIndex.projectRoot,
-        options.filepath ?? null
-    );
-
-    if (!relativeFilePath || !projectIndex.files[relativeFilePath]) {
-        return;
-    }
-
-    const fileRecord = projectIndex.files[relativeFilePath];
     const preservedSet = new Set(normalizedOptions.preservedIdentifiers ?? []);
     const ignoreMatchers = buildPatternMatchers(
         normalizedOptions.ignorePatterns ?? []
@@ -238,6 +164,64 @@ export function prepareIdentifierCasePlan(options) {
     const renameMap = new Map();
     const operations = [];
     const conflicts = [];
+    const assetRenames = [];
+    let assetConflicts = [];
+
+    if (projectIndex && assetStyle !== "off") {
+        const assetPlan = planAssetRenames({
+            projectIndex,
+            assetStyle,
+            preservedSet,
+            ignoreMatchers
+        });
+        operations.push(...assetPlan.operations);
+        conflicts.push(...assetPlan.conflicts);
+        assetRenames.push(...assetPlan.renames);
+        assetConflicts = assetPlan.conflicts ?? [];
+    }
+
+    const hasLocalSupport =
+        projectIndex && projectIndex.files && localStyle !== "off";
+
+    let fileRecord = null;
+    let relativeFilePath = null;
+    if (hasLocalSupport) {
+        relativeFilePath = resolveRelativeFilePath(
+            projectIndex.projectRoot,
+            options.filepath ?? null
+        );
+        if (relativeFilePath && projectIndex.files[relativeFilePath]) {
+            fileRecord = projectIndex.files[relativeFilePath];
+        }
+    }
+
+    if (!fileRecord) {
+        options.__identifierCaseRenameMap = renameMap;
+        if (assetRenames.length > 0) {
+            options.__identifierCaseAssetRenames = assetRenames;
+        }
+        if (
+            options.__identifierCaseDryRun === false &&
+            assetRenames.length > 0 &&
+            assetConflicts.length === 0 &&
+            projectIndex &&
+            options.__identifierCaseAssetRenamesApplied !== true
+        ) {
+            const fsFacade =
+                options.__identifierCaseFs ?? options.identifierCaseFs ?? null;
+            const logger = options.logger ?? null;
+            const result = applyAssetRenames({
+                projectIndex,
+                renames: assetRenames,
+                fsFacade,
+                logger
+            });
+            options.__identifierCaseAssetRenameResult = result;
+            options.__identifierCaseAssetRenamesApplied = true;
+        }
+        options.__identifierCasePlanGeneratedInternally = true;
+        return;
+    }
 
     const existingNamesByScope = new Map();
     for (const declaration of fileRecord.declarations ?? []) {
@@ -472,16 +456,38 @@ export function prepareIdentifierCasePlan(options) {
         }
     }
 
-    if (operations.length === 0 && conflicts.length === 0) {
-        options.__identifierCaseRenameMap = renameMap;
-        options.__identifierCasePlanGeneratedInternally = true;
-        return;
+    options.__identifierCaseRenameMap = renameMap;
+    if (assetRenames.length > 0) {
+        options.__identifierCaseAssetRenames = assetRenames;
     }
 
-    options.__identifierCaseRenamePlan = { operations };
-    options.__identifierCaseConflicts = conflicts;
-    options.__identifierCaseRenameMap = renameMap;
-    options.__identifierCasePlanGeneratedInternally = true;
+    if (operations.length === 0 && conflicts.length === 0) {
+        options.__identifierCasePlanGeneratedInternally = true;
+    } else {
+        options.__identifierCaseRenamePlan = { operations };
+        options.__identifierCaseConflicts = conflicts;
+        options.__identifierCasePlanGeneratedInternally = true;
+    }
+
+    if (
+        options.__identifierCaseDryRun === false &&
+        assetRenames.length > 0 &&
+        assetConflicts.length === 0 &&
+        projectIndex &&
+        options.__identifierCaseAssetRenamesApplied !== true
+    ) {
+        const fsFacade =
+            options.__identifierCaseFs ?? options.identifierCaseFs ?? null;
+        const logger = options.logger ?? null;
+        const result = applyAssetRenames({
+            projectIndex,
+            renames: assetRenames,
+            fsFacade,
+            logger
+        });
+        options.__identifierCaseAssetRenameResult = result;
+        options.__identifierCaseAssetRenamesApplied = true;
+    }
 }
 
 export function getIdentifierCaseRenameForNode(node, options) {

--- a/src/plugin/tests/identifier-case-assets.integration.test.js
+++ b/src/plugin/tests/identifier-case-assets.integration.test.js
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import prettier from "prettier";
+
+import { buildProjectIndex } from "../../shared/project-index/index.js";
+import {
+    clearIdentifierCaseDryRunContexts,
+    setIdentifierCaseDryRunContext
+} from "../src/reporting/identifier-case-context.js";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+
+async function createAssetRenameProject() {
+    const tempRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "gml-asset-rename-")
+    );
+
+    const writeFile = async (relativePath, contents) => {
+        const absolutePath = path.join(tempRoot, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, contents, "utf8");
+        return absolutePath;
+    };
+
+    await writeFile(
+        "MyGame.yyp",
+        JSON.stringify(
+            {
+                name: "MyGame",
+                resourceType: "GMProject",
+                resources: [
+                    {
+                        id: {
+                            name: "demo_script",
+                            path: "scripts/demo_script/demo_script.yy"
+                        }
+                    }
+                ]
+            },
+            null,
+            4
+        ) + "\n"
+    );
+
+    await writeFile(
+        "scripts/demo_script/demo_script.yy",
+        JSON.stringify(
+            {
+                resourceType: "GMScript",
+                name: "demo_script",
+                resourcePath: "scripts/demo_script/demo_script.yy"
+            },
+            null,
+            4
+        ) + "\n"
+    );
+
+    const source = "function demo_script() {\n    return 42;\n}\n";
+    const gmlPath = await writeFile(
+        "scripts/demo_script/demo_script.gml",
+        source
+    );
+
+    await writeFile(
+        "objects/obj_controller/obj_controller.yy",
+        JSON.stringify(
+            {
+                resourceType: "GMObject",
+                name: "obj_controller",
+                scriptExecute: {
+                    path: "scripts/demo_script/demo_script.yy",
+                    name: "demo_script"
+                }
+            },
+            null,
+            4
+        ) + "\n"
+    );
+
+    const projectIndex = await buildProjectIndex(tempRoot);
+
+    return {
+        projectRoot: tempRoot,
+        projectIndex,
+        scriptSource: source,
+        scriptPath: gmlPath
+    };
+}
+
+describe("asset rename execution", () => {
+    it("renames script assets and updates referencing metadata", async () => {
+        const { projectRoot, projectIndex, scriptSource, scriptPath } =
+            await createAssetRenameProject();
+
+        try {
+            clearIdentifierCaseDryRunContexts();
+            setIdentifierCaseDryRunContext({
+                filepath: scriptPath,
+                projectIndex,
+                dryRun: false
+            });
+
+            const diagnostics = [];
+            const formatOptions = {
+                plugins: [pluginPath],
+                parser: "gml-parse",
+                filepath: scriptPath,
+                gmlIdentifierCase: "off",
+                gmlIdentifierCaseAssets: "pascal",
+                gmlIdentifierCaseAcknowledgeAssetRenames: true,
+                __identifierCaseProjectIndex: projectIndex,
+                __identifierCaseDryRun: false,
+                diagnostics
+            };
+
+            await prettier.format(scriptSource, formatOptions);
+
+            assert.strictEqual(diagnostics.length, 0);
+
+            const newYyRelative = "scripts/demo_script/DemoScript.yy";
+            const newGmlRelative = "scripts/demo_script/DemoScript.gml";
+            const newYyPath = path.join(projectRoot, toSystemPath(newYyRelative));
+            const newGmlPath = path.join(projectRoot, toSystemPath(newGmlRelative));
+
+            await assertPathMissing(
+                path.join(projectRoot, "scripts/demo_script/demo_script.yy")
+            );
+            await assertPathMissing(
+                path.join(projectRoot, "scripts/demo_script/demo_script.gml")
+            );
+
+            const renamedYy = JSON.parse(
+                await fs.readFile(newYyPath, "utf8")
+            );
+            assert.strictEqual(renamedYy.name, "DemoScript");
+            assert.strictEqual(renamedYy.resourcePath, newYyRelative);
+
+            const objectData = JSON.parse(
+                await fs.readFile(
+                    path.join(
+                        projectRoot,
+                        toSystemPath("objects/obj_controller/obj_controller.yy")
+                    ),
+                    "utf8"
+                )
+            );
+            assert.deepStrictEqual(objectData.scriptExecute, {
+                path: newYyRelative,
+                name: "DemoScript"
+            });
+
+            const projectData = JSON.parse(
+                await fs.readFile(path.join(projectRoot, "MyGame.yyp"), "utf8")
+            );
+            assert.strictEqual(projectData.resources[0].id.path, newYyRelative);
+            assert.strictEqual(projectData.resources[0].id.name, "DemoScript");
+
+            const renamedGmlExists = await fileExists(newGmlPath);
+            assert.ok(renamedGmlExists, "Expected renamed GML file to exist");
+        } finally {
+            clearIdentifierCaseDryRunContexts();
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+});
+
+async function assertPathMissing(targetPath) {
+    try {
+        await fs.access(targetPath);
+        assert.fail(`Path ${targetPath} unexpectedly exists.`);
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+}
+
+async function fileExists(targetPath) {
+    try {
+        await fs.access(targetPath);
+        return true;
+    } catch (error) {
+        if (error && error.code === "ENOENT") {
+            return false;
+        }
+        throw error;
+    }
+}
+
+function toSystemPath(relativePath) {
+    return relativePath.replace(/\//g, path.sep);
+}

--- a/src/shared/project-index/index.js
+++ b/src/shared/project-index/index.js
@@ -245,12 +245,13 @@ async function scanProjectTree(projectRoot, fsFacade) {
             }
 
             const relativePosix = toPosixPath(relativePath);
-            if (relativePosix.toLowerCase().endsWith(".yy")) {
+            const lowerPath = relativePosix.toLowerCase();
+            if (lowerPath.endsWith(".yy") || lowerPath.endsWith(".yyp")) {
                 yyFiles.push({
                     absolutePath,
                     relativePath: relativePosix
                 });
-            } else if (relativePosix.toLowerCase().endsWith(".gml")) {
+            } else if (lowerPath.endsWith(".gml")) {
                 gmlFiles.push({
                     absolutePath,
                     relativePath: relativePosix
@@ -268,9 +269,16 @@ async function scanProjectTree(projectRoot, fsFacade) {
 function ensureResourceRecord(resourcesMap, resourcePath, resourceData = {}) {
     let record = resourcesMap.get(resourcePath);
     if (!record) {
+        const lowerPath = resourcePath.toLowerCase();
+        let defaultName = path.posix.basename(resourcePath);
+        if (lowerPath.endsWith(".yy")) {
+            defaultName = path.posix.basename(resourcePath, ".yy");
+        } else if (lowerPath.endsWith(".yyp")) {
+            defaultName = path.posix.basename(resourcePath, ".yyp");
+        }
         record = {
             path: resourcePath,
-            name: resourceData.name ?? path.posix.basename(resourcePath, ".yy"),
+            name: resourceData.name ?? defaultName,
             resourceType: resourceData.resourceType ?? "unknown",
             scopes: [],
             gmlFiles: [],


### PR DESCRIPTION
## Summary
- add shared identifier-case helpers and asset rename utilities that update `.yy` metadata, disk files, and dependent references
- extend the project index to recognise `.yyp` files and capture default resource names for rename planning
- document operational precautions for asset renames and add an integration test covering end-to-end script asset updates

## Testing
- node --test src/plugin/tests/identifier-case-assets.integration.test.js


------
https://chatgpt.com/codex/tasks/task_e_68eb10d6c334832f8bb21f3bca62fddc