### PR TITLE
Improve parser error diagnostics for project indexing

### DIFF
--- a/src/parser/src/gml-syntax-error.js
+++ b/src/parser/src/gml-syntax-error.js
@@ -2,6 +2,28 @@ import antlr4 from "antlr4";
 
 const { ErrorListener } = antlr4.error;
 
+export class GameMakerSyntaxError extends Error {
+    constructor({ message, line, column, wrongSymbol, rule, offendingText }) {
+        super(message);
+        this.name = "GameMakerSyntaxError";
+        if (Number.isFinite(line)) {
+            this.line = line;
+        }
+        if (Number.isFinite(column)) {
+            this.column = column;
+        }
+        if (typeof wrongSymbol === "string") {
+            this.wrongSymbol = wrongSymbol;
+        }
+        if (typeof offendingText === "string") {
+            this.offendingText = offendingText;
+        }
+        if (typeof rule === "string") {
+            this.rule = rule;
+        }
+    }
+}
+
 export default class GameMakerParseErrorListener extends ErrorListener {
     constructor() {
         super();
@@ -10,16 +32,29 @@ export default class GameMakerParseErrorListener extends ErrorListener {
     // TODO: better error messages
     syntaxError(recognizer, offendingSymbol, line, column /* msg, error */) {
         const parser = recognizer;
-        let wrongSymbol = offendingSymbol.text;
+        const offendingText = offendingSymbol?.text ?? null;
+        let wrongSymbol = offendingText;
 
         if (wrongSymbol === "<EOF>") {
             wrongSymbol = "end of file";
-        } else {
+        } else if (typeof wrongSymbol === "string" && wrongSymbol.length > 0) {
             wrongSymbol = `symbol '${wrongSymbol}'`;
+        } else {
+            wrongSymbol = "unknown symbol";
         }
 
         const stack = parser.getRuleInvocationStack();
         const currentRule = stack[0];
+
+        const createError = (message) =>
+            new GameMakerSyntaxError({
+                message,
+                line,
+                column,
+                wrongSymbol,
+                rule: currentRule,
+                offendingText
+            });
 
         const specificMessage = getSpecificSyntaxErrorMessage({
             parser,
@@ -31,17 +66,17 @@ export default class GameMakerParseErrorListener extends ErrorListener {
         });
 
         if (specificMessage) {
-            throw specificMessage;
+            throw createError(specificMessage);
         }
 
         const currentRuleFormatted = currentRule
             .replace(/([A-Z]+)*([A-Z][a-z])/g, "$1 $2")
             .toLowerCase();
 
-        throw (
+        throw createError(
             `Syntax Error (line ${line}, column ${column}): ` +
-            `unexpected ${wrongSymbol}` +
-            ` while matching rule ${currentRuleFormatted}`
+                `unexpected ${wrongSymbol}` +
+                ` while matching rule ${currentRuleFormatted}`
         );
     }
 }

--- a/src/plugin/src/project-index/gml-parser-facade.js
+++ b/src/plugin/src/project-index/gml-parser-facade.js
@@ -1,14 +1,208 @@
-import GMLParser from "../../../parser/gml-parser.js";
+import path from "node:path";
 
-function parseProjectIndexSource(sourceText) {
-    return GMLParser.parse(sourceText, {
-        getComments: false,
-        getLocations: true,
-        simplifyLocations: false,
-        getIdentifierMetadata: true
-    });
+import GMLParser from "../../../parser/gml-parser.js";
+import { GameMakerSyntaxError } from "../../../parser/src/gml-syntax-error.js";
+
+function parseProjectIndexSource(sourceText, context = {}) {
+    try {
+        return GMLParser.parse(sourceText, {
+            getComments: false,
+            getLocations: true,
+            simplifyLocations: false,
+            getIdentifierMetadata: true
+        });
+    } catch (error) {
+        throw enrichSyntaxError(error, sourceText, context);
+    }
 }
 
 export function getDefaultProjectIndexParser() {
     return parseProjectIndexSource;
+}
+
+function enrichSyntaxError(error, sourceText, context) {
+    if (!(error instanceof GameMakerSyntaxError)) {
+        return error;
+    }
+
+    const { filePath, projectRoot } = context ?? {};
+    const lineNumber = getFiniteNumber(error.line);
+    const columnNumber = getFiniteNumber(error.column);
+    const displayPath = resolveDisplayPath(filePath, projectRoot);
+
+    const baseDescription = extractBaseDescription(error.message);
+    const locationSuffix = buildLocationSuffix(
+        displayPath,
+        lineNumber,
+        columnNumber
+    );
+    const excerpt = formatSourceExcerpt(sourceText, lineNumber, columnNumber);
+
+    const originalMessage = error.message;
+    const formattedMessage =
+        `Syntax Error${locationSuffix}: ${baseDescription}` +
+        (excerpt ? `\n\n${excerpt}` : "");
+
+    error.message = formattedMessage;
+    error.originalMessage = originalMessage;
+
+    if (displayPath) {
+        error.filePath = displayPath;
+    }
+
+    if (excerpt) {
+        error.sourceExcerpt = excerpt;
+    }
+
+    return error;
+}
+
+function getFiniteNumber(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+}
+
+function resolveDisplayPath(filePath, projectRoot) {
+    if (typeof filePath !== "string" || filePath.length === 0) {
+        return null;
+    }
+
+    if (!path.isAbsolute(filePath)) {
+        return filePath;
+    }
+
+    if (typeof projectRoot === "string" && projectRoot.length > 0) {
+        const relative = path.relative(projectRoot, filePath);
+        if (
+            relative &&
+            !relative.startsWith("..") &&
+            !path.isAbsolute(relative)
+        ) {
+            return relative;
+        }
+    }
+
+    return filePath;
+}
+
+function extractBaseDescription(message) {
+    if (typeof message !== "string" || message.length === 0) {
+        return "";
+    }
+
+    const match = message.match(/^Syntax Error[^:]*:\s*(.*)$/s);
+    if (match) {
+        return match[1].trim();
+    }
+
+    return message.trim();
+}
+
+function buildLocationSuffix(displayPath, lineNumber, columnNumber) {
+    const parts = [];
+
+    if (displayPath) {
+        parts.push(displayPath);
+    }
+
+    if (lineNumber != null) {
+        if (columnNumber != null) {
+            parts.push(`line ${lineNumber}, column ${columnNumber}`);
+        } else {
+            parts.push(`line ${lineNumber}`);
+        }
+    }
+
+    if (parts.length === 0) {
+        return "";
+    }
+
+    return ` (${parts.join(": ")})`;
+}
+
+function formatSourceExcerpt(sourceText, lineNumber, columnNumber) {
+    if (
+        lineNumber == null ||
+        lineNumber < 1 ||
+        typeof sourceText !== "string"
+    ) {
+        return "";
+    }
+
+    const lines = splitLines(sourceText);
+    const lineIndex = Math.min(lineNumber - 1, lines.length - 1);
+
+    if (lineIndex < 0 || lineIndex >= lines.length) {
+        return "";
+    }
+
+    const rawLineText = lines[lineIndex];
+    const lineNumberWidth = String(lineNumber).length;
+    const gutter = `${String(lineNumber).padStart(lineNumberWidth)} | `;
+    const { lineText, pointerOffset } = expandTabsForDisplay(
+        rawLineText,
+        columnNumber
+    );
+    const contentLine = `${gutter}${lineText}`;
+
+    if (columnNumber == null || columnNumber < 0) {
+        return contentLine;
+    }
+
+    const indicatorSpacing = " ".repeat(lineNumberWidth) + " | ";
+    const pointerLine = `${indicatorSpacing}${" ".repeat(pointerOffset)}^`;
+
+    return `${contentLine}\n${pointerLine}`;
+}
+
+function splitLines(sourceText) {
+    return sourceText.split(/\r\n|\n|\r|\u2028|\u2029|\u0085/);
+}
+
+function expandTabsForDisplay(lineText, columnNumber, tabSize = 4) {
+    if (typeof lineText !== "string" || lineText.length === 0) {
+        return { lineText: "", pointerOffset: 0 };
+    }
+
+    if (!lineText.includes("\t")) {
+        const clampedIndex = clampColumnIndex(lineText.length, columnNumber);
+        return { lineText, pointerOffset: clampedIndex };
+    }
+
+    const clampedIndex = clampColumnIndex(lineText.length, columnNumber);
+    let expanded = "";
+    let pointerOffset = 0;
+
+    for (let index = 0; index < lineText.length; index += 1) {
+        if (index === clampedIndex) {
+            pointerOffset = expanded.length;
+        }
+
+        const char = lineText[index];
+        if (char === "\t") {
+            const spacesToAdd =
+                tabSize - (expanded.length % tabSize) || tabSize;
+            expanded += " ".repeat(spacesToAdd);
+        } else {
+            expanded += char;
+        }
+    }
+
+    if (clampedIndex >= lineText.length) {
+        pointerOffset = expanded.length;
+    }
+
+    return { lineText: expanded, pointerOffset };
+}
+
+function clampColumnIndex(length, columnNumber) {
+    if (!Number.isFinite(columnNumber) || columnNumber < 0) {
+        return 0;
+    }
+
+    if (!Number.isFinite(length) || length <= 0) {
+        return 0;
+    }
+
+    return Math.min(Math.max(0, Math.trunc(columnNumber)), length);
 }

--- a/src/plugin/tests/project-index-parser-errors.test.js
+++ b/src/plugin/tests/project-index-parser-errors.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getDefaultProjectIndexParser } from "../src/project-index/gml-parser-facade.js";
+
+test("project index parser reports syntax errors with context", () => {
+    const parser = getDefaultProjectIndexParser();
+    const invalidSource = [
+        "function example() {",
+        "    var value = ;",
+        "}",
+        ""
+    ].join("\n");
+
+    assert.throws(
+        () =>
+            parser(invalidSource, {
+                filePath: "objects/example/Step_0.gml",
+                projectRoot: "/project/root"
+            }),
+        (error) => {
+            assert.match(
+                error.message,
+                /Syntax Error \(objects\/example\/Step_0\.gml: line 2, column \d+\): unexpected symbol ';/
+            );
+            assert.ok(error.message.includes("2 |     var value = ;"));
+            assert.strictEqual(error.filePath, "objects/example/Step_0.gml");
+            assert.strictEqual(
+                error.sourceExcerpt,
+                "2 |     var value = ;\n  |                 ^"
+            );
+            assert.ok(error.message.includes(error.sourceExcerpt));
+            assert.ok(error.originalMessage?.includes("Syntax Error"));
+            return true;
+        }
+    );
+});


### PR DESCRIPTION
## Summary
- expose a dedicated `GameMakerSyntaxError` class so syntax errors carry location metadata
- enrich project index parsing failures with relative file paths and annotated source excerpts
- add a regression test that exercises the new contextual error reporting

## Testing
- npm test *(fails: existing Prettier plugin fixture expectations)*
- node --test src/plugin/tests/project-index-parser-errors.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ed8071a8e4832f8141ea19044fe34d