### PR TITLE
Generalize Codex policy/mechanism workflow guidance

### DIFF
--- a/.github/workflows/codex-policy-mechanism.yml
+++ b/.github/workflows/codex-policy-mechanism.yml
@@ -1,0 +1,35 @@
+name: Codex – Policy Mechanism Separation
+on:
+  schedule:
+    - cron: "20 1 * * 1" # weekly on Mondays at 01:20 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/_codex-open-pr-and-ping.yml
+    secrets: inherit
+    with:
+      pr_title: "Codex: Separate policy evaluators from mechanisms"
+      pr_body: |
+        ## Summary
+        * Identify formatter modules where policy heuristics are intertwined with operational logic.
+        * Extract policy evaluators or strategy objects so that formatting actions can delegate to them.
+
+        ## Testing
+        * npm test
+      prompt: >
+        Inspect modules where policy decisions (flags, thresholds, cache sizing, heuristic lookups, or other
+        conditional rules) are implemented in the same place that performs operational side effects. Look for
+        code that both decides "what" should happen and immediately carries out the "how", leaving no seam to
+        exercise the policy independently.
+
+        For one of these hotspots, design and implement a refactor that extracts the policy computation into a
+        dedicated evaluator, ruleset, or strategy object. Adjust the mechanism code to depend on the extracted
+        policy rather than recomputing heuristics inline. Ensure the new abstraction keeps existing behaviour
+        intact, adds focused unit coverage where practical, and documents the separation so future contributors
+        keep policy and mechanisms decoupled.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,9 @@ quick-start flow, formatter configuration, and day-to-day development commands.
   predictable.
 - [Project Index next steps](project-index-next-steps.md) — Tracks remaining
   follow-up work now that cache persistence and discovery ship in the plugin.
+- [Codex workflow guide](codex-workflow-guide.md) — Describes the Codex PR
+  seeders we rely on, including the policy/mechanism separation sweep and the
+  hotspots it targets.
 
 ## Metadata tooling
 

--- a/docs/codex-workflow-guide.md
+++ b/docs/codex-workflow-guide.md
@@ -1,0 +1,44 @@
+# Codex workflow guide
+
+This guide captures the bespoke automation we run through the Codex PR seeding
+workflows. Each entry summarises the intent of the workflow, the hotspots it
+reviews, and the architectural guardrails we expect it to reinforce.
+
+## Policy mechanism separation
+
+**Workflow:** `.github/workflows/codex-policy-mechanism.yml`
+
+### Why this exists
+
+Several formatter subsystems evolved utility modules that both compute policy
+heuristics (flags, thresholds, cache sizing, or diagnostic lookups) and execute
+the operational steps that mutate state or perform I/O. Bundling the policy and
+mechanism together makes the code difficult to audit, limits our ability to test
+policy decisions in isolation, and encourages copy-paste heuristics that drift
+out of sync.
+
+### Hotspots we monitor
+
+- Bootstrapping flows that both choose cache or discovery policy and immediately
+  perform filesystem orchestration. When the same module decides whether work is
+  needed and performs it, we lose the ability to reuse the policy elsewhere.
+- Coordinators that interleave concurrency or caching strategy with I/O. The
+  logic that determines eviction thresholds or rebuild triggers should feed a
+  worker, not drive the filesystem directly.
+- Transformation pipelines where diagnostic heuristics live beside the mutation
+  routines. Embedding the "should we fix this" logic inside the function that
+  mutates the AST or document makes it impossible to exercise the heuristics in
+  isolation.
+
+### Expected Codex outcome
+
+We expect Codex to identify one of these hotspots (or a newly added peer) and
+extract the policy evaluation into a dedicated evaluator, strategy object, or
+ruleset module. The mechanism code should delegate to the new abstraction rather
+than inlining the heuristics. The resulting design ought to:
+
+- Preserve existing behaviour while making the policy testable in isolation.
+- Document the seam so future contributors avoid re-coupling policy and
+  mechanism code.
+- Encourage incremental clean-up that chips away at the monolithic modules
+  highlighted above.


### PR DESCRIPTION
## Summary
- relax the Codex policy/mechanism workflow prompt so it describes the smell generically rather than naming specific files
- update the workflow guide to call out the categories of hotspots instead of repo-specific paths

## Testing
- not run (not needed for workflow/docs update)


------
https://chatgpt.com/codex/tasks/task_e_68efaef671e4832fa04a80fe2fad7219