### PR TITLE
Prefer synthetic merge results for regression gating

### DIFF
--- a/.github/workflows/codex-automerge-prs.yml
+++ b/.github/workflows/codex-automerge-prs.yml
@@ -475,7 +475,7 @@ jobs:
             echo "No merge/test-results directory found to preserve."
           fi
 
-      # === Regression compare (base vs head only; merged is informational) ===
+      # === Regression compare (base vs synthetic merge; fall back to head) ===
       - name: Install compare script dependency
         if: ${{ needs.pr-meta.outputs.changed_files != '0' }}
         run: npm install --no-save fast-xml-parser@^4
@@ -488,11 +488,14 @@ jobs:
           import path from 'node:path';
           import { XMLParser } from 'fast-xml-parser';
 
+          const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+
           function readCases(...dirs) {
-            const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
             const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
             const results = new Map();
             const queue = dirs.flat().filter(Boolean);
+            let usedDir = null;
+            let displayDir = '';
 
             for (const dir of queue) {
               const resolved = path.isAbsolute(dir) ? dir : path.join(workspace, dir);
@@ -504,6 +507,9 @@ jobs:
               if (files.length === 0) {
                 continue;
               }
+
+              usedDir = resolved;
+              displayDir = path.relative(workspace, resolved) || resolved;
 
               for (const file of files) {
                 const xml = fs.readFileSync(path.join(resolved, file), 'utf8');
@@ -531,7 +537,7 @@ jobs:
               break;
             }
 
-            return results;
+            return { results, usedDir, displayDir };
           }
 
           const baseCandidates = [path.join('base', 'test-results'), 'base-test-results'];
@@ -539,24 +545,42 @@ jobs:
             baseCandidates.push(process.env.BASE_RESULTS_DIR);
           }
 
+          const mergeCandidates = [path.join('merge', 'test-results'), 'merge-test-results'];
+          if (process.env.MERGE_RESULTS_DIR) {
+            mergeCandidates.push(process.env.MERGE_RESULTS_DIR);
+          }
+
           const base = readCases(baseCandidates);
           const head = readCases('test-results');
+          const merged = readCases(mergeCandidates);
+
+          const target = merged.usedDir ? merged : head;
+          const targetLabel = merged.usedDir
+            ? `synthetic merge (${merged.displayDir || 'merge/test-results'})`
+            : `PR head (${head.displayDir || 'test-results'})`;
+
+          if (merged.usedDir) {
+            console.log(`Using synthetic merge test results for regression detection: ${targetLabel}.`);
+          } else {
+            console.log('Synthetic merge test results were not found; falling back to PR head results.');
+          }
+
           const regressions = [];
 
-          for (const [key, headStatus] of head.entries()) {
-            const baseStatus = base.get(key);
+          for (const [key, targetStatus] of target.results.entries()) {
+            const baseStatus = base.results.get(key);
             if (baseStatus === undefined) continue; // new test -> ignore even if failing
-            if ((baseStatus === 'passed' || baseStatus === 'skipped') && headStatus === 'failed') {
-              regressions.push({ test: key, from: baseStatus, to: headStatus });
+            if ((baseStatus === 'passed' || baseStatus === 'skipped') && targetStatus === 'failed') {
+              regressions.push({ test: key, from: baseStatus, to: targetStatus });
             }
           }
 
           if (regressions.length) {
-            console.log('New failing tests detected (compared to base):');
+            console.log(`New failing tests detected (compared to base using ${targetLabel}):`);
             for (const r of regressions) console.log('- ' + r.test + ' (' + r.from + ' -> ' + r.to + ')');
             process.exit(1);
           } else {
-            console.log('No new failing tests compared to base.');
+            console.log(`No new failing tests compared to base using ${targetLabel}.`);
           }
           EOF
           node compare-junit.mjs


### PR DESCRIPTION
## Summary
- update the auto-merge workflow to compare base test results against the synthetic merge run when detecting regressions
- fall back to PR head results only when synthetic merge artifacts are unavailable, with logging to make the decision explicit

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68eeb001acd8832f96b70c84dc076561