### PR TITLE
Fix regression test workflow artifact handling

### DIFF
--- a/.github/workflows/codex-verify-before-automerge.yml
+++ b/.github/workflows/codex-verify-before-automerge.yml
@@ -36,6 +36,12 @@ jobs:
         working-directory: base
         run: npm ci
 
+      - name: Prepare test result directory (base)
+        working-directory: base
+        run: |
+          rm -rf test-results
+          mkdir -p test-results
+
       - name: Run shared tests (base)
         working-directory: base
         run: >
@@ -86,6 +92,11 @@ jobs:
       - name: Install deps (head)
         run: npm ci
 
+      - name: Prepare test result directory (head)
+        run: |
+          rm -rf test-results
+          mkdir -p test-results
+
       - name: Run shared tests (head)
         run: >
           node --test
@@ -127,10 +138,10 @@ jobs:
 
       - name: Compare JUnit results (fail only on regressions)
         run: |
-          node -e "require('fs').writeFileSync('compare-junit.js', `
-          const fs = require('fs');
-          const path = require('path');
-          const { XMLParser } = require('fast-xml-parser');
+          cat <<'EOF' > compare-junit.js
+          import fs from 'node:fs';
+          import path from 'node:path';
+          import { XMLParser } from 'fast-xml-parser';
 
           function readCases(rootDir) {
             const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
@@ -164,8 +175,8 @@ jobs:
             return results;
           }
 
-          const base = readCases('base');
-          const head = readCases('.');
+          const base = readCases(path.resolve(process.cwd(), 'base'));
+          const head = readCases(process.cwd());
 
           const regressions = [];
           for (const [key, headStatus] of head.entries()) {
@@ -183,7 +194,8 @@ jobs:
           } else {
             console.log('No new failing tests compared to base.');
           }
-          `); node compare-junit.js"
+          EOF
+          node compare-junit.js
         shell: bash
 
       - name: Publish PR test summary (head only)


### PR DESCRIPTION
## Summary
- create the test-results directory for both the base and head checkouts before running the suite so reporters can write their output
- generate the compare-junit helper with an ESM-compatible script written via here-document to avoid shell interpolation issues

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68edc2723398832fbefe27801bf31ba6