### PR TITLE
Remove enum-specific trailing comment padding override

### DIFF
--- a/src/plugin/src/printer/enum-alignment.js
+++ b/src/plugin/src/printer/enum-alignment.js
@@ -1,22 +1,11 @@
-export function prepareEnumMembersForPrinting(
-    members,
-    trailingCommentPadding,
-    getNodeName
-) {
+export function prepareEnumMembersForPrinting(members, getNodeName) {
     if (!Array.isArray(members) || members.length === 0) {
         return;
     }
 
-    const resolvedPadding =
-        typeof trailingCommentPadding === "number" &&
-        Number.isFinite(trailingCommentPadding)
-            ? Math.max(trailingCommentPadding, 0)
-            : 0;
-
     const memberCount = members.length;
     const nameLengths = new Array(memberCount);
 
-    let maxNameLength = 0;
     let maxInitializerNameLength = 0;
 
     // A single indexed pass avoids re-scanning the array when computing
@@ -28,10 +17,6 @@ export function prepareEnumMembersForPrinting(
 
         nameLengths[index] = length;
 
-        if (length > maxNameLength) {
-            maxNameLength = length;
-        }
-
         if (member?.initializer && length > maxInitializerNameLength) {
             maxInitializerNameLength = length;
         }
@@ -41,10 +26,6 @@ export function prepareEnumMembersForPrinting(
 
     members.forEach((member, index) => {
         const nameLength = nameLengths[index];
-        member._commentColumnTarget = maxNameLength + resolvedPadding;
-        member._hasTrailingComma = index !== members.length - 1;
-        member._nameLengthForAlignment = nameLength;
-
         if (shouldAlignInitializers && member.initializer) {
             member._enumNameAlignmentPadding =
                 maxInitializerNameLength - nameLength;
@@ -52,25 +33,6 @@ export function prepareEnumMembersForPrinting(
             member._enumNameAlignmentPadding = 0;
         }
     });
-}
-
-export function getEnumMemberCommentPadding(member) {
-    if (!member) {
-        return 0;
-    }
-
-    const targetColumn =
-        typeof member._commentColumnTarget === "number" &&
-        Number.isFinite(member._commentColumnTarget)
-            ? member._commentColumnTarget
-            : 0;
-
-    const baseLength =
-        (member._nameLengthForAlignment || 0) +
-        (member._enumNameAlignmentPadding || 0) +
-        (member._hasTrailingComma ? 1 : 0);
-
-    return Math.max(targetColumn - baseLength - 1, 0);
 }
 
 export function getEnumNameAlignmentPadding(member) {

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -27,7 +27,6 @@ import {
     getSizeRetrievalFunctionSuffixes
 } from "./optimizations/loop-size-hoisting.js";
 import {
-    getEnumMemberCommentPadding,
     getEnumNameAlignmentPadding,
     prepareEnumMembersForPrinting
 } from "./enum-alignment.js";
@@ -40,10 +39,7 @@ import {
     formatLineComment,
     normalizeDocCommentTypeAnnotations
 } from "../comments/line-comment-formatting.js";
-import {
-    getTrailingCommentPadding,
-    resolveLineCommentOptions
-} from "../options/line-comment-options.js";
+import { resolveLineCommentOptions } from "../options/line-comment-options.js";
 import { getCommentArray, isCommentNode } from "../../../shared/comments.js";
 import { coercePositiveIntegerOption } from "../options/option-utils.js";
 import {
@@ -869,11 +865,7 @@ export function print(path, options, print) {
             );
         }
         case "EnumDeclaration": {
-            prepareEnumMembersForPrinting(
-                node.members,
-                getTrailingCommentPadding(options),
-                getNodeName
-            );
+            prepareEnumMembersForPrinting(node.members, getNodeName);
             return concat([
                 "enum ",
                 print("name"),
@@ -1032,18 +1024,6 @@ export function print(path, options, print) {
             return concat(["new ", print("expression"), ...argsPrinted]);
         }
         case "EnumMember": {
-            const comments = getCommentArray(node);
-            if (comments.length > 0) {
-                const padding = getEnumMemberCommentPadding(node);
-                comments.forEach((comment) => {
-                    if (
-                        comment &&
-                        (comment.trailing || comment.placement === "endOfLine")
-                    ) {
-                        comment.inlinePadding = padding;
-                    }
-                });
-            }
             const extraPadding = getEnumNameAlignmentPadding(node);
             let nameDoc = print("name");
             if (extraPadding > 0) {


### PR DESCRIPTION
## Summary
- remove the enum member comment padding helper so trailing comments use the normal trailing comment options
- simplify enum member alignment prep to only track initializer padding

## Testing
- npm run test:plugin *(fails: plugin fixtures expect the previous enum trailing comment padding)*

------
https://chatgpt.com/codex/tasks/task_e_68edb132e848832f90492a6351348cde