### PR TITLE
Normalize legacy #define directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,18 @@ See the [Prettier CLI docs](https://prettier.io/docs/en/cli.html) for more optio
 formatter-specific tooling? Browse the [documentation index](docs/README.md) for plans and guides on metadata harvesting,
 identifier handling, and rename safety nets.
 
+### Legacy `#define` directives
+
+GameMaker Studio 2 rejects `#define` statements, so the formatter automatically normalises them while preserving the
+surrounding whitespace:
+
+- Macro-style directives are rewritten as `#macro` declarations so compiled builds remain valid.
+- Markers that look like region headers or footers are converted to `#region`/`#endregion`.
+- Lines that do not match either pattern are dropped entirely so stray `#define` placeholders cannot break builds.
+
+Add a comment explaining the original intent if you run into a line that the formatter removes—the deleted directive was
+never valid GML and GameMaker would have rejected it at compile time.
+
 ### Visual Studio Code
 
 1. Install the [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension.

--- a/src/parser/GameMakerLanguageLexer.g4
+++ b/src/parser/GameMakerLanguageLexer.g4
@@ -132,7 +132,7 @@ Static:                         'static';
 Macro: '#macro' {this.ignoreNewline = false};
 EscapedNewLine: '\\';
 
-Define: '#define' -> pushMode(REGION_NAME);  // TODO: Define is NOT valid in GML – this needs to be fixed. Any use of #define should be replaced by #macro
+Define: '#define' -> pushMode(REGION_NAME);  // Legacy #define directives are normalised later to #macro/#region or dropped entirely
 Region: '#region' -> pushMode(REGION_NAME);
 EndRegion: '#endregion' -> pushMode(REGION_NAME);
 

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -857,13 +857,25 @@ export function print(path, options, print) {
             return concat(["#endregion", print("name")]);
         }
         case "DefineStatement": {
-            // GameMaker Studio has historically supported both `#define` and
-            // `#macro` directives. The formatter normalises legacy `#define`
-            // entries to the modern `#macro` spelling so that the generated
-            // output matches GameMaker's current syntax expectations and the
-            // existing golden fixtures. Preserve the original spacing and
-            // payload by reusing the captured `name` token text.
-            return concat(["#macro", print("name")]);
+            const directive =
+                typeof node.replacementDirective === "string"
+                    ? node.replacementDirective
+                    : "#macro";
+            const suffixDoc =
+                typeof node.replacementSuffix === "string"
+                    ? node.replacementSuffix
+                    : print("name");
+
+            if (typeof suffixDoc === "string") {
+                const needsSeparator =
+                    suffixDoc.length > 0 && !/^\s/.test(suffixDoc);
+
+                return needsSeparator
+                    ? concat([directive, " ", suffixDoc])
+                    : concat([directive, suffixDoc]);
+            }
+
+            return concat([directive, suffixDoc]);
         }
         case "DeleteStatement": {
             return concat(["delete ", print("argument")]);

--- a/src/plugin/tests/define-normalization.input.gml
+++ b/src/plugin/tests/define-normalization.input.gml
@@ -1,0 +1,8 @@
+#define  LEGACY_MACRO(value) ((value) * 2)
+#define region Utility Scripts
+#define    end region Utility Scripts
+#define 123 not valid
+
+#region AlreadyValid
+#macro STILL_VALID 1
+var sentinel = true;

--- a/src/plugin/tests/define-normalization.output.gml
+++ b/src/plugin/tests/define-normalization.output.gml
@@ -1,0 +1,8 @@
+#macro  LEGACY_MACRO(value) ((value) * 2)
+#region Utility Scripts
+#endregion Utility Scripts
+#region AlreadyValid
+
+#macro STILL_VALID 1
+
+var sentinel = true;


### PR DESCRIPTION
## Summary
- normalize legacy `#define` statements to either `#macro`, region markers, or drop them when no valid replacement exists
- add fixture coverage and a focused unit test to guard the new normalization behaviour
- document the formatter’s handling of `#define` directives and clarify the lexer comment

## Testing
- node --test --test-name-pattern "normalises legacy #define directives" tests/plugin.test.js
- node --test --test-name-pattern "formats define-normalization" tests/plugin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ec5481e7c8832fbe7783d892f6c195