### PR TITLE
Add asset rename utilities and integration tests

### DIFF
--- a/docs/asset-rename-precautions.md
+++ b/docs/asset-rename-precautions.md
@@ -1,0 +1,24 @@
+# Asset Rename Precautions
+
+Automated asset renames mutate both metadata (`.yy`) and source files on disk. To
+minimise data loss risks, follow these safeguards before running the rename
+pipeline:
+
+1. **Create a reversible checkpoint.** Capture a clean version-control commit or
+   take an external backup of the GameMaker project tree before executing the
+   formatter. A snapshot lets you undo every rename if an unexpected mutation
+   slips through.
+2. **Validate filesystem permissions.** Ensure the formatter process can write
+   to the `.yy`/`.gml` files being renamed and to their parent directories. The
+   rename utilities perform explicit access checks and will abort when write
+   access is missing, preventing partial moves.
+3. **Monitor rename summaries.** Review the generated rename log so that any
+   individual file move can be reverted quickly if required. Keep the summary
+   alongside your backup until the project has been verified in the GameMaker
+   IDE.
+
+If a rename run fails midway, restore from the backup or revert the checkpoint
+before retrying. This mirrors the operational guidance captured in the
+identifier-case risk plan and ensures a straightforward rollback path when the
+rename batch touches large dependency graphs across rooms, objects, and scripts.
+

