### PR TITLE
Add Codex POLA workflow and review guidance

### DIFF
--- a/.github/workflows/codex-pola.yml
+++ b/.github/workflows/codex-pola.yml
@@ -1,0 +1,30 @@
+name: Codex 77 – POLA Behaviour Audit
+on:
+  schedule:
+    - cron: "24 1,13 * * *" # twice daily at 01:24 and 13:24 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: POLA Behaviour Audit"
+      pr_body: >
+        Seed PR for Codex to reconcile option documentation and inline comments
+        with the behaviours the formatter actually ships.
+      prompt: >
+        Hunt for places where our documentation, option descriptions, or inline
+        comments promise one behaviour but the implementation does something
+        subtly different (for example "0 disables" while the code coerces the
+        value to `null`). Choose one concrete contradiction that would surprise
+        a player or contributor, then either bring the implementation back in
+        line with the documented contract or tighten the docs so the behaviour
+        is explicit. When tweaking text, keep the tone consistent with nearby
+        guidance and call out the change in the PR body so reviewers can weigh
+        whether future code should follow the clarified rule.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
+
+## Automation workflows
+
+- [POLA behaviour audit workflow](workflows/pola-behaviour-audit.md) — Review
+  checklist for Codex runs that align documentation and implementation with the
+  Principle of Least Astonishment.

--- a/docs/workflows/pola-behaviour-audit.md
+++ b/docs/workflows/pola-behaviour-audit.md
@@ -1,0 +1,31 @@
+# POLA behaviour audit workflow
+
+The "Codex: POLA Behaviour Audit" automation focuses on the Principle of Least
+Astonishment. The workflow triages spots where comments, option descriptions, or
+user-facing docs promise one outcome but the code implements another. Keeping
+expectations and reality aligned prevents configuration foot-guns and helps
+contributors trust the formatter.
+
+## Review checklist
+
+When Codex opens a pull request for this workflow:
+
+1. **Confirm the contradiction.** Reproduce the cited behaviour gap by reading
+   the implementation and, when possible, running the relevant tests or script.
+   The example should demonstrate how a player or contributor would be
+   surprised.
+2. **Decide between code or docs.** Evaluate whether correcting the behaviour or
+   clarifying the documentation best honours the published contract. Prefer
+   fixing code if existing users rely on the documented promise; otherwise, make
+   the docs explicit about the actual runtime behaviour.
+3. **Check for ripple effects.** If code changes are proposed, ensure new tests
+   cover the clarified behaviour and that neighbouring options or helper
+   routines stay consistent. For documentation updates, verify that all
+   references to the option (README, CLI help, inline comments) reflect the new
+   wording.
+4. **Document the resolution.** Expect the PR body to explain the original
+   mismatch and the reasoning behind the chosen fix. Request revisions if the
+   trade-offs or migration notes are unclear.
+
+Following this checklist keeps the formatter predictable and reduces "surprise"
+bugs stemming from mismatched intent and implementation.


### PR DESCRIPTION
## Summary
- add a Codex automation that opens POLA behaviour audit PRs
- document reviewer expectations for those PRs and link them from the docs index

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efaf0af634832f9cc717cf957ed683