### PR TITLE
Codex: Floating-Point Equality Pitfalls

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1397,7 +1397,7 @@ function printElements(
         }
 
         return parts;
-    }, listKey);
+    });
 }
 
 function isComplexArgumentNode(node) {
@@ -1669,7 +1669,7 @@ function printStatements(path, options, print, childrenAttribute) {
         }
 
         return parts;
-    }, childrenAttribute);
+    });
 }
 
 export function applyAssignmentAlignment(statements, options) {

--- a/src/shared/tests/number-utils.test.js
+++ b/src/shared/tests/number-utils.test.js
@@ -46,5 +46,12 @@ describe("number-utils", () => {
                 "5 MB"
             );
         });
+
+        it("promotes values near unit boundaries despite rounding noise", () => {
+            const truncatedThird = 0.333_333_333_333_333;
+            const bytes = truncatedThird * 3 * 1024 * 1024;
+
+            assert.equal(formatByteSize(bytes), "1.0MB");
+        });
     });
 });


### PR DESCRIPTION
Seed PR for Codex to replace an unsafe floating-point equality check with a tolerance-aware comparison backed by tests.
