### PR TITLE
Detect asset rename conflicts via project index

### DIFF
--- a/src/plugin/src/identifier-case/common.js
+++ b/src/plugin/src/identifier-case/common.js
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 export const COLLISION_CONFLICT_CODE = "collision";
 export const PRESERVE_CONFLICT_CODE = "preserve";
 export const IGNORE_CONFLICT_CODE = "ignored";
+export const RESERVED_CONFLICT_CODE = "reserved";
 
 export function escapeForRegExp(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -63,7 +64,8 @@ export function createConflict({
     message,
     scope,
     identifier,
-    suggestions = []
+    suggestions = [],
+    details = null
 }) {
     return {
         code,
@@ -71,7 +73,8 @@ export function createConflict({
         message,
         scope,
         identifier,
-        suggestions
+        suggestions,
+        details
     };
 }
 


### PR DESCRIPTION
## Summary
- extend the asset rename planner to inspect the ProjectIndex for duplicate, case-only, and reserved-name collisions before mutating metadata
- enrich identifier-case conflicts with a reserved-word code and optional details for richer diagnostics
- add integration coverage for asset rename collision and reserved-word guidance to ensure conflicts abort writes and provide remediation tips

## Testing
- `npm test` *(fails: Project layout lacks src/plugin/src/printer/enum-alignment.js, causing ERR_MODULE_NOT_FOUND when running existing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc5c3d2ac832fa8f418dd0bab1647