### PR TITLE
Add Codex workflow to clarify comment intent

### DIFF
--- a/.github/workflows/codex-document-intent.yml
+++ b/.github/workflows/codex-document-intent.yml
@@ -1,0 +1,28 @@
+name: Codex Document Intent
+on:
+  schedule:
+    - cron: "40 4,16 * * *" # twice daily at 04:40, 16:40 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Document Intent"
+      pr_body: "Seed PR prompting Codex to clarify terse comments with intent and context."
+      prompt: >
+        Audit the repository for inline comments that describe changes as "no-op," "do X," or
+        similarly terse directives without giving the reader enough context to trust the change.
+        When you spot a fragile or context-heavy section guarded by a minimal comment, expand the
+        note to capture the intent behind the code, why the behaviour matters, and what would break
+        if it were altered. Where the surrounding implementation depends on external design docs or
+        longer write-ups, link to the relevant guide so the next reader can explore the background.
+        Prefer tightening comments near complex state transitions, unconventional control flow, or
+        maintenance hazards so future contributors understand the guardrails instead of treating the
+        comment as a throwaway placeholder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   classifies edge cases and applies rename overrides.
 - [Dead code audit playbook](dead-code-audit.md) — Checklist and remediation
   steps for pruning unused code surfaced by the formatter’s metadata reports.
+- [Codex automation reference](codex-action-reference.md) — Explains the Codex
+  follow-up workflows that open documentation and code-quality PRs so reviewers
+  know what the automation is looking for.
 
 ## Usage & rollout
 

--- a/docs/codex-action-reference.md
+++ b/docs/codex-action-reference.md
@@ -1,0 +1,22 @@
+# Codex automation reference
+
+This catalog describes the Codex automation that regularly opens follow-up pull
+requests. Each entry summarises the workflow's intent so contributors know what
+to expect when Codex files a patch and how to review it effectively.
+
+## Document intent sweeps (`codex-document-intent.yml`)
+
+Codex inspects inline comments for phrases like "no-op" or imperative "do X"
+notes that skip the underlying rationale. When it finds fragile or
+context-dependent sections annotated with throwaway comments, Codex proposes
+clarifying the note so future contributors understand the behaviour being
+protected. Expect updates that:
+
+- expand short comments with the reasoning behind guard clauses or unusual
+  control flow;
+- call out risks if the surrounding implementation changes; and
+- link to design documents or reference guides whenever the context lives
+  outside the file.
+
+Reviewers should ensure the suggested explanations accurately reflect the code
+path and that any new links point at durable documentation.


### PR DESCRIPTION
## Summary
- add a Codex workflow that seeds PRs to expand terse comments with clear intent and supporting context
- document the new automation in the Codex action reference and link the guide from the docs index

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efaf032498832fa06c3a3f8cf3c99d