### PR TITLE
Fix fast-xml-parser resolution in automerge workflow

### DIFF
--- a/.github/workflows/codex-automerge-prs.yml
+++ b/.github/workflows/codex-automerge-prs.yml
@@ -332,7 +332,6 @@ jobs:
                 paths: [
                   process.cwd(),
                   process.env.GITHUB_WORKSPACE || '',
-                  __dirname,
                 ].filter(Boolean),
               });
               ({ XMLParser } = require(resolved));


### PR DESCRIPTION
## Summary
- remove usage of __dirname when resolving fast-xml-parser in the PR summary script
- ensure the regression summary comment can load fast-xml-parser in the GitHub Actions runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee6d46c0ec832fa3ebf0f06f513f4c