### PR TITLE
Add identifier IDs per scope to the project index

### DIFF
--- a/docs/naming-convention-option-plan.md
+++ b/docs/naming-convention-option-plan.md
@@ -151,6 +151,8 @@ The following roadmap refines the high-level phases into discrete, testable work
    - *Prerequisites:* Step 8 foundation working reliably.
    - *Actions:*
      - Sequentially enable renaming for scripts/functions, macros, enums, and instance/global variables.
+     - ProjectIndex now publishes per-scope identifier buckets (with stable `identifierId` values) so that rename planners can
+       reason about collisions and resource paths before executing conversions.
      - Leverage the `ProjectIndex.identifiers` buckets for each scope to surface potential collisions before conversion.
      - For each scope, add dedicated tests and conflict scenarios; adjust project index to track new reference types as needed.
    - *Deliverables:* Incremental PRs per scope, expanded documentation describing scope-specific toggles.

--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -153,8 +153,11 @@ export function prepareIdentifierCasePlan(options) {
         context?.projectIndex ??
         null;
     // Scripts, macros, enums, globals, and instance assignments are now tracked via
-    // `projectIndex.identifiers`. Local-scope renaming remains the only executed
-    // transformation here until per-scope toggles are wired through.
+    // `projectIndex.identifiers` with dedicated identifier IDs per scope. Local-scope
+    // renaming remains the only executed transformation until the scope toggles
+    // (e.g. gmlIdentifierCaseFunctions, gmlIdentifierCaseMacros, etc.) are
+    // connected to the rename planner. Future stages will consult these per-scope
+    // buckets to respect collisions before enabling the additional conversions.
 
     const normalizedOptions = normalizeIdentifierCaseOptions(options);
     const localStyle = normalizedOptions.scopeStyles?.locals ?? "off";

--- a/src/plugin/tests/identifier-case-fixtures/object-instance-collisions.gml
+++ b/src/plugin/tests/identifier-case-fixtures/object-instance-collisions.gml
@@ -1,0 +1,3 @@
+speed_bonus = 1;
+SpeedBonus = speed_bonus + 1;
+speedBonus = SpeedBonus + 1;

--- a/src/plugin/tests/identifier-case-fixtures/scope-identifier-collisions.gml
+++ b/src/plugin/tests/identifier-case-fixtures/scope-identifier-collisions.gml
@@ -1,0 +1,24 @@
+#macro MACRO_VALUE 10
+#macro macro_value 20
+#macro MacroValue 30
+
+globalvar global_rate, GLOBAL_RATE;
+global.GLOBALPOINT = 1;
+global.globalPoint = 2;
+
+enum RewardLevel {
+    Bronze,
+    bronze
+}
+
+enum RewardLevelCopy {
+    Bronze,
+    BRONZE
+}
+
+function scopeCollision() {
+    var local_total = MACRO_VALUE + macro_value + MacroValue;
+    global_rate = local_total;
+    GLOBAL_RATE = globalPoint + GLOBALPOINT;
+    return RewardLevel.Bronze + RewardLevelCopy.BRONZE;
+}

--- a/src/plugin/tests/identifier-case-scope-identifiers.integration.test.js
+++ b/src/plugin/tests/identifier-case-scope-identifiers.integration.test.js
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildProjectIndex } from "../../shared/project-index/index.js";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const fixturesDirectory = path.join(
+    currentDirectory,
+    "identifier-case-fixtures"
+);
+const scriptFixturePath = path.join(
+    fixturesDirectory,
+    "scope-identifier-collisions.gml"
+);
+const objectFixturePath = path.join(
+    fixturesDirectory,
+    "object-instance-collisions.gml"
+);
+
+async function createIdentifierFixtureProject() {
+    const tempRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "gml-scope-identifiers-")
+    );
+
+    const writeFile = async (relativePath, contents) => {
+        const absolutePath = path.join(tempRoot, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, contents, "utf8");
+        return absolutePath;
+    };
+
+    await writeFile(
+        "MyGame.yyp",
+        JSON.stringify({ name: "MyGame", resourceType: "GMProject" })
+    );
+
+    await writeFile(
+        "scripts/scopeCollision/scopeCollision.yy",
+        JSON.stringify({ resourceType: "GMScript", name: "scopeCollision" })
+    );
+
+    const scriptSource = await fs.readFile(scriptFixturePath, "utf8");
+    await writeFile("scripts/scopeCollision/scopeCollision.gml", scriptSource);
+
+    await writeFile(
+        "objects/obj_tracker/obj_tracker.yy",
+        JSON.stringify({
+            resourceType: "GMObject",
+            name: "obj_tracker",
+            eventList: [
+                {
+                    name: "Step_0",
+                    eventType: 3,
+                    eventNum: 0,
+                    eventId: {
+                        name: "Step_0",
+                        path: "objects/obj_tracker/obj_tracker_Step_0.gml"
+                    }
+                }
+            ]
+        })
+    );
+
+    const objectSource = await fs.readFile(objectFixturePath, "utf8");
+    await writeFile("objects/obj_tracker/obj_tracker_Step_0.gml", objectSource);
+
+    return { projectRoot: tempRoot };
+}
+
+describe("project index identifier tracking", () => {
+    it("assigns identifier ids per scope and preserves collision entries", async () => {
+        const { projectRoot } = await createIdentifierFixtureProject();
+
+        try {
+            const index = await buildProjectIndex(projectRoot);
+
+            const scriptEntry =
+                index.identifiers.scripts["scope:script:scopeCollision"];
+            assert.ok(scriptEntry, "expected scopeCollision script entry");
+            assert.equal(
+                scriptEntry.identifierId,
+                "script:scope:script:scopeCollision"
+            );
+
+            const macros = index.identifiers.macros;
+            assert.ok(macros.MACRO_VALUE);
+            assert.equal(macros.MACRO_VALUE.identifierId, "macro:MACRO_VALUE");
+            assert.ok(macros.macro_value);
+            assert.equal(macros.macro_value.identifierId, "macro:macro_value");
+            assert.ok(macros.MacroValue);
+            assert.equal(macros.MacroValue.identifierId, "macro:MacroValue");
+
+            const globalVars = index.identifiers.globalVariables;
+            assert.equal(
+                globalVars.global_rate.identifierId,
+                "global:global_rate"
+            );
+            assert.equal(
+                globalVars.GLOBAL_RATE.identifierId,
+                "global:GLOBAL_RATE"
+            );
+
+            const enumEntries = Object.values(index.identifiers.enums);
+            assert.ok(enumEntries.length >= 2, "expected enum entries");
+            for (const entry of enumEntries) {
+                assert.ok(
+                    entry.identifierId?.startsWith("enum:"),
+                    "expected enum identifier prefix"
+                );
+            }
+
+            const enumMembers = Object.values(index.identifiers.enumMembers);
+            const sharedMembers = enumMembers.filter(
+                (entry) => entry.name === "Bronze"
+            );
+            assert.ok(sharedMembers.length >= 2);
+            for (const member of sharedMembers) {
+                assert.ok(
+                    member.identifierId?.startsWith("enum-member:"),
+                    "expected enum member identifier prefix"
+                );
+            }
+
+            const instanceEntries = Object.values(
+                index.identifiers.instanceVariables
+            );
+            const speedBonusNames = instanceEntries.filter((entry) =>
+                ["speed_bonus", "SpeedBonus", "speedBonus"].includes(
+                    entry.name
+                )
+            );
+            assert.equal(speedBonusNames.length, 3);
+            for (const instance of speedBonusNames) {
+                assert.ok(
+                    instance.identifierId?.startsWith("instance:"),
+                    "expected instance identifier prefix"
+                );
+            }
+        } finally {
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/shared/project-index/index.js
+++ b/src/shared/project-index/index.js
@@ -697,6 +697,18 @@ function createIdentifierCollections() {
     };
 }
 
+function buildIdentifierId(scope, value) {
+    if (!scope || typeof scope !== "string") {
+        return null;
+    }
+
+    if (typeof value !== "string" || value.length === 0) {
+        return null;
+    }
+
+    return `${scope}:${value}`;
+}
+
 function createEnumLookup(ast, filePath) {
     const enumDeclarations = new Map();
     const memberDeclarations = new Map();
@@ -775,10 +787,13 @@ function ensureScriptEntry(identifierCollections, descriptor) {
         return null;
     }
 
+    const identifierId = buildIdentifierId("script", descriptor.id);
+
     return ensureCollectionEntry(
         identifierCollections.scripts,
         descriptor.id,
         () => ({
+            identifierId,
             id: descriptor.id,
             name: descriptor.name ?? null,
             displayName:
@@ -799,6 +814,10 @@ function registerScriptDeclaration({
     const entry = ensureScriptEntry(identifierCollections, descriptor);
     if (!entry) {
         return;
+    }
+
+    if (!entry.identifierId) {
+        entry.identifierId = buildIdentifierId("script", descriptor?.id ?? "");
     }
 
     if (descriptor.name && !entry.name) {
@@ -851,10 +870,13 @@ function registerScriptReference({ identifierCollections, callRecord }) {
         return;
     }
 
+    const identifierId = buildIdentifierId("script", targetScopeId);
+
     const entry = ensureCollectionEntry(
         identifierCollections.scripts,
         targetScopeId,
         () => ({
+            identifierId,
             id: targetScopeId,
             name: callRecord.target?.name ?? null,
             displayName: callRecord.target?.name
@@ -865,6 +887,10 @@ function registerScriptReference({ identifierCollections, callRecord }) {
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     if (callRecord.target?.name && !entry.name) {
         entry.name = callRecord.target.name;
@@ -898,15 +924,22 @@ function registerMacroOccurrence({
         return;
     }
 
+    const identifierId = buildIdentifierId("macro", identifierRecord.name);
+
     const entry = ensureCollectionEntry(
         identifierCollections.macros,
         identifierRecord.name,
         () => ({
+            identifierId,
             name: identifierRecord.name,
             declarations: [],
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     const clone = cloneIdentifierForCollections(identifierRecord, filePath);
     if (role === "declaration") {
@@ -934,10 +967,12 @@ function registerEnumOccurrence({
     }
 
     const enumInfo = enumLookup?.enumDeclarations?.get(enumKey) ?? null;
+    const identifierId = buildIdentifierId("enum", enumKey);
     const entry = ensureCollectionEntry(
         identifierCollections.enums,
         enumKey,
         () => ({
+            identifierId,
             key: enumKey,
             name: enumInfo?.name ?? identifierRecord?.name ?? null,
             filePath: enumInfo?.filePath ?? filePath ?? null,
@@ -945,6 +980,10 @@ function registerEnumOccurrence({
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     if (enumInfo && !entry.name) {
         entry.name =
@@ -978,11 +1017,13 @@ function registerEnumMemberOccurrence({
 
     const memberInfo = enumLookup?.memberDeclarations?.get(memberKey) ?? null;
     const enumKey = memberInfo?.enumKey ?? null;
+    const identifierId = buildIdentifierId("enum-member", memberKey);
 
     const entry = ensureCollectionEntry(
         identifierCollections.enumMembers,
         memberKey,
         () => ({
+            identifierId,
             key: memberKey,
             name: memberInfo?.name ?? identifierRecord?.name ?? null,
             enumKey,
@@ -995,6 +1036,10 @@ function registerEnumMemberOccurrence({
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     if (memberInfo?.enumKey && !entry.enumName) {
         entry.enumName =
@@ -1020,15 +1065,22 @@ function registerGlobalOccurrence({
         return;
     }
 
+    const identifierId = buildIdentifierId("global", identifierRecord.name);
+
     const entry = ensureCollectionEntry(
         identifierCollections.globalVariables,
         identifierRecord.name,
         () => ({
+            identifierId,
             name: identifierRecord.name,
             declarations: [],
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     const clone = cloneIdentifierForCollections(identifierRecord, filePath);
     if (role === "declaration") {
@@ -1050,10 +1102,12 @@ function registerInstanceOccurrence({
     }
 
     const key = `${scopeDescriptor?.id ?? "instance"}:${identifierRecord.name}`;
+    const identifierId = buildIdentifierId("instance", key);
     const entry = ensureCollectionEntry(
         identifierCollections.instanceVariables,
         key,
         () => ({
+            identifierId,
             key,
             name: identifierRecord.name,
             scopeId: scopeDescriptor?.id ?? null,
@@ -1062,6 +1116,10 @@ function registerInstanceOccurrence({
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     const clone = cloneIdentifierForCollections(identifierRecord, filePath);
     if (role === "declaration") {
@@ -1190,11 +1248,16 @@ function registerInstanceAssignment({
         return;
     }
 
+    const identifierKey = `${
+        scopeDescriptor?.id ?? "instance"
+    }:${identifierRecord.name}`;
+    const identifierId = buildIdentifierId("instance", identifierKey);
     const entry = ensureCollectionEntry(
         identifierCollections.instanceVariables,
-        `${scopeDescriptor?.id ?? "instance"}:${identifierRecord.name}`,
+        identifierKey,
         () => ({
-            key: `${scopeDescriptor?.id ?? "instance"}:${identifierRecord.name}`,
+            identifierId,
+            key: identifierKey,
             name: identifierRecord.name,
             scopeId: scopeDescriptor?.id ?? null,
             scopeKind: scopeDescriptor?.kind ?? null,
@@ -1202,6 +1265,10 @@ function registerInstanceAssignment({
             references: []
         })
     );
+
+    if (!entry.identifierId) {
+        entry.identifierId = identifierId;
+    }
 
     const clone = cloneIdentifierForCollections(identifierRecord, filePath);
 
@@ -1604,6 +1671,9 @@ export async function buildProjectIndex(
 
     const identifiers = {
         scripts: mapToObject(identifierCollections.scripts, (entry) => ({
+            identifierId:
+                entry.identifierId ??
+                buildIdentifierId("script", entry.id ?? entry.name ?? ""),
             id: entry.id,
             name: entry.name ?? null,
             displayName: entry.displayName ?? entry.name ?? entry.id,
@@ -1624,11 +1694,17 @@ export async function buildProjectIndex(
             }))
         })),
         macros: mapToObject(identifierCollections.macros, (entry) => ({
+            identifierId:
+                entry.identifierId ??
+                buildIdentifierId("macro", entry.name ?? ""),
             name: entry.name,
             declarations: entry.declarations.map((item) => ({ ...item })),
             references: entry.references.map((item) => ({ ...item }))
         })),
         enums: mapToObject(identifierCollections.enums, (entry) => ({
+            identifierId:
+                entry.identifierId ??
+                buildIdentifierId("enum", entry.key ?? entry.name ?? ""),
             key: entry.key,
             name: entry.name ?? null,
             filePath: entry.filePath ?? null,
@@ -1638,6 +1714,9 @@ export async function buildProjectIndex(
         enumMembers: mapToObject(
             identifierCollections.enumMembers,
             (entry) => ({
+                identifierId:
+                    entry.identifierId ??
+                    buildIdentifierId("enum-member", entry.key ?? ""),
                 key: entry.key,
                 name: entry.name ?? null,
                 enumKey: entry.enumKey ?? null,
@@ -1650,6 +1729,9 @@ export async function buildProjectIndex(
         globalVariables: mapToObject(
             identifierCollections.globalVariables,
             (entry) => ({
+                identifierId:
+                    entry.identifierId ??
+                    buildIdentifierId("global", entry.name ?? ""),
                 name: entry.name,
                 declarations: entry.declarations.map((item) => ({ ...item })),
                 references: entry.references.map((item) => ({ ...item }))
@@ -1658,6 +1740,9 @@ export async function buildProjectIndex(
         instanceVariables: mapToObject(
             identifierCollections.instanceVariables,
             (entry) => ({
+                identifierId:
+                    entry.identifierId ??
+                    buildIdentifierId("instance", entry.key ?? ""),
                 key: entry.key,
                 name: entry.name ?? null,
                 scopeId: entry.scopeId ?? null,

--- a/src/shared/tests/project-index-identifiers.test.js
+++ b/src/shared/tests/project-index-identifiers.test.js
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildProjectIndex } from "../project-index/index.js";
+
+async function writeFile(rootDir, relativePath, contents) {
+    const absolutePath = path.join(rootDir, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, contents, "utf8");
+}
+
+test("buildProjectIndex assigns identifier ids for each scope", async () => {
+    const tempRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "gml-index-scope-")
+    );
+
+    try {
+        await writeFile(
+            tempRoot,
+            "MyGame.yyp",
+            JSON.stringify({ name: "MyGame", resourceType: "GMProject" })
+        );
+
+        await writeFile(
+            tempRoot,
+            "scripts/scopeCollision/scopeCollision.yy",
+            JSON.stringify({
+                resourceType: "GMScript",
+                name: "scopeCollision"
+            })
+        );
+
+        await writeFile(
+            tempRoot,
+            "scripts/scopeCollision/scopeCollision.gml",
+            [
+                "#macro MACRO_VALUE 10",
+                "#macro macro_value 20",
+                "globalvar global_rate, GLOBAL_RATE;",
+                "global.GLOBALPOINT = 1;",
+                "global.globalPoint = 2;",
+                "enum RewardLevel {",
+                "    Bronze,",
+                "    bronze",
+                "}",
+                "function scopeCollision() {",
+                "    var local_total = MACRO_VALUE + macro_value;",
+                "    global_rate = local_total;",
+                "    GLOBAL_RATE = globalPoint + GLOBALPOINT;",
+                "    return RewardLevel.Bronze;",
+                "}",
+                ""
+            ].join("\n")
+        );
+
+        await writeFile(
+            tempRoot,
+            "objects/obj_tracker/obj_tracker.yy",
+            JSON.stringify({
+                resourceType: "GMObject",
+                name: "obj_tracker",
+                eventList: [
+                    {
+                        name: "Create_0",
+                        eventType: 0,
+                        eventNum: 0,
+                        eventId: {
+                            name: "Create_0",
+                            path: "objects/obj_tracker/obj_tracker_Create_0.gml"
+                        }
+                    }
+                ]
+            })
+        );
+
+        await writeFile(
+            tempRoot,
+            "objects/obj_tracker/obj_tracker_Create_0.gml",
+            [
+                "speed_bonus = 1;",
+                "SpeedBonus = speed_bonus + 1;",
+                "speedBonus = SpeedBonus + 1;",
+                ""
+            ].join("\n")
+        );
+
+        const index = await buildProjectIndex(tempRoot);
+
+        const scriptEntry =
+            index.identifiers.scripts["scope:script:scopeCollision"];
+        assert.ok(scriptEntry);
+        assert.equal(
+            scriptEntry.identifierId,
+            "script:scope:script:scopeCollision"
+        );
+
+        const macroUpper = index.identifiers.macros.MACRO_VALUE;
+        assert.equal(macroUpper.identifierId, "macro:MACRO_VALUE");
+        const macroLower = index.identifiers.macros.macro_value;
+        assert.equal(macroLower.identifierId, "macro:macro_value");
+
+        const globalLower = index.identifiers.globalVariables.global_rate;
+        assert.equal(globalLower.identifierId, "global:global_rate");
+        const globalUpper = index.identifiers.globalVariables.GLOBAL_RATE;
+        assert.equal(globalUpper.identifierId, "global:GLOBAL_RATE");
+
+        const enumEntries = Object.values(index.identifiers.enums);
+        assert.ok(enumEntries.length >= 1);
+        for (const entry of enumEntries) {
+            assert.ok(entry.identifierId?.startsWith("enum:"));
+        }
+
+        const instanceEntries = Object.values(
+            index.identifiers.instanceVariables
+        );
+        const instanceIds = instanceEntries.map((entry) => entry.identifierId);
+        assert.ok(instanceIds.every((id) => id?.startsWith("instance:")));
+        const uniqueInstanceIds = new Set(instanceIds);
+        assert.ok(uniqueInstanceIds.size >= 3);
+    } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary
- add stable identifierId fields to project-index collections and expose them in the serialized identifiers payload
- document the new per-scope identifier tracking and update the identifier-case planner commentary
- add scope collision fixtures and tests exercising script, macro, enum, global, and instance tracking

## Testing
- npm run test:shared
- npm run test:plugin *(fails: known fixture expectations in plugin.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1f847a50832f85eaee8ec8b5c3c1