### PR TITLE
Add Codex SRP workflow for single-responsibility sweeps

### DIFF
--- a/.github/workflows/codex-srp.yml
+++ b/.github/workflows/codex-srp.yml
@@ -1,0 +1,54 @@
+name: Codex SRP – Single Responsibility Guardrail
+
+on:
+  schedule:
+    - cron: "0 5 * * 1" # every Monday at 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      line_threshold:
+        description: "Minimum number of implementation lines before Codex proposes SRP helpers"
+        required: false
+        default: "60"
+      verb_candidates:
+        description: "Comma-separated verbs that imply multiple responsibilities"
+        required: false
+        default: "init,compute,render,load,update,finalize"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  LINE_THRESHOLD: ${{ github.event.inputs.line_threshold || '60' }}
+  VERB_CANDIDATES: ${{ github.event.inputs.verb_candidates || 'init,compute,render,load,update,finalize' }}
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Single Responsibility Sweep"
+      pr_body: |
+        Codex, please audit the codebase for oversized functions whose names
+        combine multiple verbs. Suggest helper extractions that reinforce the
+        single-responsibility principle so that follow-up changes only need to
+        touch one focused unit.
+
+        • Maximum acceptable implementation size: ${{ env.LINE_THRESHOLD }} lines
+        • Verb stems that suggest multiple responsibilities: ${{ env.VERB_CANDIDATES }}
+
+        Share a short before/after summary in the PR description and note any
+        areas that still require human follow-up.
+      prompt: >
+        Run a repository-wide guardrail pass to enforce the single-responsibility
+        principle. Identify one function whose body exceeds ${{ env.LINE_THRESHOLD }}
+        non-comment, non-blank lines and whose name clearly strings together
+        multiple verb stems (e.g., from this list: ${{ env.VERB_CANDIDATES }}).
+        Explain why the current implementation violates SRP, then propose and
+        implement helper extraction(s) so that each resulting function owns a
+        single change-triggering responsibility. Keep public APIs stable,
+        preserve tests, and update documentation if behaviour shifts. If no
+        candidate qualifies, document the audit findings and outline a follow-up
+        plan instead of forcing changes.
+      branch_prefix: "codex-srp"

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,6 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
+- [Codex automation playbook](codex-actions.md) — Documents the Codex-assisted
+  maintenance workflows. Start here to understand why each guardrail exists and
+  how to tune the triggers when new risks emerge.

--- a/docs/codex-actions.md
+++ b/docs/codex-actions.md
@@ -1,0 +1,20 @@
+# Codex automation playbook
+
+The repository relies on a suite of Codex-assisted GitHub Actions to keep the
+formatter codebase tidy. Each workflow seeds a dedicated pull request with clear
+instructions so Codex can do targeted maintenance without human babysitting.
+
+## Single Responsibility Guardrail
+
+The **Codex SRP – Single Responsibility Guardrail** workflow (`codex-srp.yml`)
+scans for functions that balloon past a configurable line limit and combine
+multiple verb stems in their names (for example `initComputeRender`). Those cues
+usually indicate that a single unit is juggling distinct duties. When triggered,
+Codex proposes extracting helper functions so each piece of logic owns exactly
+one change-triggering responsibility. The follow-up review should focus on
+whether the extracted helpers keep behaviour intact, have meaningful names, and
+leave the remaining code easier to extend without cascading edits.
+
+Tweak the workflow dispatch inputs to adjust the acceptable line threshold or
+to monitor a different list of verb cues. If a scheduled run finds no matches,
+Codex reports the audit instead of forcing a refactor.


### PR DESCRIPTION
## Summary
- add a Codex SRP guardrail workflow that targets long, multi-verb functions and asks for helper extraction
- document the new guardrail in the Codex automation playbook and surface it from the docs index

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68efaf0c4d4c832fa85dc93de5e819de