### PR TITLE
Codex: relocate path utilities to shared module

### DIFF
--- a/src/plugin/src/identifier-case/asset-rename-executor.js
+++ b/src/plugin/src/identifier-case/asset-rename-executor.js
@@ -11,7 +11,7 @@ import {
 
 import { isNonEmptyString } from "../../../shared/string-utils.js";
 import { isObjectLike } from "../../../shared/object-utils.js";
-import { fromPosixPath } from "../utils/path-utils.js";
+import { fromPosixPath } from "../../../shared/path-utils.js";
 import { DEFAULT_WRITE_ACCESS_MODE } from "./common.js";
 
 const defaultFsFacade = Object.freeze({

--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { formatIdentifierCase } from "./identifier-case-utils.js";
 import { asArray } from "../../../shared/array-utils.js";
-import { toPosixPath } from "../utils/path-utils.js";
+import { toPosixPath } from "../../../shared/path-utils.js";
 import { createMetricsTracker } from "../reporting/metrics-tracker.js";
 import { buildLocationKey } from "../../../shared/location-keys.js";
 import { isNonEmptyString } from "../../../shared/string-utils.js";

--- a/src/plugin/src/project-index/index.js
+++ b/src/plugin/src/project-index/index.js
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { cloneLocation } from "../../../shared/ast-locations.js";
-import { toPosixPath } from "../utils/path-utils.js";
+import { toPosixPath } from "../../../shared/path-utils.js";
 import { isNonEmptyArray } from "../../../shared/array-utils.js";
 import { hasOwn } from "../../../shared/object-utils.js";
 import { createMetricsTracker } from "../reporting/metrics-tracker.js";

--- a/src/plugin/tests/assets-rename.integration.test.js
+++ b/src/plugin/tests/assets-rename.integration.test.js
@@ -9,7 +9,7 @@ import {
     planAssetRenames,
     applyAssetRenames
 } from "../src/identifier-case/asset-renames.js";
-import { fromPosixPath } from "../src/utils/path-utils.js";
+import { fromPosixPath } from "../../shared/path-utils.js";
 
 describe("asset rename utilities", () => {
     it("renames script assets and updates dependent resource metadata atomically", async () => {

--- a/src/plugin/tests/identifier-case-assets.integration.test.js
+++ b/src/plugin/tests/identifier-case-assets.integration.test.js
@@ -13,7 +13,7 @@ import {
     setIdentifierCaseDryRunContext
 } from "../src/identifier-case/identifier-case-context.js";
 import { prepareIdentifierCasePlan } from "../src/identifier-case/local-plan.js";
-import { fromPosixPath } from "../src/utils/path-utils.js";
+import { fromPosixPath } from "../../shared/path-utils.js";
 
 const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
 const pluginPath = path.resolve(currentDirectory, "../src/gml.js");

--- a/src/shared/path-utils.js
+++ b/src/shared/path-utils.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { isNonEmptyString } from "../../../shared/string-utils.js";
+import { isNonEmptyString } from "./string-utils.js";
 
 const WINDOWS_SEPARATOR_PATTERN = /\\+/g;
 const POSIX_SEPARATOR_PATTERN = /\/+/g;

--- a/src/shared/tests/path-utils.test.js
+++ b/src/shared/tests/path-utils.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import { describe, it } from "node:test";
+
+import { fromPosixPath, toPosixPath } from "../path-utils.js";
+
+describe("path utilities", () => {
+    it("converts Windows separators to POSIX separators", () => {
+        const converted = toPosixPath("\\\\Foo\\Bar\\Baz.gml");
+        assert.equal(converted, "/Foo/Bar/Baz.gml");
+    });
+
+    it("returns an empty string for non-string inputs", () => {
+        assert.equal(toPosixPath(null), "");
+        assert.equal(toPosixPath(undefined), "");
+        assert.equal(fromPosixPath(null), "");
+    });
+
+    it("converts POSIX separators to the current platform separator", () => {
+        const native = fromPosixPath("scripts/demo/DemoScript.gml");
+        const expected =
+            os.platform() === "win32"
+                ? "scripts\\demo\\DemoScript.gml"
+                : "scripts/demo/DemoScript.gml";
+        assert.equal(native, expected);
+    });
+});


### PR DESCRIPTION
## Summary
- move the path normalization helpers from `src/plugin/src/utils/path-utils.js` into `src/shared/path-utils.js` so identifier-case and project index code reuse a shared implementation
- update imports and integration tests to use the shared module
- add shared unit tests covering `toPosixPath`/`fromPosixPath` behavior

## Testing
- npm run test:shared
- npm run test:plugin *(fails: fixture expectations already out of sync on this branch)*

------
https://chatgpt.com/codex/tasks/task_e_68ee957a7354832fb593a3f4e64d9b94