### PR TITLE
Add Codex workflow to enforce Law of Demeter guardrails

### DIFF
--- a/.github/workflows/codex-demeter.yml
+++ b/.github/workflows/codex-demeter.yml
@@ -1,0 +1,27 @@
+name: Codex – Law of Demeter Guardrails
+on:
+  schedule:
+    - cron: "7 6 * * *"  # once per day at 06:07 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Law of Demeter Guardrails"
+      pr_body: |
+        Seed PR for Codex to rein in long-reaching property access and reinforce the
+        Law of Demeter across the codebase.
+      prompt: >
+        Search the repository for property chains longer than three segments (for example,
+        patterns like `alpha.beta.gamma.delta`). Highlight the exact lines you choose in your
+        summary so reviewers can see the high-risk chains that motivated the work. Refactor the
+        most compelling instance by introducing intermediate helpers, facades, or other seams so
+        collaborators only talk to their immediate neighbours. Keep the fix tightly scoped,
+        document any new helper surfaces, and make sure existing tests still pass.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   [Feather Data Plan](feather-data-plan.md) and the reserved identifier coverage
   in [Identifier Case & Naming Convention Guide](naming-conventions.md#5-reserved-identifier-dataset)
   when updating the scrapers.
+
+## Codex workflow index
+
+- **Law of Demeter Guardrails** (`codex-demeter.yml`) — Flags property chains that
+  stretch across more than three segments and nudges Codex to add intermediate
+  helpers or facades so each module only talks to its direct collaborators.


### PR DESCRIPTION
## Summary
- add a Codex workflow focused on Law of Demeter guardrails and highlighting long property chains
- document the workflow in the Codex index so reviewers know it targets intermediate helper extraction

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68efaec5b704832f99603d84bf33924f