### PR TITLE
Add Codex defensive input hardening workflow

### DIFF
--- a/.github/workflows/codex-defensive.yml
+++ b/.github/workflows/codex-defensive.yml
@@ -1,0 +1,32 @@
+name: Codex – Defensive Input Hardening
+
+on:
+  schedule:
+    - cron: "21 4 * * *"  # once a day at 04:21
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Defensive Input Hardening"
+      pr_body: >
+        Seed PR for Codex to reinforce defensive programming anywhere external
+        data is accepted without validation or functions rely on `any`/loosely
+        typed parameters. Tighten inputs before they can propagate invalid
+        states.
+      prompt: >
+        Identify a concrete hotspot where we deserialize external data or call a
+        function typed as `any`, `unknown`, or otherwise loosely typed without
+        guarding the input shape. Implement a focused hardening layer that adds
+        runtime validation, schema checks, or default value handling so that
+        malformed payloads are rejected or normalized early. Update or add
+        regression coverage capturing the failure before and the guarded path
+        after. Keep the scope small—address one high-impact site with pragmatic
+        validation while preserving existing API behaviour.

--- a/docs/defensive-input-hardening.md
+++ b/docs/defensive-input-hardening.md
@@ -1,0 +1,41 @@
+# Defensive Input Hardening Playbook
+
+The `Codex – Defensive Input Hardening` workflow searches for functions that
+accept `any`/loosely typed parameters or deserialize external data without
+performing checks. When the workflow files a pull request, contributors should
+lean on the following defensive programming patterns:
+
+## 1. Validate external inputs early
+- Parse untyped payloads through runtime schema validators (e.g. Zod, Yup) or
+  lightweight shape checks before data reaches business logic.
+- Reject malformed objects with explicit errors so call-sites fail loudly.
+- Normalize optional fields during validation to eliminate `undefined` drift
+  later in the pipeline.
+
+## 2. Prefer safe type boundaries
+- Replace `any` parameters with narrower TypeScript unions or branded aliases
+  that capture the intended shape.
+- Introduce dedicated parsing helpers that accept `unknown` and return typed
+  results via user-defined type guards.
+- Add exhaustive switch/case coverage when discriminated unions model incoming
+  variants.
+
+## 3. Layer default and fallback handling
+- Supply defaults for omitted optional fields using object spread patterns or
+  utility helpers such as `withDefaults`.
+- Clamp numeric ranges, truncate strings, and sanitize enums before persisting
+  values.
+- When bridging legacy callers, wrap existing APIs with adapter functions that
+  perform normalization while preserving the outward contract.
+
+## 4. Strengthen test coverage around validation
+- Add regression tests covering both the failure mode prior to validation and
+  the hardened path after the change.
+- Exercise boundary cases (empty strings, nullish values, extreme numbers) to
+  ensure guard rails stay intact.
+- Document the expected error messages or defaults in test assertions so future
+  regressions are easy to spot.
+
+Following these guardrails keeps external data ingestion predictable and makes
+it easier to reason about error handling across the formatter and parser
+surfaces.


### PR DESCRIPTION
## Summary
- add a scheduled Codex workflow that focuses on functions with loosely typed inputs or external data ingestion
- configure the prompt to ask for validation layers, schema checks, and default handling when hardening inputs
- document the defensive programming patterns the workflow expects contributors to follow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68efaee984a8832f883497fa62c24455