### PR TITLE
Add Codex low coupling workflow and reference

### DIFF
--- a/.github/workflows/codex-low-coupling.yml
+++ b/.github/workflows/codex-low-coupling.yml
@@ -1,0 +1,33 @@
+name: Codex 80 – Low Coupling Guardrail
+
+on:
+  schedule:
+    - cron: "20 4,16 * * *" # twice daily at 04:20, 16:20 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Low Coupling Guardrail"
+      pr_body: |
+        Seed PR for Codex to reduce deep peer coupling by replacing fragile deep imports
+        with stable abstractions and dependency boundaries.
+      prompt: >
+        Audit the repository for modules that import peers using deep relative paths
+        ("../.." or deeper) or paths containing "/internal/" segments. For each finding,
+        cite the file and import statement, explain why the coupling is risky, and
+        recommend an appropriate abstraction (interface, adapter, factory, or public
+        facade) that would let the consumer depend on stable contracts rather than
+        implementation details. Prefer dependency injection or other boundary-enforcing
+        patterns so callers receive collaborators via constructors or parameters instead
+        of reaching into internal modules. Where improvements are tractable, implement
+        the minimal changes needed to introduce the abstraction, update imports, and
+        keep behaviour identical. Run formatters, linters, and relevant tests before
+        finishing, and document any follow-up work if a larger refactor is required.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   classifies edge cases and applies rename overrides.
 - [Dead code audit playbook](dead-code-audit.md) — Checklist and remediation
   steps for pruning unused code surfaced by the formatter’s metadata reports.
+- [Codex workflow reference](codex-workflow-reference.md) — Summaries of the
+  Codex automation guardrails and the abstraction patterns they recommend when
+  surfacing issues.
 
 ## Usage & rollout
 

--- a/docs/codex-workflow-reference.md
+++ b/docs/codex-workflow-reference.md
@@ -1,0 +1,31 @@
+# Codex workflow reference
+
+Use this guide to understand what each Codex automation is looking for and which
+remediation patterns keep the resulting pull requests focused and maintainable.
+
+## Codex 80 – Low Coupling Guardrail
+
+The low-coupling workflow scans for modules that import siblings or cousins via
+fragile deep paths—specifically:
+
+- Relative imports that climb multiple directory levels (for example `../..`).
+- Paths that reach into `internal` directories that should be treated as
+  implementation details.
+
+When Codex opens a pull request from this workflow, it should recommend
+structural boundaries that keep consumers aligned with stable contracts. The
+expected remediation patterns include:
+
+- **Interfaces and abstract types** that define the collaborator’s public
+  surface, keeping callers unaware of underlying implementations.
+- **Adapters or facades** that translate between domains or expose curated entry
+  points so downstream modules stop depending on private utilities.
+- **Factories** that construct the right concrete implementation while returning
+  interface-shaped handles to consumers.
+- **Dependency injection** (constructor parameters, factory arguments, or
+  provider functions) so modules receive collaborators from the outside instead
+  of importing deep internal files.
+
+Codex should note when deeper redesign is required, but its default move is to
+introduce the smallest abstraction that removes the deep import while preserving
+behaviour and test coverage.


### PR DESCRIPTION
## Summary
- add a Codex automation that scans for deep peer imports and recommends abstractions
- document the low coupling guardrail and its patterns in the Codex workflow reference, linked from the docs index

## Testing
- not run (not needed for documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68efaebb7b44832fbdb05f7dc4b19859