### PR TITLE
Add Codex composition workflow and documentation

### DIFF
--- a/.github/workflows/codex-composition.yml
+++ b/.github/workflows/codex-composition.yml
@@ -1,0 +1,29 @@
+name: Codex – Favor Composition Over Inheritance
+
+on:
+  schedule:
+    - cron: "45 4 * * *" # daily at 04:45 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Promote Composition"
+      pr_body: "Seed PR for Codex to replace overgrown inheritance with composition."
+      prompt: >
+        Locate the class that most egregiously subclasses another type (uses `extends`)
+        while overriding at least three methods from the parent. Study the inheritance
+        chain and determine whether those overrides are handling distinct concerns or
+        conditional branches that would be better served by composing helper objects or
+        mixins. Refactor the chosen class to delegate behaviour to injected
+        collaborators, mixin utilities, or other composition-friendly structures instead
+        of deepening the subclass. Keep the public API and observable behaviour
+        identical, trim any now-unused overrides, update tests/docs if directly
+        impacted, and verify formatters and linters succeed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
 - [Examples: Tricky identifier casing](examples/naming-convention/tricky-identifiers.md)
   — A collection of real-world identifiers that demonstrate how the formatter
   classifies edge cases and applies rename overrides.
+- [Codex Automation Guide](codex-guide.md) — Explains how Codex workflows target
+  recurring refactors, including the composition prompts that prefer injected
+  collaborators or mixins over deep inheritance chains.
 - [Dead code audit playbook](dead-code-audit.md) — Checklist and remediation
   steps for pruning unused code surfaced by the formatter’s metadata reports.
 

--- a/docs/codex-guide.md
+++ b/docs/codex-guide.md
@@ -1,0 +1,45 @@
+# Codex Automation Guide
+
+Codex automation keeps this repository honest by surfacing recurring refactors
+that improve maintainability. Each workflow seeds a PR with a focused prompt so
+Codex can explore and implement small, reviewable changes. Use this guide to
+understand the intent behind those prompts and the architectural patterns they
+reinforce.
+
+## Favor composition over inheritance
+
+The [`Codex – Favor Composition Over Inheritance`](../.github/workflows/codex-composition.yml)
+workflow tracks classes that extend a parent and override several methods. Once a
+class needs three or more overrides to bend the base implementation to its will,
+subclassing is usually hiding multiple responsibilities inside one type. Codex is
+asked to redirect those behaviours through composition-friendly patterns instead
+of piling more conditionals into the subclass.
+
+### Patterns Codex should reach for
+
+- **Injected collaborators** — Extract the overridden behaviour into discrete
+  helpers that are constructed or passed in with the class. Collaborators can own
+  cross-cutting concerns (validation, persistence, formatting) so the original
+  class orchestrates rather than implements everything itself.
+- **Strategy objects** — When behaviour varies by configuration or runtime
+  conditions, define an interface the parent class can call and supply concrete
+  strategies via dependency injection. Each strategy isolates one variation and
+  can be tested independently.
+- **Mixin utilities** — If multiple classes share the same overridden snippets,
+  promote those blocks into mixins or modules that can be composed together
+  without forcing a shared base class.
+- **Event emitters or hooks** — Instead of overriding lifecycle methods, surface
+  well-named hooks that forward to delegates. Consumers register listeners or
+  provide callbacks, keeping the inheritance tree shallow.
+
+### Review checklist
+
+- Did Codex replace the subclass overrides with delegates or mixins that make
+  responsibilities clearer?
+- Are any remaining overrides justified and limited to coordinating composed
+  pieces rather than re-implementing parent logic wholesale?
+- Were docs and tests touched by the refactor updated to match the new structure?
+
+If a refactor would destabilise critical behaviour, Codex is instructed to stop
+short of speculative changes and document the limitation in the PR summary. That
+note helps maintainers decide how to approach the follow-up manually.


### PR DESCRIPTION
## Summary
- add a Codex automation workflow that targets classes overriding many inherited methods and encourages composition
- document the composition-first patterns Codex should use and link the new guide from the docs index

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68efaec77a40832fb72110fa1f1ef762