### PR TITLE
Move isWordChar helper to shared utilities

### DIFF
--- a/src/plugin/src/parsers/conditional-assignment-sanitizer.js
+++ b/src/plugin/src/parsers/conditional-assignment-sanitizer.js
@@ -1,12 +1,4 @@
-const WORD_CHAR_PATTERN = /[A-Za-z0-9_]/;
-
-function isWordChar(character) {
-    if (typeof character !== "string" || character.length === 0) {
-        return false;
-    }
-
-    return WORD_CHAR_PATTERN.test(character);
-}
+import { isWordChar } from "../../../shared/string-utils.js";
 
 function createIndexMapper(insertPositions) {
     if (!Array.isArray(insertPositions) || insertPositions.length === 0) {

--- a/src/shared/string-utils.js
+++ b/src/shared/string-utils.js
@@ -6,6 +6,16 @@ export function isNonEmptyTrimmedString(value) {
     return typeof value === "string" && value.trim().length > 0;
 }
 
+const WORD_CHAR_PATTERN = /[A-Za-z0-9_]/;
+
+export function isWordChar(character) {
+    if (typeof character !== "string" || character.length === 0) {
+        return false;
+    }
+
+    return WORD_CHAR_PATTERN.test(character);
+}
+
 export function toTrimmedString(value) {
     return typeof value === "string" ? value.trim() : "";
 }

--- a/src/shared/tests/string-utils.test.js
+++ b/src/shared/tests/string-utils.test.js
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import {
     isNonEmptyString,
     isNonEmptyTrimmedString,
+    isWordChar,
     toTrimmedString,
     capitalize
 } from "../string-utils.js";
@@ -40,4 +41,14 @@ test("capitalize leaves falsy and non-string inputs unchanged", () => {
     assert.strictEqual(capitalize(null), null);
     assert.strictEqual(capitalize(undefined), undefined);
     assert.strictEqual(capitalize(42), 42);
+});
+
+test("isWordChar validates alphanumeric and underscore characters", () => {
+    assert.strictEqual(isWordChar("a"), true);
+    assert.strictEqual(isWordChar("Z"), true);
+    assert.strictEqual(isWordChar("0"), true);
+    assert.strictEqual(isWordChar("_"), true);
+    assert.strictEqual(isWordChar(""), false);
+    assert.strictEqual(isWordChar("-"), false);
+    assert.strictEqual(isWordChar(null), false);
 });


### PR DESCRIPTION
## Summary
- move the conditional assignment sanitizer's word-character helper into the shared string utilities module
- update string utility tests to cover the new isWordChar helper and import it where needed

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_68edb1f15b84832fb39629add6a925b7