### PR TITLE
Add Codex SLA workflow for abstraction layer stewardship

### DIFF
--- a/.github/workflows/codex-sla.yml
+++ b/.github/workflows/codex-sla.yml
@@ -1,0 +1,26 @@
+name: Codex SLA – Abstraction Layer Stewardship
+
+on:
+  schedule:
+    - cron: "0 */4 * * *" # every 4 hours
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Abstraction Layer Stewardship"
+      pr_body: "Seed PR for Codex to keep orchestration code and low-level mechanics in separate layers."
+      prompt: >
+        Audit the codebase for a function that orchestrates high-level behaviour (controllers,
+        command handlers, or other entry points) yet still mutates raw arrays, indexes into
+        collections, or performs other primitive bookkeeping inline. Extract that low-level work
+        into focused helpers so the orchestrator reads as a sequence of delegation steps at a single
+        abstraction layer. Preserve behaviour, keep the diff tight, and ensure any new helper
+        contracts are documented or tested as appropriate.

--- a/docs/codex-actions-reference.md
+++ b/docs/codex-actions-reference.md
@@ -1,0 +1,8 @@
+# Codex Action Reference
+
+## Abstraction Layer Stewardship (codex-sla)
+
+- **Workflow**: `.github/workflows/codex-sla.yml`
+- **Cadence**: Scheduled every four hours with an option for manual dispatch when urgent review is required.
+- **Objective**: Locate orchestrator-style functions that mix high-level sequencing with inline primitive work such as array/index manipulation, and restructure them so low-level mechanics live in named helpers.
+- **SLA Expectation**: Each Codex run that opens this workflow's PR should land a refinement keeping the orchestrator at a single abstraction layer—delegating detailed bookkeeping to helpers, documenting new contracts, and preserving behaviour with existing or new tests as needed.


### PR DESCRIPTION
## Summary
- add a Codex workflow that targets orchestrator functions mixing high- and low-level logic
- provide documentation outlining the SLA expectations for the new action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efaef7d868832f8c23d53464ae63e2