### PR TITLE
Add npm script for performance benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test": "npm run test:shared && npm run test:parser && npm run test:plugin && npm run test:cli",
     "test:shared": "node --test src/shared/tests/*.test.js",
     "test:parser": "cd src/parser && npm test",
+    "test:performance": "node scripts/bench-identifier-pipeline.mjs",
     "format:gml": "node ./src/cli/prettier-wrapper.js",
     "format": "npm exec -- prettier --ignore-path ./.prettierignore --write \"{src/**/*.js,src/**/*.mjs,scripts/**/*.{js,mjs},*.{js,cjs,mjs}}\"",
     "format:check": "npm exec -- prettier --ignore-path ./.prettierignore --check \"{src/**/*.js,src/**/*.mjs,scripts/**/*.{js,mjs},*.{js,cjs,mjs}}\"",


### PR DESCRIPTION
## Summary
- add a `test:performance` npm script so contributors can trigger the identifier pipeline benchmark from the root package

## Testing
- npm run test:performance -- --help

------
https://chatgpt.com/codex/tasks/task_e_68edaab77fc8832fbaf6190e9a2188af