### PR TITLE
Align enum trailing comments with member widths

### DIFF
--- a/src/plugin/src/comments/comment-printer.js
+++ b/src/plugin/src/comments/comment-printer.js
@@ -10,6 +10,7 @@ import {
 } from "./line-comment-formatting.js";
 import {
     getTrailingCommentInlinePadding,
+    getTrailingCommentPadding,
     resolveLineCommentOptions
 } from "../options/line-comment-options.js";
 
@@ -209,10 +210,22 @@ function applyTrailingCommentPadding(comment, options) {
     }
 
     const inlinePadding = getTrailingCommentInlinePadding(options);
+    const trailingPadding = getTrailingCommentPadding(options);
+    const baseTrailingPadding = Math.max(trailingPadding - 1, 0);
+    const enumPadding =
+        typeof comment._enumTrailingPadding === "number"
+            ? comment._enumTrailingPadding
+            : 0;
+
+    const desiredPadding = Math.max(
+        inlinePadding,
+        baseTrailingPadding + enumPadding
+    );
+
     if (typeof comment.inlinePadding === "number") {
-        comment.inlinePadding = Math.max(comment.inlinePadding, inlinePadding);
-    } else if (inlinePadding > 0) {
-        comment.inlinePadding = inlinePadding;
+        comment.inlinePadding = Math.max(comment.inlinePadding, desiredPadding);
+    } else if (desiredPadding > 0) {
+        comment.inlinePadding = desiredPadding;
     }
 }
 

--- a/src/plugin/src/printer/enum-alignment.js
+++ b/src/plugin/src/printer/enum-alignment.js
@@ -1,10 +1,20 @@
-export function prepareEnumMembersForPrinting(members, getNodeName) {
+const ENUM_INITIALIZER_OPERATOR_WIDTH = " = ".length;
+
+export function prepareEnumMembersForPrinting(enumNode, getNodeName) {
+    if (!enumNode || typeof enumNode !== "object") {
+        return;
+    }
+
+    const members = enumNode.members;
     if (!Array.isArray(members) || members.length === 0) {
         return;
     }
 
     const memberCount = members.length;
     const nameLengths = new Array(memberCount);
+    const initializerWidths = new Array(memberCount);
+    const memberWidths = new Array(memberCount);
+    const trailingCommentLists = new Array(memberCount);
 
     let maxInitializerNameLength = 0;
 
@@ -17,6 +27,11 @@ export function prepareEnumMembersForPrinting(members, getNodeName) {
 
         nameLengths[index] = length;
 
+        const initializerWidth = getEnumInitializerWidth(member?.initializer);
+        initializerWidths[index] = initializerWidth;
+
+        trailingCommentLists[index] = collectTrailingEnumComments(member);
+
         if (member?.initializer && length > maxInitializerNameLength) {
             maxInitializerNameLength = length;
         }
@@ -25,6 +40,7 @@ export function prepareEnumMembersForPrinting(members, getNodeName) {
     const shouldAlignInitializers = maxInitializerNameLength > 0;
 
     const lastIndex = memberCount - 1;
+    let maxMemberWidth = 0;
 
     // A hand-rolled loop avoids creating a callback closure for `Array#forEach`
     // and repeatedly reading `members.length` inside the hot post-processing
@@ -33,11 +49,60 @@ export function prepareEnumMembersForPrinting(members, getNodeName) {
     for (let index = 0; index < memberCount; index += 1) {
         const member = members[index];
         const nameLength = nameLengths[index];
-        if (shouldAlignInitializers && member.initializer) {
-            member._enumNameAlignmentPadding =
-                maxInitializerNameLength - nameLength;
-        } else {
-            member._enumNameAlignmentPadding = 0;
+        const hasInitializer = Boolean(member?.initializer);
+
+        const alignmentPadding =
+            shouldAlignInitializers && hasInitializer
+                ? maxInitializerNameLength - nameLength
+                : 0;
+
+        member._enumNameAlignmentPadding = alignmentPadding;
+
+        const initializerWidth = initializerWidths[index] ?? 0;
+        const initializerSpan = hasInitializer
+            ? ENUM_INITIALIZER_OPERATOR_WIDTH + initializerWidth
+            : 0;
+
+        const memberWidth = nameLength + alignmentPadding + initializerSpan;
+
+        memberWidths[index] = memberWidth;
+        if (memberWidth > maxMemberWidth) {
+            maxMemberWidth = memberWidth;
+        }
+    }
+
+    if (maxMemberWidth === 0) {
+        return;
+    }
+
+    const hasTrailingComma = enumNode?.hasTrailingComma === true;
+
+    for (let index = 0; index < memberCount; index += 1) {
+        const comments = trailingCommentLists[index];
+        if (!comments || comments.length === 0) {
+            continue;
+        }
+
+        const memberWidth = memberWidths[index] ?? 0;
+        const isLastMember = index === lastIndex;
+        const commaWidth = !isLastMember || hasTrailingComma ? 1 : 0;
+        const extraPadding = Math.max(
+            maxMemberWidth - memberWidth - commaWidth,
+            0
+        );
+
+        if (extraPadding === 0) {
+            continue;
+        }
+
+        for (const comment of comments) {
+            if (comment && typeof comment === "object") {
+                const previous =
+                    typeof comment._enumTrailingPadding === "number"
+                        ? comment._enumTrailingPadding
+                        : 0;
+                comment._enumTrailingPadding = Math.max(previous, extraPadding);
+            }
         }
     }
 }
@@ -49,4 +114,46 @@ export function getEnumNameAlignmentPadding(member) {
 
     const padding = member._enumNameAlignmentPadding;
     return typeof padding === "number" && padding > 0 ? padding : 0;
+}
+
+function getEnumInitializerWidth(initializer) {
+    if (typeof initializer === "string") {
+        return initializer.trim().length;
+    }
+
+    if (initializer == null) {
+        return 0;
+    }
+
+    if (typeof initializer === "number") {
+        return String(initializer).length;
+    }
+
+    if (typeof initializer === "object") {
+        const text = String(initializer.value ?? "").trim();
+        return text.length;
+    }
+
+    return String(initializer).trim().length;
+}
+
+function collectTrailingEnumComments(member) {
+    const comments = member?.comments;
+    if (!Array.isArray(comments) || comments.length === 0) {
+        return [];
+    }
+
+    const trailingComments = [];
+
+    for (const comment of comments) {
+        if (
+            comment &&
+            typeof comment === "object" &&
+            (comment.trailing === true || comment.placement === "endOfLine")
+        ) {
+            trailingComments.push(comment);
+        }
+    }
+
+    return trailingComments;
 }

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -865,7 +865,7 @@ export function print(path, options, print) {
             );
         }
         case "EnumDeclaration": {
-            prepareEnumMembersForPrinting(node.members, getNodeName);
+            prepareEnumMembersForPrinting(node, getNodeName);
             return concat([
                 "enum ",
                 print("name"),


### PR DESCRIPTION
## Summary
- compute enum member widths and record trailing comment padding metadata to keep inline comments aligned
- adjust trailing comment padding logic to honor enum-specific offsets and use consistent base spacing
- update enum printing to prepare members with the full declaration node so comment metadata can be applied

## Testing
- node --test --test-name-pattern testMath tests/plugin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68edbcb6fb84832f9db3a84acd1a5bfc