--- a/src/plugin/src/assets/rename.js
+++ b/src/plugin/src/assets/rename.js
@@ -1,0 +1,407 @@
+import path from "node:path";
+import {
+    readFileSync as nodeReadFileSync,
+    writeFileSync as nodeWriteFileSync,
+    renameSync as nodeRenameSync,
+    accessSync as nodeAccessSync,
+    statSync as nodeStatSync,
+    mkdirSync as nodeMkdirSync,
+    existsSync as nodeExistsSync
+} from "node:fs";
+
+import { DEFAULT_WRITE_ACCESS_MODE } from "../identifier-case/common.js";
+
+const defaultFsFacade = Object.freeze({
+    readFileSync(targetPath, encoding = "utf8") {
+        return nodeReadFileSync(targetPath, encoding);
+    },
+    writeFileSync(targetPath, contents) {
+        nodeWriteFileSync(targetPath, contents, "utf8");
+    },
+    renameSync(fromPath, toPath) {
+        nodeRenameSync(fromPath, toPath);
+    },
+    accessSync(targetPath, mode = DEFAULT_WRITE_ACCESS_MODE) {
+        if (mode != null) {
+            nodeAccessSync(targetPath, mode);
+        } else {
+            nodeAccessSync(targetPath);
+        }
+    },
+    statSync(targetPath) {
+        return nodeStatSync(targetPath);
+    },
+    mkdirSync(targetPath) {
+        nodeMkdirSync(targetPath, { recursive: true });
+    },
+    existsSync(targetPath) {
+        return nodeExistsSync(targetPath);
+    }
+});
+
+function toSystemPath(relativePath) {
+    if (typeof relativePath !== "string") {
+        return relativePath ?? "";
+    }
+
+    return relativePath.replace(/\//g, path.sep);
+}
+
+function resolveAbsolutePath(projectRoot, relativePath) {
+    if (!relativePath) {
+        return projectRoot;
+    }
+
+    if (path.isAbsolute(relativePath)) {
+        return relativePath;
+    }
+
+    const systemRelative = toSystemPath(relativePath);
+    return path.join(projectRoot, systemRelative);
+}
+
+function stringifyJson(json) {
+    return `${JSON.stringify(json, null, 4)}\n`;
+}
+
+function readJsonFile(fsFacade, absolutePath, cache) {
+    if (cache && cache.has(absolutePath)) {
+        return cache.get(absolutePath);
+    }
+
+    const raw = fsFacade.readFileSync(absolutePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (cache) {
+        cache.set(absolutePath, parsed);
+    }
+    return parsed;
+}
+
+function getObjectAtPath(json, propertyPath) {
+    if (!propertyPath) {
+        return json;
+    }
+
+    const segments = propertyPath
+        .split(".")
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0);
+
+    let current = json;
+    for (const segment of segments) {
+        if (Array.isArray(current)) {
+            const index = Number(segment);
+            if (
+                !Number.isInteger(index) ||
+                index < 0 ||
+                index >= current.length
+            ) {
+                return null;
+            }
+            current = current[index];
+            continue;
+        }
+
+        if (!current || typeof current !== "object") {
+            return null;
+        }
+
+        if (!Object.hasOwn(current, segment)) {
+            return null;
+        }
+
+        current = current[segment];
+    }
+
+    return current;
+}
+
+function updateReferenceObject(json, propertyPath, newResourcePath, newName) {
+    if (!json) {
+        return false;
+    }
+
+    const target = getObjectAtPath(json, propertyPath);
+    if (!target || typeof target !== "object") {
+        return false;
+    }
+
+    let changed = false;
+
+    if (
+        typeof newResourcePath === "string" &&
+        newResourcePath.length > 0 &&
+        target.path !== newResourcePath
+    ) {
+        target.path = newResourcePath;
+        changed = true;
+    }
+
+    if (
+        typeof newName === "string" &&
+        newName.length > 0 &&
+        target.name !== newName
+    ) {
+        target.name = newName;
+        changed = true;
+    }
+
+    return changed;
+}
+
+function ensureWritableDirectory(fsFacade, directoryPath) {
+    if (!directoryPath) {
+        return;
+    }
+
+    try {
+        if (typeof fsFacade.accessSync === "function") {
+            fsFacade.accessSync(directoryPath, DEFAULT_WRITE_ACCESS_MODE);
+            return;
+        }
+
+        if (typeof fsFacade.existsSync === "function") {
+            if (fsFacade.existsSync(directoryPath)) {
+                return;
+            }
+        }
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+
+    if (typeof fsFacade.mkdirSync === "function") {
+        fsFacade.mkdirSync(directoryPath);
+    }
+}
+
+function ensureWritableFile(fsFacade, filePath) {
+    try {
+        if (typeof fsFacade.accessSync === "function") {
+            fsFacade.accessSync(filePath, DEFAULT_WRITE_ACCESS_MODE);
+            return;
+        }
+
+        if (typeof fsFacade.statSync === "function") {
+            fsFacade.statSync(filePath);
+            return;
+        }
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+
+    ensureWritableDirectory(fsFacade, path.dirname(filePath));
+}
+
+export function createAssetRenameExecutor({
+    projectIndex,
+    fsFacade = null,
+    logger = null
+} = {}) {
+    if (!projectIndex || typeof projectIndex.projectRoot !== "string") {
+        return {
+            queueRename() {
+                return false;
+            },
+            commit() {
+                return { writes: [], renames: [] };
+            }
+        };
+    }
+
+    const effectiveFs = fsFacade
+        ? { ...defaultFsFacade, ...fsFacade }
+        : defaultFsFacade;
+    const projectRoot = projectIndex.projectRoot;
+    const jsonCache = new Map();
+    const pendingWrites = new Map();
+    const renameActions = [];
+
+    return {
+        queueRename(rename) {
+            if (!rename?.resourcePath || !rename?.toName) {
+                return false;
+            }
+
+            const resourceAbsolute = resolveAbsolutePath(
+                projectRoot,
+                rename.resourcePath
+            );
+            const resourceJson = readJsonFile(
+                effectiveFs,
+                resourceAbsolute,
+                jsonCache
+            );
+
+            if (!resourceJson || typeof resourceJson !== "object") {
+                throw new Error(
+                    `Unable to parse resource metadata at '${rename.resourcePath}'.`
+                );
+            }
+
+            let resourceChanged = false;
+            if (resourceJson.name !== rename.toName) {
+                resourceJson.name = rename.toName;
+                resourceChanged = true;
+            }
+
+            if (
+                typeof rename.newResourcePath === "string" &&
+                rename.newResourcePath.length > 0 &&
+                resourceJson.resourcePath !== rename.newResourcePath
+            ) {
+                resourceJson.resourcePath = rename.newResourcePath;
+                resourceChanged = true;
+            }
+
+            if (resourceChanged) {
+                pendingWrites.set(resourceAbsolute, resourceJson);
+            }
+
+            const groupedReferences = new Map();
+            for (const mutation of rename.referenceMutations ?? []) {
+                if (!mutation?.filePath) {
+                    continue;
+                }
+                const entries = groupedReferences.get(mutation.filePath) ?? [];
+                entries.push(mutation);
+                groupedReferences.set(mutation.filePath, entries);
+            }
+
+            for (const [filePath, mutations] of groupedReferences.entries()) {
+                const absolutePath = resolveAbsolutePath(projectRoot, filePath);
+                let targetJson;
+                try {
+                    targetJson = readJsonFile(
+                        effectiveFs,
+                        absolutePath,
+                        jsonCache
+                    );
+                } catch (error) {
+                    if (logger && typeof logger.warn === "function") {
+                        logger.warn(
+                            `Skipping asset reference update for '${filePath}': ${error.message}`
+                        );
+                    }
+                    continue;
+                }
+
+                if (!targetJson || typeof targetJson !== "object") {
+                    continue;
+                }
+
+                let updated = false;
+                for (const mutation of mutations) {
+                    const changed = updateReferenceObject(
+                        targetJson,
+                        mutation.propertyPath,
+                        rename.newResourcePath,
+                        rename.toName
+                    );
+                    if (changed) {
+                        updated = true;
+                    }
+                }
+
+                if (updated) {
+                    pendingWrites.set(absolutePath, targetJson);
+                }
+            }
+
+            const newResourceAbsolute = resolveAbsolutePath(
+                projectRoot,
+                rename.newResourcePath
+            );
+
+            if (newResourceAbsolute !== resourceAbsolute) {
+                renameActions.push({
+                    from: resourceAbsolute,
+                    to: newResourceAbsolute
+                });
+            }
+
+            for (const gmlRename of rename.gmlRenames ?? []) {
+                if (!gmlRename?.from || !gmlRename?.to) {
+                    continue;
+                }
+
+                const fromAbsolute = resolveAbsolutePath(
+                    projectRoot,
+                    gmlRename.from
+                );
+                const toAbsolute = resolveAbsolutePath(
+                    projectRoot,
+                    gmlRename.to
+                );
+
+                if (fromAbsolute === toAbsolute) {
+                    continue;
+                }
+
+                renameActions.push({ from: fromAbsolute, to: toAbsolute });
+            }
+
+            return true;
+        },
+
+        commit() {
+            const writeActions = Array.from(pendingWrites.entries()).map(
+                ([filePath, jsonData]) => ({
+                    filePath,
+                    contents: stringifyJson(jsonData)
+                })
+            );
+
+            if (writeActions.length === 0 && renameActions.length === 0) {
+                return { writes: [], renames: [] };
+            }
+
+            for (const action of writeActions) {
+                ensureWritableFile(effectiveFs, action.filePath);
+            }
+
+            for (const action of renameActions) {
+                ensureWritableFile(effectiveFs, action.from);
+                ensureWritableDirectory(effectiveFs, path.dirname(action.to));
+                if (
+                    typeof effectiveFs.existsSync === "function" &&
+                    effectiveFs.existsSync(action.to)
+                ) {
+                    throw new Error(
+                        `Cannot rename '${action.from}' to existing path '${action.to}'.`
+                    );
+                }
+            }
+
+            for (const action of writeActions) {
+                ensureWritableDirectory(
+                    effectiveFs,
+                    path.dirname(action.filePath)
+                );
+                effectiveFs.writeFileSync(action.filePath, action.contents);
+            }
+
+            for (const action of renameActions) {
+                ensureWritableDirectory(effectiveFs, path.dirname(action.to));
+                effectiveFs.renameSync(action.from, action.to);
+            }
+
+            return { writes: writeActions, renames: renameActions.slice() };
+        }
+    };
+}
+
+export const __private__ = {
+    defaultFsFacade,
+    toSystemPath,
+    resolveAbsolutePath,
+    stringifyJson,
+    readJsonFile,
+    getObjectAtPath,
+    updateReferenceObject,
+    ensureWritableFile,
+    ensureWritableDirectory
+};

--- a/src/plugin/src/identifier-case/asset-renames.js
+++ b/src/plugin/src/identifier-case/asset-renames.js
@@ -1,13 +1,4 @@
 import path from "node:path";
-import {
-    readFileSync as nodeReadFileSync,
-    writeFileSync as nodeWriteFileSync,
-    renameSync as nodeRenameSync,
-    accessSync as nodeAccessSync,
-    statSync as nodeStatSync,
-    mkdirSync as nodeMkdirSync,
-    existsSync as nodeExistsSync
-} from "node:fs";
 
 import { formatIdentifierCase } from "../../../shared/identifier-case.js";
 import {
@@ -17,194 +8,9 @@ import {
     createConflict,
     matchesIgnorePattern,
     incrementFileOccurrence,
-    summarizeFileOccurrences,
-    DEFAULT_WRITE_ACCESS_MODE
+    summarizeFileOccurrences
 } from "./common.js";
-
-const defaultFsFacade = Object.freeze({
-    readFileSync(targetPath, encoding = "utf8") {
-        return nodeReadFileSync(targetPath, encoding);
-    },
-    writeFileSync(targetPath, contents) {
-        nodeWriteFileSync(targetPath, contents, "utf8");
-    },
-    renameSync(fromPath, toPath) {
-        nodeRenameSync(fromPath, toPath);
-    },
-    accessSync(targetPath, mode = DEFAULT_WRITE_ACCESS_MODE) {
-        if (mode != null) {
-            nodeAccessSync(targetPath, mode);
-        } else {
-            nodeAccessSync(targetPath);
-        }
-    },
-    statSync(targetPath) {
-        return nodeStatSync(targetPath);
-    },
-    mkdirSync(targetPath) {
-        nodeMkdirSync(targetPath, { recursive: true });
-    },
-    existsSync(targetPath) {
-        return nodeExistsSync(targetPath);
-    }
-});
-
-function toSystemPath(relativePath) {
-    if (typeof relativePath !== "string") {
-        return relativePath ?? "";
-    }
-
-    return relativePath.replace(/\//g, path.sep);
-}
-
-function resolveAbsolutePath(projectRoot, relativePath) {
-    if (!relativePath) {
-        return projectRoot;
-    }
-
-    if (path.isAbsolute(relativePath)) {
-        return relativePath;
-    }
-
-    const systemRelative = toSystemPath(relativePath);
-    return path.join(projectRoot, systemRelative);
-}
-
-function stringifyJson(json) {
-    return `${JSON.stringify(json, null, 4)}\n`;
-}
-
-function readJsonFile(fsFacade, absolutePath, cache) {
-    if (cache && cache.has(absolutePath)) {
-        return cache.get(absolutePath);
-    }
-
-    const raw = fsFacade.readFileSync(absolutePath, "utf8");
-    const parsed = JSON.parse(raw);
-    if (cache) {
-        cache.set(absolutePath, parsed);
-    }
-    return parsed;
-}
-
-function getObjectAtPath(json, propertyPath) {
-    if (!propertyPath) {
-        return json;
-    }
-
-    const segments = propertyPath
-        .split(".")
-        .map((segment) => segment.trim())
-        .filter((segment) => segment.length > 0);
-
-    let current = json;
-    for (const segment of segments) {
-        if (Array.isArray(current)) {
-            const index = Number(segment);
-            if (
-                !Number.isInteger(index) ||
-                index < 0 ||
-                index >= current.length
-            ) {
-                return null;
-            }
-            current = current[index];
-            continue;
-        }
-
-        if (!current || typeof current !== "object") {
-            return null;
-        }
-
-        if (!Object.hasOwn(current, segment)) {
-            return null;
-        }
-
-        current = current[segment];
-    }
-
-    return current;
-}
-
-function updateReferenceObject(json, propertyPath, newResourcePath, newName) {
-    if (!json) {
-        return false;
-    }
-
-    const target = getObjectAtPath(json, propertyPath);
-    if (!target || typeof target !== "object") {
-        return false;
-    }
-
-    let changed = false;
-
-    if (
-        typeof newResourcePath === "string" &&
-        newResourcePath.length > 0 &&
-        target.path !== newResourcePath
-    ) {
-        target.path = newResourcePath;
-        changed = true;
-    }
-
-    if (
-        typeof newName === "string" &&
-        newName.length > 0 &&
-        target.name !== newName
-    ) {
-        target.name = newName;
-        changed = true;
-    }
-
-    return changed;
-}
-
-function ensureWritableDirectory(fsFacade, directoryPath) {
-    if (!directoryPath) {
-        return;
-    }
-
-    try {
-        if (typeof fsFacade.accessSync === "function") {
-            fsFacade.accessSync(directoryPath, DEFAULT_WRITE_ACCESS_MODE);
-            return;
-        }
-
-        if (typeof fsFacade.existsSync === "function") {
-            if (fsFacade.existsSync(directoryPath)) {
-                return;
-            }
-        }
-    } catch (error) {
-        if (!error || error.code !== "ENOENT") {
-            throw error;
-        }
-    }
-
-    if (typeof fsFacade.mkdirSync === "function") {
-        fsFacade.mkdirSync(directoryPath);
-    }
-}
-
-function ensureWritableFile(fsFacade, filePath) {
-    try {
-        if (typeof fsFacade.accessSync === "function") {
-            fsFacade.accessSync(filePath, DEFAULT_WRITE_ACCESS_MODE);
-            return;
-        }
-
-        if (typeof fsFacade.statSync === "function") {
-            fsFacade.statSync(filePath);
-            return;
-        }
-    } catch (error) {
-        if (!error || error.code !== "ENOENT") {
-            throw error;
-        }
-    }
-
-    ensureWritableDirectory(fsFacade, path.dirname(filePath));
-}
+import { createAssetRenameExecutor } from "../assets/rename.js";
 
 function summarizeReferences(referenceMutations, resourcePath) {
     const counts = new Map();
@@ -399,162 +205,23 @@ export function applyAssetRenames({
         return { writes: [], renames: [] };
     }
 
-    const effectiveFs = fsFacade
-        ? { ...defaultFsFacade, ...fsFacade }
-        : defaultFsFacade;
-    const root = projectIndex.projectRoot;
+    const executor = createAssetRenameExecutor({
+        projectIndex,
+        fsFacade,
+        logger
+    });
 
-    const jsonCache = new Map();
-    const pendingWrites = new Map();
-    const renameActions = [];
-
+    let hasQueuedRenames = false;
     for (const rename of renames) {
-        if (!rename?.resourcePath || !rename?.toName) {
-            continue;
-        }
-
-        const resourceAbsolute = resolveAbsolutePath(root, rename.resourcePath);
-        const resourceJson = readJsonFile(
-            effectiveFs,
-            resourceAbsolute,
-            jsonCache
-        );
-
-        if (!resourceJson || typeof resourceJson !== "object") {
-            throw new Error(
-                `Unable to parse resource metadata at '${rename.resourcePath}'.`
-            );
-        }
-
-        let resourceChanged = false;
-        if (resourceJson.name !== rename.toName) {
-            resourceJson.name = rename.toName;
-            resourceChanged = true;
-        }
-
-        if (
-            typeof rename.newResourcePath === "string" &&
-            resourceJson.resourcePath !== rename.newResourcePath
-        ) {
-            resourceJson.resourcePath = rename.newResourcePath;
-            resourceChanged = true;
-        }
-
-        if (resourceChanged) {
-            pendingWrites.set(resourceAbsolute, resourceJson);
-        }
-
-        const groupedReferences = new Map();
-        for (const mutation of rename.referenceMutations ?? []) {
-            if (!mutation?.filePath) {
-                continue;
-            }
-            const entries = groupedReferences.get(mutation.filePath) ?? [];
-            entries.push(mutation);
-            groupedReferences.set(mutation.filePath, entries);
-        }
-
-        for (const [filePath, mutations] of groupedReferences.entries()) {
-            const absolutePath = resolveAbsolutePath(root, filePath);
-            let targetJson;
-            try {
-                targetJson = readJsonFile(effectiveFs, absolutePath, jsonCache);
-            } catch (error) {
-                if (logger && typeof logger.warn === "function") {
-                    logger.warn(
-                        `Skipping asset reference update for '${filePath}': ${error.message}`
-                    );
-                }
-                continue;
-            }
-
-            if (!targetJson || typeof targetJson !== "object") {
-                continue;
-            }
-
-            let updated = false;
-            for (const mutation of mutations) {
-                const changed = updateReferenceObject(
-                    targetJson,
-                    mutation.propertyPath,
-                    rename.newResourcePath,
-                    rename.toName
-                );
-                if (changed) {
-                    updated = true;
-                }
-            }
-
-            if (updated) {
-                pendingWrites.set(absolutePath, targetJson);
-            }
-        }
-
-        const newResourceAbsolute = resolveAbsolutePath(
-            root,
-            rename.newResourcePath
-        );
-
-        if (newResourceAbsolute !== resourceAbsolute) {
-            renameActions.push({
-                from: resourceAbsolute,
-                to: newResourceAbsolute
-            });
-        }
-
-        for (const gmlRename of rename.gmlRenames ?? []) {
-            if (!gmlRename?.from || !gmlRename?.to) {
-                continue;
-            }
-
-            const fromAbsolute = resolveAbsolutePath(root, gmlRename.from);
-            const toAbsolute = resolveAbsolutePath(root, gmlRename.to);
-
-            if (fromAbsolute === toAbsolute) {
-                continue;
-            }
-
-            renameActions.push({ from: fromAbsolute, to: toAbsolute });
+        const queued = executor.queueRename(rename);
+        if (queued) {
+            hasQueuedRenames = true;
         }
     }
 
-    const writeActions = Array.from(pendingWrites.entries()).map(
-        ([filePath, jsonData]) => ({
-            filePath,
-            contents: stringifyJson(jsonData)
-        })
-    );
-
-    if (writeActions.length === 0 && renameActions.length === 0) {
+    if (!hasQueuedRenames) {
         return { writes: [], renames: [] };
     }
 
-    for (const action of writeActions) {
-        ensureWritableFile(effectiveFs, action.filePath);
-    }
-
-    for (const action of renameActions) {
-        ensureWritableFile(effectiveFs, action.from);
-        ensureWritableDirectory(effectiveFs, path.dirname(action.to));
-        if (
-            typeof effectiveFs.existsSync === "function" &&
-            effectiveFs.existsSync(action.to)
-        ) {
-            throw new Error(
-                `Cannot rename '${action.from}' to existing path '${action.to}'.`
-            );
-        }
-    }
-
-    for (const action of writeActions) {
-        ensureWritableDirectory(effectiveFs, path.dirname(action.filePath));
-        effectiveFs.writeFileSync(action.filePath, action.contents);
-    }
-
-    for (const action of renameActions) {
-        ensureWritableDirectory(effectiveFs, path.dirname(action.to));
-        effectiveFs.renameSync(action.from, action.to);
-    }
-
-    return { writes: writeActions, renames: renameActions };
+    return executor.commit();
 }

--- a/src/plugin/tests/assets-rename.integration.test.js
+++ b/src/plugin/tests/assets-rename.integration.test.js
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { buildProjectIndex } from "../../shared/project-index/index.js";
+import {
+    planAssetRenames,
+    applyAssetRenames
+} from "../src/identifier-case/asset-renames.js";
+
+describe("asset rename utilities", () => {
+    it("renames script assets and updates dependent resource metadata atomically", async () => {
+        const projectRoot = await createSyntheticProject();
+
+        try {
+            const projectIndex = await buildProjectIndex(projectRoot);
+
+            const { renames, conflicts } = planAssetRenames({
+                projectIndex,
+                assetStyle: "pascal"
+            });
+
+            assert.deepStrictEqual(conflicts, []);
+            assert.strictEqual(renames.length, 1);
+
+            const result = applyAssetRenames({ projectIndex, renames });
+
+            assert.ok(
+                result.renames.length > 0,
+                "Expected rename actions to be recorded"
+            );
+
+            const renamedYyRelative = "scripts/demo_script/DemoScript.yy";
+            const renamedGmlRelative = "scripts/demo_script/DemoScript.gml";
+            const renamedYyPath = path.join(
+                projectRoot,
+                toSystemPath(renamedYyRelative)
+            );
+            const renamedGmlPath = path.join(
+                projectRoot,
+                toSystemPath(renamedGmlRelative)
+            );
+
+            await assertRejectsNotFound(
+                path.join(projectRoot, "scripts/demo_script/demo_script.yy")
+            );
+            await assertRejectsNotFound(
+                path.join(projectRoot, "scripts/demo_script/demo_script.gml")
+            );
+
+            const scriptData = JSON.parse(
+                await fs.readFile(renamedYyPath, "utf8")
+            );
+            assert.strictEqual(scriptData.name, "DemoScript");
+            assert.strictEqual(scriptData.resourcePath, renamedYyRelative);
+            assert.deepStrictEqual(scriptData.linkedScript, {
+                path: renamedYyRelative,
+                name: "DemoScript"
+            });
+
+            const projectData = JSON.parse(
+                await fs.readFile(path.join(projectRoot, "MyGame.yyp"), "utf8")
+            );
+            assert.strictEqual(
+                projectData.resources[0].id.path,
+                renamedYyRelative
+            );
+            assert.strictEqual(projectData.resources[0].id.name, "DemoScript");
+
+            const objectData = JSON.parse(
+                await fs.readFile(
+                    path.join(
+                        projectRoot,
+                        toSystemPath(
+                            "objects/obj_controller/obj_controller.yy"
+                        )
+                    ),
+                    "utf8"
+                )
+            );
+            assert.deepStrictEqual(objectData.scriptExecute, {
+                path: renamedYyRelative,
+                name: "DemoScript"
+            });
+            assert.deepStrictEqual(
+                objectData.eventList[0].actionList[0].script,
+                {
+                    path: renamedYyRelative,
+                    name: "DemoScript"
+                }
+            );
+
+            const roomData = JSON.parse(
+                await fs.readFile(
+                    path.join(
+                        projectRoot,
+                        toSystemPath("rooms/room_start/room_start.yy")
+                    ),
+                    "utf8"
+                )
+            );
+            assert.deepStrictEqual(roomData.creationCodeScript, {
+                path: renamedYyRelative,
+                name: "DemoScript"
+            });
+            assert.deepStrictEqual(
+                roomData.layers[0].instances[0].creationCodeScript,
+                {
+                    path: renamedYyRelative,
+                    name: "DemoScript"
+                }
+            );
+
+            const gmlContent = await fs.readFile(renamedGmlPath, "utf8");
+            assert.ok(
+                gmlContent.includes("function demo_script()"),
+                "Renamed GML file should preserve original code"
+            );
+        } finally {
+            await fs.rm(projectRoot, { recursive: true, force: true });
+        }
+    });
+});
+
+async function createSyntheticProject() {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "gml-asset-utils-"));
+
+    const writeJson = async (relativePath, data) => {
+        const absolutePath = path.join(root, toSystemPath(relativePath));
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(
+            absolutePath,
+            `${JSON.stringify(data, null, 4)}\n`,
+            "utf8"
+        );
+    };
+
+    const writeText = async (relativePath, contents) => {
+        const absolutePath = path.join(root, toSystemPath(relativePath));
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, contents, "utf8");
+    };
+
+    const scriptPath = "scripts/demo_script/demo_script.yy";
+    const objectPath = "objects/obj_controller/obj_controller.yy";
+    const roomPath = "rooms/room_start/room_start.yy";
+
+    await writeJson("MyGame.yyp", {
+        name: "MyGame",
+        resourceType: "GMProject",
+        resources: [
+            {
+                id: { name: "demo_script", path: scriptPath }
+            },
+            {
+                id: { name: "obj_controller", path: objectPath }
+            },
+            {
+                id: { name: "room_start", path: roomPath }
+            }
+        ]
+    });
+
+    await writeJson(scriptPath, {
+        resourceType: "GMScript",
+        name: "demo_script",
+        resourcePath: scriptPath,
+        linkedScript: { path: scriptPath, name: "demo_script" }
+    });
+
+    await writeText(
+        "scripts/demo_script/demo_script.gml",
+        "function demo_script() {\n    return 42;\n}\n"
+    );
+
+    await writeJson(objectPath, {
+        resourceType: "GMObject",
+        name: "obj_controller",
+        scriptExecute: { path: scriptPath, name: "demo_script" },
+        eventList: [
+            {
+                resourceType: "GMEvent",
+                eventType: 0,
+                eventNum: 0,
+                actionList: [
+                    {
+                        resourceType: "GMObjectEventAction",
+                        actionName: "ExecuteScript",
+                        script: { path: scriptPath, name: "demo_script" }
+                    }
+                ]
+            }
+        ]
+    });
+
+    await writeJson(roomPath, {
+        resourceType: "GMRoom",
+        name: "room_start",
+        creationCodeScript: { path: scriptPath, name: "demo_script" },
+        layers: [
+            {
+                resourceType: "GMRInstanceLayer",
+                name: "Instances",
+                instances: [
+                    {
+                        resourceType: "GMRInstance",
+                        name: "obj_controller_1",
+                        objectId: { name: "obj_controller", path: objectPath },
+                        creationCodeScript: {
+                            path: scriptPath,
+                            name: "demo_script"
+                        }
+                    }
+                ]
+            }
+        ],
+        instanceCreationOrder: [{ name: "obj_controller", path: objectPath }]
+    });
+
+    return root;
+}
+
+async function assertRejectsNotFound(targetPath) {
+    try {
+        await fs.access(targetPath);
+        assert.fail(`Path '${targetPath}' unexpectedly exists.`);
+    } catch (error) {
+        if (!error || error.code !== "ENOENT") {
+            throw error;
+        }
+    }
+}
+
+function toSystemPath(relativePath) {
+    return relativePath.replace(/\//g, path.sep);
+}


### PR DESCRIPTION
## Summary
- add a reusable asset rename executor that rewrites .yy metadata, updates referencing resources, and performs guarded filesystem moves
- refactor the identifier-case asset renamer to use the shared executor and keep rename batches atomic
- document operational precautions for running asset renames and add an integration test covering metadata and disk updates

## Testing
- `node --test src/plugin/tests/assets-rename.integration.test.js`
- `npm run test:plugin` *(fails: missing src/plugin/src/printer/enum-alignment.js in upstream test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc3d163ac832fb881d5bfd5a318cc