### PR TITLE
Add Codex ISP workflow and documentation

### DIFF
--- a/.github/workflows/codex-isp.yml
+++ b/.github/workflows/codex-isp.yml
@@ -1,0 +1,38 @@
+name: Codex ISP – Interface Segregation
+
+on:
+  schedule:
+    - cron: "15 */4 * * *" # every 4 hours at :15
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Interface Segregation Sweep"
+      pr_body: |
+        Seed PR for Codex to inspect oversized interface or type contracts whose
+        names hint at overly broad responsibilities (for example, `*Service` or
+        `*Manager`).
+      prompt: >
+        Audit the repository for TypeScript or JavaScript interface/type
+        definitions that accumulate many members (properties or methods) and use
+        broad, catch-all names such as "Service", "Manager", or "Controller".
+        Identify one such definition whose size or naming suggests it violates
+        the Interface Segregation Principle. Explain why the contract is too
+        wide, then split it into smaller, role-focused interfaces or types. Each
+        replacement contract should model a cohesive responsibility with only
+        the members required by its consumers.
+
+        After defining the new contracts, update the existing implementations
+        and call sites so they depend on the appropriate specialized interface.
+        Prioritise minimal, well-scoped changes: keep renames atomic, avoid
+        incidental refactors, and ensure tests continue to pass. If no suitable
+        candidate is found, document the investigation in the commit message and
+        outline what evidence you gathered.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
+
+## Automation
+
+- [Codex action list](codex-action-list.md) — Expectations and curated examples
+  for Codex automation sweeps, including the Interface Segregation Principle
+  check defined in `codex-isp.yml`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,8 +50,6 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
-<<<<<<< HEAD
-
 ## Automation
 
 - [Codex automation playbook](codex-actions.md) — Documents the Codex-assisted

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
+
 ## Automation
 
 - [Codex automation playbook](codex-actions.md) — Documents the Codex-assisted

--- a/docs/codex-action-list.md
+++ b/docs/codex-action-list.md
@@ -1,0 +1,40 @@
+# Codex action list
+
+## Interface Segregation sweep (`codex-isp.yml`)
+
+Codex runs the Interface Segregation sweep on a regular cadence. When the
+workflow opens a seed pull request, the assistant is expected to:
+
+- Search for TypeScript/JavaScript interfaces or type aliases with many members
+  (methods or properties) coupled to broad names such as `FooService`,
+  `BarManager`, or `BazController`.
+- Flag contracts whose sprawl suggests they violate the Interface Segregation
+  Principle (ISP) and articulate why the responsibilities are too broad.
+- Partition the contract into role-specific interfaces that group cohesive
+  responsibilities together.
+- Update the implementing classes/objects and any consuming call sites to depend
+  on the smaller interfaces.
+- Keep the change narrowly focused on the chosen contract: avoid unrelated
+  refactors, preserve public API stability unless strictly necessary, and ensure
+  tests keep passing.
+- When no suitable candidate is found, document the investigation with concrete
+  evidence (e.g., lists of reviewed files, metrics for member counts) and explain
+  what would be required for a future ISP refactor.
+
+### Examples of acceptable improvements
+
+- Splitting a 15-member `ProjectService` interface into `ProjectReader` (read
+  operations) and `ProjectMutator` (write operations) so that read-only
+  components can depend on a smaller contract.
+- Breaking up a `ResourceManager` type alias that mixes cache maintenance,
+  network orchestration, and logging hooks into separate interfaces for cache
+  hydration, fetch coordination, and audit logging. Consumers import only the
+  slice they require, reducing accidental coupling.
+- Replacing a `TelemetryController` interface that exposes configuration
+  management, live sampling controls, and reporting pipelines with dedicated
+  `TelemetryConfig`, `TelemetrySampling`, and `TelemetryReporter` contracts, and
+  updating implementations to advertise the appropriate subset.
+
+These examples illustrate the expectation: highlight a specific oversized
+contract, justify the split, introduce cohesive replacements, and migrate the
+consumers without broad collateral edits.


### PR DESCRIPTION
## Summary
- add a Codex workflow that seeds interface segregation sweeps for large, broadly named contracts
- document the expected ISP analysis flow and worked examples in the Codex action list and link it from the docs index

## Testing
- eslint . --cache --fix

------
https://chatgpt.com/codex/tasks/task_e_68efaed6b380832fb058e273b4b85fec