### PR TITLE
Avoid duplicate push and PR runs in auto-merge workflow

### DIFF
--- a/.github/workflows/codex-automerge-prs.yml
+++ b/.github/workflows/codex-automerge-prs.yml
@@ -26,10 +26,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  detect-push-context:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_pr_meta: ${{ steps.check.outputs.skip_pr_meta }}
+    steps:
+      - name: Detect duplicate push
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = (context.ref || '').replace('refs/heads/', '');
+
+            if (!ref) {
+              core.setOutput('skip_pr_meta', 'false');
+              return;
+            }
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${ref}`,
+              per_page: 1,
+            });
+
+            const pr = prs[0];
+            const shouldSkip = Boolean(pr);
+
+            if (shouldSkip) {
+              core.notice(`Push to ${ref} is covered by open PR #${pr.number}; skipping duplicate push run.`);
+            }
+
+            core.setOutput('skip_pr_meta', shouldSkip ? 'true' : 'false');
+
   ###########################################################################
   # PR metadata (used by regression test gating + merges)
   ###########################################################################
   pr-meta:
+    needs: detect-push-context
+    if: github.event_name != 'push' || needs.detect-push-context.outputs.skip_pr_meta != 'true'
     runs-on: ubuntu-latest
     outputs:
       number: ${{ steps.get.outputs.number }}


### PR DESCRIPTION
## Summary
- add a guard job that checks push events for an existing open PR
- skip the pr-meta job on push events when the same branch already has a PR run

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68eeb1b74738832fac27f892b9f29f3e