### PR TITLE
Avoid hoisting Feather fixes across unrelated functions

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -9097,6 +9097,13 @@ function referencesIdentifier(node, variableName) {
             continue;
         }
 
+        if (isFunctionLikeNode(value)) {
+            // Nested functions introduce new scopes. References to the same
+            // identifier name inside them do not require hoisting the current
+            // declaration, so skip descending into those subtrees.
+            continue;
+        }
+
         if (Array.isArray(value)) {
             for (const item of value) {
                 stack.push({ value: item, parent, key });


### PR DESCRIPTION
## Summary
- prevent the Feather GM1036 fix from descending into nested function scopes when scanning for identifier usage
- keep local var declarations inside their original function bodies so synthetic docs are emitted correctly

## Testing
- node --test --test-name-pattern testGM1036 src/plugin/tests/plugin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68edbd4beaa0832f8b502d74e71a8f86