### PR TITLE
Improve auto-merge test summary comment

### DIFF
--- a/.github/workflows/codex-automerge-prs.yml
+++ b/.github/workflows/codex-automerge-prs.yml
@@ -315,18 +315,201 @@ jobs:
           use-actions-summary: true
 
       # 👇 Adds/updates a sticky PR comment with a concise summary & failures
-      - name: Comment test results on PR (sticky)
+      - name: Comment summarized test results on PR (sticky)
         if: ${{ always() && github.event_name == 'pull_request' && needs.pr-meta.outputs.changed_files != '0' }}
         continue-on-error: true
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.pr-meta.outputs.number }}
         with:
-          files: |
-            test-results/**/*.xml
-          check_name: Node.js test results (PR head)
-          comment_mode: changes
-          pull_request_build: merge
-          compare_to_earlier_commit: true
-          comment_title: "Node.js test results (PR head)"
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const { XMLParser } = await import('fast-xml-parser');
+
+            const marker = '<!-- codex-automerge-pr-test-summary -->';
+            const prNumber = Number(process.env.PR_NUMBER || 0);
+            if (!prNumber) {
+              core.warning('Cannot determine PR number for summary comment.');
+              return;
+            }
+
+            const pr = context.payload.pull_request || {};
+            const baseLabel = `${pr.base?.ref || 'base'} @ ${(pr.base?.sha || '').slice(0, 7) || '???????'}`;
+            const headLabel = `${pr.head?.ref || 'head'} @ ${(pr.head?.sha || context.sha || '').slice(0, 7) || '???????'}`;
+
+            function collectSuiteStats(dir) {
+              const resultsDir = path.join(process.cwd(), dir);
+              const totals = { tests: 0, passed: 0, failed: 0, skipped: 0, time: 0 };
+              const notes = [];
+              if (!fs.existsSync(resultsDir)) {
+                notes.push(`No directory found at ${dir}.`);
+                return { available: false, totals, notes };
+              }
+
+              const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.xml'));
+              if (files.length === 0) {
+                notes.push(`No JUnit XML files found in ${dir}.`);
+                return { available: false, totals, notes };
+              }
+
+              const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
+
+              const suiteList = [];
+              const seenSuites = new Set();
+              const visitNode = (node) => {
+                if (!node || typeof node !== 'object') return;
+                if (Array.isArray(node)) {
+                  for (const child of node) visitNode(child);
+                  return;
+                }
+                const hasCases = Object.prototype.hasOwnProperty.call(node, 'testcase');
+                const hasCounts = Object.prototype.hasOwnProperty.call(node, 'tests');
+                const hasNestedSuites = Object.prototype.hasOwnProperty.call(node, 'testsuite');
+                const shouldRecord = hasCases || (!hasNestedSuites && hasCounts);
+                if (shouldRecord && !seenSuites.has(node)) {
+                  seenSuites.add(node);
+                  suiteList.push(node);
+                }
+                for (const value of Object.values(node)) visitNode(value);
+              };
+
+              for (const file of files) {
+                try {
+                  const xml = fs.readFileSync(path.join(resultsDir, file), 'utf8');
+                  if (!xml.trim()) continue;
+                  const data = parser.parse(xml);
+                  visitNode(data);
+                } catch (error) {
+                  notes.push(`Failed to parse ${path.join(dir, file)}: ${error.message}`);
+                }
+              }
+
+              if (suiteList.length === 0) {
+                notes.push(`No test suites discovered in ${dir}.`);
+                return { available: false, totals, notes };
+              }
+
+              for (const suite of suiteList) {
+                const rawCases = suite.testcase;
+                const cases = rawCases ? (Array.isArray(rawCases) ? rawCases : [rawCases]) : [];
+                if (cases.length > 0) {
+                  let recordedTime = false;
+                  for (const tc of cases) {
+                    if (!tc || typeof tc !== 'object') continue;
+                    totals.tests += 1;
+                    const hasFailure = tc.failure !== undefined || tc.failures !== undefined || tc.error !== undefined || tc.errors !== undefined;
+                    const isSkipped = tc.skipped !== undefined;
+                    if (hasFailure) {
+                      totals.failed += 1;
+                    } else if (isSkipped) {
+                      totals.skipped += 1;
+                    } else {
+                      totals.passed += 1;
+                    }
+                    const caseTime = Number.parseFloat(tc.time ?? tc.duration ?? tc.elapsed ?? 0);
+                    if (Number.isFinite(caseTime)) {
+                      totals.time += caseTime;
+                      recordedTime = true;
+                    }
+                  }
+                  if (!recordedTime) {
+                    const suiteTime = Number.parseFloat(suite.time ?? 0);
+                    if (Number.isFinite(suiteTime)) {
+                      totals.time += suiteTime;
+                    }
+                  }
+                } else {
+                  const tests = Number.parseInt(suite.tests ?? 0, 10);
+                  const failures = Number.parseInt(suite.failures ?? 0, 10) + Number.parseInt(suite.errors ?? 0, 10);
+                  const skipped = Number.parseInt(suite.skipped ?? 0, 10);
+                  if (Number.isFinite(tests)) totals.tests += tests;
+                  if (Number.isFinite(failures)) totals.failed += failures;
+                  if (Number.isFinite(skipped)) totals.skipped += skipped;
+                  const inferredPassed = tests - failures - skipped;
+                  if (Number.isFinite(inferredPassed) && inferredPassed > 0) {
+                    totals.passed += inferredPassed;
+                  }
+                  const suiteTime = Number.parseFloat(suite.time ?? 0);
+                  if (Number.isFinite(suiteTime)) {
+                    totals.time += suiteTime;
+                  }
+                }
+              }
+
+              return { available: true, totals, notes };
+            }
+
+            const baseSummary = collectSuiteStats(path.join('base', 'test-results'));
+            const headSummary = collectSuiteStats('test-results');
+
+            const formatDuration = (seconds) => {
+              if (!Number.isFinite(seconds) || seconds < 0) return '—';
+              if (seconds === 0) return '0s';
+              if (seconds < 1) return `${(seconds * 1000).toFixed(0)}ms`;
+              if (seconds >= 60) {
+                const minutes = Math.floor(seconds / 60);
+                const rem = seconds - minutes * 60;
+                return `${minutes}m ${rem.toFixed(1)}s`;
+              }
+              return `${seconds.toFixed(2)}s`;
+            };
+
+            const formatRow = (label, summary) => {
+              if (!summary.available || summary.totals.tests === 0) {
+                return `| ${label} | — | — | — | — |`;
+              }
+              const { passed, failed, skipped, time } = summary.totals;
+              return `| ${label} | ${passed} | ${failed} | ${skipped} | ${formatDuration(time)} |`;
+            };
+
+            const lines = [
+              marker,
+              '### Node.js regression test summary',
+              '',
+              '| Target | Passed | Failed | Skipped | Duration |',
+              '| --- | ---: | ---: | ---: | ---: |',
+              formatRow(`Base (${baseLabel})`, baseSummary),
+              formatRow(`PR (${headLabel})`, headSummary),
+              '',
+              '_Durations are aggregated from reported test case timings._'
+            ];
+
+            const notes = [...baseSummary.notes, ...headSummary.notes];
+            if (notes.length) {
+              lines.push('', ...notes.map(n => `> ⚠️ ${n}`));
+            }
+
+            const body = lines.join('\n');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.notice('Updated existing test summary comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.notice('Created new test summary comment.');
+            }
 
       # 👇 Attach raw reports so anyone can download/open them from the PR
       - name: Upload test reports as artifacts


### PR DESCRIPTION
## Summary
- replace the previous unit test comment action with a github-script step that posts a structured summary
- parse the base and PR JUnit reports to show passed, failed, skipped counts and aggregated durations with clear labelling

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ee5e20c0fc832fadba8350487b3cf2