### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -10,7 +10,10 @@ import {
     getNonEmptyString
 } from "../../../shared/string-utils.js";
 import { isObjectLike, withObjectLike } from "../../../shared/object-utils.js";
-import { normalizeIdentifierCaseOptions } from "../options/identifier-case.js";
+import {
+    normalizeIdentifierCaseOptions,
+    IdentifierCaseStyle
+} from "../options/identifier-case.js";
 import { peekIdentifierCaseDryRunContext } from "./identifier-case-context.js";
 import {
     applyBootstrappedIdentifierCaseProjectIndex,
@@ -445,7 +448,7 @@ function planIdentifierRenamesForScope({
         return;
     }
 
-    if (style === "off") {
+    if (style === IdentifierCaseStyle.OFF) {
         return;
     }
 
@@ -768,7 +771,8 @@ export async function prepareIdentifierCasePlan(options) {
     // and rename maps without mutating sources when the style is disabled.
 
     const normalizedOptions = normalizeIdentifierCaseOptions(options);
-    const localStyle = normalizedOptions.scopeStyles?.locals ?? "off";
+    const localStyle =
+        normalizedOptions.scopeStyles?.locals ?? IdentifierCaseStyle.OFF;
     const assetStyle = normalizedOptions.scopeStyles?.assets ?? "off";
     const functionStyle = normalizedOptions.scopeStyles?.functions ?? "off";
     const structStyle = normalizedOptions.scopeStyles?.structs ?? "off";
@@ -776,7 +780,7 @@ export async function prepareIdentifierCasePlan(options) {
     const instanceStyle = normalizedOptions.scopeStyles?.instance ?? "off";
     const globalStyle = normalizedOptions.scopeStyles?.globals ?? "off";
 
-    const shouldPlanLocals = localStyle !== "off";
+    const shouldPlanLocals = localStyle !== IdentifierCaseStyle.OFF;
     const shouldPlanAssets = assetStyle !== "off";
     const shouldPlanFunctions = functionStyle !== "off";
     const shouldPlanStructs = structStyle !== "off";
@@ -883,7 +887,9 @@ export async function prepareIdentifierCasePlan(options) {
     }
 
     const hasLocalSupport =
-        projectIndex && projectIndex.files && localStyle !== "off";
+        projectIndex &&
+        projectIndex.files &&
+        localStyle !== IdentifierCaseStyle.OFF;
 
     if (hasLocalSupport) {
         metrics.incrementCounter("locals.supportedFiles");

--- a/src/plugin/tests/identifier-case-options.test.js
+++ b/src/plugin/tests/identifier-case-options.test.js
@@ -6,6 +6,7 @@ import {
     IDENTIFIER_CASE_SCOPE_NAMES,
     IDENTIFIER_CASE_INHERIT_VALUE,
     IDENTIFIER_CASE_ACKNOWLEDGE_ASSETS_OPTION_NAME,
+    IdentifierCaseStyle,
     normalizeIdentifierCaseOptions,
     getIdentifierCaseScopeOptionName,
     IDENTIFIER_CASE_IGNORE_OPTION_NAME,
@@ -16,13 +17,16 @@ describe("gml identifier case option normalization", () => {
     it("defaults to disabled renaming when options are omitted", () => {
         const normalized = normalizeIdentifierCaseOptions({});
 
-        assert.strictEqual(normalized.baseStyle, "off");
+        assert.strictEqual(normalized.baseStyle, IdentifierCaseStyle.OFF);
         for (const scope of IDENTIFIER_CASE_SCOPE_NAMES) {
             assert.strictEqual(
                 normalized.scopeSettings[scope],
                 IDENTIFIER_CASE_INHERIT_VALUE
             );
-            assert.strictEqual(normalized.scopeStyles[scope], "off");
+            assert.strictEqual(
+                normalized.scopeStyles[scope],
+                IdentifierCaseStyle.OFF
+            );
         }
         assert.deepStrictEqual(normalized.ignorePatterns, []);
         assert.deepStrictEqual(normalized.preservedIdentifiers, []);
@@ -53,6 +57,28 @@ describe("gml identifier case option normalization", () => {
             "PlayerScore"
         ]);
         assert.strictEqual(normalized.assetRenamesAcknowledged, true);
+    });
+
+    it("rejects unknown locals identifier case style values", () => {
+        assert.throws(
+            () =>
+                normalizeIdentifierCaseOptions({
+                    [getIdentifierCaseScopeOptionName("locals")]: "kebab"
+                }),
+            /invalid identifier case style/i
+        );
+    });
+
+    it("accepts valid locals identifier case style values", () => {
+        const normalized = normalizeIdentifierCaseOptions({
+            [getIdentifierCaseScopeOptionName("locals")]:
+                IdentifierCaseStyle.SNAKE_UPPER
+        });
+
+        assert.strictEqual(
+            normalized.scopeStyles.locals,
+            IdentifierCaseStyle.SNAKE_UPPER
+        );
     });
 
     it("rejects enabling asset renames without acknowledgment", () => {


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
