### PR TITLE
Add metrics instrumentation and performance benchmark tooling

### DIFF
--- a/scripts/bench-identifier-pipeline.mjs
+++ b/scripts/bench-identifier-pipeline.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import path from "node:path";
+import process from "node:process";
+
+import { buildProjectIndex } from "../src/shared/project-index/index.js";
+import { prepareIdentifierCasePlan } from "../src/plugin/src/identifier-case/local-plan.js";
+
+function createConsoleLogger(verbose) {
+    if (!verbose) {
+        return null;
+    }
+    return {
+        debug(...args) {
+            console.debug(...args);
+        }
+    };
+}
+
+function formatMetrics(label, metrics) {
+    return {
+        label,
+        totalTimeMs: metrics?.totalTimeMs ?? null,
+        counters: metrics?.counters ?? {},
+        timings: metrics?.timings ?? {},
+        caches: metrics?.caches ?? {},
+        metadata: metrics?.metadata ?? {}
+    };
+}
+
+async function run() {
+    const [, , projectRootArg, fileArg, ...rest] = process.argv;
+    const flags = new Set(rest);
+    const verbose = flags.has("--verbose");
+    const projectRoot = path.resolve(projectRootArg ?? process.cwd());
+
+    const logger = createConsoleLogger(verbose);
+
+    const indexRuns = [];
+    let latestIndex = null;
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+        const index = await buildProjectIndex(projectRoot, undefined, {
+            logger,
+            logMetrics: verbose
+        });
+        indexRuns.push(
+            formatMetrics(`project-index-run-${attempt}`, index.metrics)
+        );
+        latestIndex = index;
+    }
+
+    const results = {
+        projectRoot,
+        index: indexRuns
+    };
+
+    if (fileArg) {
+        const filepath = path.resolve(fileArg);
+        const renameOptions = {
+            filepath,
+            __identifierCaseProjectIndex: latestIndex,
+            gmlIdentifierCase: "camel",
+            gmlIdentifierCaseLocals: "camel",
+            gmlIdentifierCaseAssets: "pascal",
+            gmlIdentifierCaseAcknowledgeAssetRenames: true,
+            logIdentifierCaseMetrics: verbose,
+            logger
+        };
+
+        prepareIdentifierCasePlan(renameOptions);
+
+        results.renamePlan = formatMetrics(
+            "identifier-case-plan",
+            renameOptions.__identifierCaseMetricsReport
+        );
+        results.renamePlan.operations =
+            renameOptions.__identifierCaseRenamePlan?.operations?.length ?? 0;
+        results.renamePlan.conflicts =
+            renameOptions.__identifierCaseConflicts?.length ?? 0;
+    }
+
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/shared/metrics.js
+++ b/src/shared/metrics.js
@@ -1,0 +1,157 @@
+const hasHrtime = typeof process?.hrtime?.bigint === "function";
+
+function nowMs() {
+    if (hasHrtime) {
+        const ns = process.hrtime.bigint();
+        return Number(ns / 1000000n);
+    }
+    return Date.now();
+}
+
+function normalizeLabel(label) {
+    return typeof label === "string" && label.length > 0 ? label : "unknown";
+}
+
+export function createMetricsTracker({
+    category = "metrics",
+    logger = null,
+    autoLog = false
+} = {}) {
+    const startTime = nowMs();
+    const timings = new Map();
+    const counters = Object.create(null);
+    const caches = Object.create(null);
+    const metadata = Object.create(null);
+
+    function recordTiming(label, durationMs) {
+        const normalized = normalizeLabel(label);
+        const previous = timings.get(normalized) ?? 0;
+        timings.set(normalized, previous + Math.max(0, durationMs));
+    }
+
+    function startTimer(label) {
+        const startedAt = nowMs();
+        return () => {
+            recordTiming(label, nowMs() - startedAt);
+        };
+    }
+
+    function timeSync(label, callback) {
+        const stop = startTimer(label);
+        try {
+            return callback();
+        } finally {
+            stop();
+        }
+    }
+
+    async function timeAsync(label, callback) {
+        const stop = startTimer(label);
+        try {
+            return await callback();
+        } finally {
+            stop();
+        }
+    }
+
+    function incrementCounter(label, amount = 1) {
+        const normalized = normalizeLabel(label);
+        const previous = counters[normalized] ?? 0;
+        counters[normalized] = previous + amount;
+    }
+
+    function recordCacheEvent(cacheName, key) {
+        const normalized = normalizeLabel(cacheName);
+        const existing = caches[normalized] ?? {
+            hits: 0,
+            misses: 0,
+            stale: 0
+        };
+        existing[key] += 1;
+        caches[normalized] = existing;
+    }
+
+    function snapshot(extra = {}) {
+        const endTime = nowMs();
+        const summary = {
+            category,
+            totalTimeMs: endTime - startTime,
+            timings: Object.fromEntries(timings),
+            counters: { ...counters },
+            caches: Object.fromEntries(
+                Object.entries(caches).map(([name, value]) => [
+                    name,
+                    { ...value }
+                ])
+            ),
+            metadata: { ...metadata }
+        };
+
+        if (extra && typeof extra === "object") {
+            if (extra.timings) {
+                for (const [label, value] of Object.entries(extra.timings)) {
+                    summary.timings[label] = value;
+                }
+            }
+            if (extra.counters) {
+                for (const [label, value] of Object.entries(extra.counters)) {
+                    summary.counters[label] = value;
+                }
+            }
+            if (extra.caches) {
+                for (const [label, value] of Object.entries(extra.caches)) {
+                    summary.caches[label] = value;
+                }
+            }
+            if (extra.metadata) {
+                Object.assign(summary.metadata, extra.metadata);
+            }
+        }
+
+        return summary;
+    }
+
+    function logSummary(message = "summary", extra = {}) {
+        if (!logger || typeof logger.debug !== "function") {
+            return;
+        }
+        const report = snapshot(extra);
+        logger.debug(`[${category}] ${message}`, report);
+    }
+
+    function finalize(extra = {}) {
+        const report = snapshot(extra);
+        if (autoLog) {
+            logSummary("summary", extra);
+        }
+        return report;
+    }
+
+    function setMetadata(key, value) {
+        if (typeof key !== "string" || key.length === 0) {
+            return;
+        }
+        metadata[key] = value;
+    }
+
+    return {
+        category,
+        timeSync,
+        timeAsync,
+        startTimer,
+        incrementCounter,
+        recordCacheHit(cacheName) {
+            recordCacheEvent(cacheName, "hits");
+        },
+        recordCacheMiss(cacheName) {
+            recordCacheEvent(cacheName, "misses");
+        },
+        recordCacheStale(cacheName) {
+            recordCacheEvent(cacheName, "stale");
+        },
+        snapshot,
+        finalize,
+        logSummary,
+        setMetadata
+    };
+}


### PR DESCRIPTION
## Summary
- instrument the project index builder with reusable metrics tracking, cache hit reporting, and bounded parsing concurrency
- extend the identifier-case rename planner to collect per-stage metrics and expose them through the generated plan
- add a benchmark script and design doc updates describing the new metrics-driven tuning guidance

## Testing
- npm run test:shared
- npm run test:plugin (fails: fixture assertions)

------
https://chatgpt.com/codex/tasks/task_e_68ec1e15f4cc832f8039ee4b5157fe4f