### PR TITLE
Fix regression test workflow artifact handling

### DIFF
--- a/.github/workflows/codex-verify-before-automerge.yml
+++ b/.github/workflows/codex-verify-before-automerge.yml
@@ -36,6 +36,12 @@ jobs:
         working-directory: base
         run: npm ci
 
+      - name: Prepare test result directory (base)
+        working-directory: base
+        run: |
+          rm -rf test-results
+          mkdir -p test-results
+
       - name: Run shared tests (base)
         working-directory: base
         run: >
@@ -86,6 +92,11 @@ jobs:
       - name: Install deps (head)
         run: npm ci
 
+      - name: Prepare test result directory (head)
+        run: |
+          rm -rf test-results
+          mkdir -p test-results
+
       - name: Run shared tests (head)
         run: >
           node --test
@@ -127,7 +138,7 @@ jobs:
 
       - name: Compare JUnit results (fail only on regressions)
         run: |
-          node -e "require('fs').writeFileSync('compare-junit.js', `
+          cat <<'EOF' > compare-junit.js
           const fs = require('fs');
           const path = require('path');
           const { XMLParser } = require('fast-xml-parser');
@@ -183,7 +194,8 @@ jobs:
           } else {
             console.log('No new failing tests compared to base.');
           }
-          `); node compare-junit.js"
+          EOF
+          node compare-junit.js
         shell: bash
 
       - name: Publish PR test summary (head only)


### PR DESCRIPTION
## Summary
- create the test-results directory for both the base and head checkouts before running the suite so reporters can write their output
- rewrite the compare-junit.js generation step to avoid shell backtick interpolation issues by using a here-document

## Testing
- npm test *(fails: existing suite has known failing cases)*

------
https://chatgpt.com/codex/tasks/task_e_68edc2723398832fbefe27801bf31ba6