### PR TITLE
Record identifier-case write reporting and tests

### DIFF
--- a/src/plugin/src/reporting/identifier-case-report.js
+++ b/src/plugin/src/reporting/identifier-case-report.js
@@ -579,8 +579,15 @@ export function maybeReportIdentifierCaseDryRun(options) {
     }
 
     if (dryRun === false) {
+        const result = summarizeIdentifierCasePlan({
+            renamePlan,
+            conflicts
+        });
+
         options.__identifierCaseReportEmitted = true;
-        return null;
+        options.__identifierCaseReportResult = result;
+
+        return result;
     }
 
     const effectiveLogger = logger ?? options.logger ?? console;

--- a/src/plugin/tests/identifier-case-fixtures/locals-write.gml
+++ b/src/plugin/tests/identifier-case-fixtures/locals-write.gml
@@ -1,0 +1,7 @@
+function rename_write_demo(value) {
+    var should_rename = value + 1;
+    var retained = should_rename * value;
+
+    should_rename += retained;
+    return should_rename;
+}


### PR DESCRIPTION
## Summary
- return a summarized identifier-case report even when formatting runs in write mode so skipped renames are recorded
- parameterize the locals identifier-case integration helper to load alternate fixtures and exercise dry-run vs write output
- add a new locals-write fixture that demonstrates successful local renaming under write mode

## Testing
- node --test src/plugin/tests/identifier-case-locals.integration.test.js
- npm run test:plugin *(fails: existing golden fixture expectations differ in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb14b9b5bc832fbad20b99c4ceeb87