### PR TITLE
Skip Node.js test summary for empty change PRs

### DIFF
--- a/.github/workflows/codex-automerge-prs.yml
+++ b/.github/workflows/codex-automerge-prs.yml
@@ -303,7 +303,7 @@ jobs:
         shell: bash
 
       - name: Publish PR test summary (head only)
-        if: always()
+        if: ${{ always() && needs.pr-meta.outputs.changed_files != '0' }}
         continue-on-error: true
         uses: dorny/test-reporter@v2
         with:


### PR DESCRIPTION
## Summary
- prevent the auto-merge workflow from publishing the Node.js test summary when a PR has no file changes
- ensures the "Node.js test results (PR head)" check is skipped for empty change PRs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee5c5382bc832fb08d7f7bf804301a