### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -38,6 +38,7 @@ import {
     mergeUniqueValues,
     uniqueArray
 } from "../shared/array-utils.js";
+import { isErrorLike } from "../shared/utils/capability-probes.js";
 import {
     normalizeStringList,
     toNormalizedLowerCaseString,
@@ -610,7 +611,9 @@ async function resolveTargetStats(target, { usage } = {}) {
             `Unable to access ${target}: ${details}`,
             { usage }
         );
-        cliError.cause = error instanceof Error ? error : undefined;
+        if (isErrorLike(error)) {
+            cliError.cause = error;
+        }
         throw cliError;
     }
 }

--- a/src/cli/lib/cli-errors.js
+++ b/src/cli/lib/cli-errors.js
@@ -1,4 +1,8 @@
 import { toTrimmedString } from "../../shared/string-utils.js";
+import {
+    isAggregateErrorLike,
+    isErrorLike
+} from "../../shared/utils/capability-probes.js";
 
 const DEFAULT_INDENT = "  ";
 
@@ -34,7 +38,7 @@ function extractStackBody(stack) {
 }
 
 function formatAggregateErrors(error, seen) {
-    if (!(error instanceof AggregateError) || !Array.isArray(error.errors)) {
+    if (!isAggregateErrorLike(error)) {
         return null;
     }
 
@@ -133,7 +137,7 @@ function formatErrorValue(value, seen) {
         return String(value);
     }
 
-    if (value instanceof Error) {
+    if (isErrorLike(value)) {
         return formatErrorObject(value, seen);
     }
 

--- a/src/cli/lib/command-parsing.js
+++ b/src/cli/lib/command-parsing.js
@@ -1,4 +1,13 @@
 import { CliUsageError } from "./cli-errors.js";
+import { isErrorLike } from "../../shared/utils/capability-probes.js";
+
+function isCommanderError(error) {
+    return (
+        isErrorLike(error) &&
+        error.name === "CommanderError" &&
+        typeof error.code === "string"
+    );
+}
 
 export {
     coercePositiveInteger,
@@ -29,7 +38,7 @@ export function parseCommandLine(command, args) {
             };
         }
 
-        if (error instanceof Error && error.name === "CommanderError") {
+        if (isCommanderError(error)) {
             throw new CliUsageError(error.message.trim(), {
                 usage: command.helpInformation()
             });

--- a/src/cli/lib/env-overrides.js
+++ b/src/cli/lib/env-overrides.js
@@ -1,5 +1,6 @@
 import { CliUsageError } from "./cli-errors.js";
 import { isNonEmptyString } from "../../shared/string-utils.js";
+import { isErrorLike } from "../../shared/utils/capability-probes.js";
 
 const DEFAULT_SOURCE = "env";
 
@@ -17,14 +18,14 @@ function createOverrideError({ error, envVar, getUsage }) {
         ? `Invalid value provided for ${envVar}.`
         : "Invalid environment variable value provided.";
     const message =
-        error instanceof Error &&
+        isErrorLike(error) &&
         isNonEmptyString(error.message) &&
         !/^error\b/i.test(error.message.trim())
             ? error.message
             : fallbackMessage;
 
     const cliError = new CliUsageError(message, { usage });
-    cliError.cause = error instanceof Error ? error : undefined;
+    cliError.cause = isErrorLike(error) ? error : undefined;
     return cliError;
 }
 

--- a/src/cli/tests/command-parsing.test.js
+++ b/src/cli/tests/command-parsing.test.js
@@ -51,4 +51,27 @@ describe("parseCommandLine", () => {
                 typeof error.usage === "string"
         );
     });
+
+    it("supports Commander-style errors without Error prototypes", () => {
+        const command = {
+            parse() {
+                throw {
+                    name: "CommanderError",
+                    code: "commander.invalidOption",
+                    message: "bad option"
+                };
+            },
+            helpInformation() {
+                return "usage info";
+            }
+        };
+
+        assert.throws(
+            () => parseCommandLine(command, []),
+            (error) =>
+                error instanceof CliUsageError &&
+                error.message === "bad option" &&
+                error.usage === "usage info"
+        );
+    });
 });

--- a/src/cli/tests/env-overrides.test.js
+++ b/src/cli/tests/env-overrides.test.js
@@ -97,6 +97,38 @@ describe("applyEnvOptionOverride", () => {
             }
         );
     });
+
+    it("preserves resolver failures that mimic Error objects", () => {
+        const command = {
+            setOptionValueWithSource() {
+                throw new Error("should not be called");
+            }
+        };
+
+        const failure = {
+            name: "ResolverFailure",
+            message: "custom failure"
+        };
+
+        assert.throws(
+            () =>
+                applyEnvOptionOverride({
+                    command,
+                    env: { TEST_VALUE: "value" },
+                    envVar: "TEST_VALUE",
+                    optionName: "testOption",
+                    resolveValue() {
+                        throw failure;
+                    }
+                }),
+            (error) => {
+                assert.ok(error instanceof CliUsageError);
+                assert.equal(error.message, "custom failure");
+                assert.equal(error.cause, failure);
+                return true;
+            }
+        );
+    });
 });
 
 describe("applyEnvOptionOverrides", () => {

--- a/src/parser/src/gml-parser.js
+++ b/src/parser/src/gml-parser.js
@@ -5,6 +5,7 @@ import GameMakerLanguageParser from "./generated/GameMakerLanguageParser.js";
 import GameMakerASTBuilder from "./gml-ast-builder.js";
 import GameMakerParseErrorListener from "./gml-syntax-error.js";
 import { getLineBreakCount } from "../../shared/utils/line-breaks.js";
+import { isErrorLike } from "../../shared/utils/capability-probes.js";
 
 export default class GMLParser {
     constructor(text, options) {
@@ -49,9 +50,11 @@ export default class GMLParser {
             tree = parser.program();
         } catch (error) {
             if (error) {
-                const normalisedError =
-                    error instanceof Error ? error : new Error(String(error));
-                throw normalisedError;
+                if (isErrorLike(error)) {
+                    throw error;
+                }
+
+                throw new Error(String(error));
             }
             throw new Error("Unknown syntax error while parsing GML source.");
         }

--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -24,6 +24,11 @@ import { isFiniteNumber } from "../../../shared/number-utils.js";
 import { asArray, isNonEmptyArray } from "../../../shared/array-utils.js";
 import { hasOwn, isObjectLike } from "../../../shared/object-utils.js";
 import { escapeRegExp } from "../../../shared/regexp.js";
+import {
+    hasIterableItems,
+    isMapLike,
+    isSetLike
+} from "../../../shared/utils/capability-probes.js";
 import { collectCommentNodes, getCommentArray } from "../comments/index.js";
 import {
     getFeatherDiagnosticById,
@@ -3848,7 +3853,7 @@ function fixArgumentReferencesWithinFunction(
         references.map((reference) => reference.index)
     );
 
-    if (!(mapping instanceof Map) || mapping.size === 0) {
+    if (!isMapLike(mapping) || !hasIterableItems(mapping)) {
         return fixes;
     }
 
@@ -16239,7 +16244,10 @@ function fixSpecifierSpacing(typeText, specifierBaseTypes) {
         return typeText ?? "";
     }
 
-    if (!(specifierBaseTypes instanceof Set) || specifierBaseTypes.size === 0) {
+    if (
+        !isSetLike(specifierBaseTypes) ||
+        !hasIterableItems(specifierBaseTypes)
+    ) {
         return typeText;
     }
 
@@ -16396,7 +16404,7 @@ function fixTypeUnionSpacing(typeText, baseTypesLower) {
         return typeText ?? "";
     }
 
-    if (!(baseTypesLower instanceof Set) || baseTypesLower.size === 0) {
+    if (!isSetLike(baseTypesLower) || !hasIterableItems(baseTypesLower)) {
         return typeText;
     }
 
@@ -17328,7 +17336,7 @@ function isGpuPopStateCall(node) {
 function getManualFeatherFixRegistry(ast) {
     let registry = ast[MANUAL_FIX_TRACKING_KEY];
 
-    if (registry instanceof Set) {
+    if (isSetLike(registry)) {
         return registry;
     }
 
@@ -17395,7 +17403,7 @@ function applyMissingFunctionCallCorrections({ ast, diagnostic }) {
     const replacements =
         extractFunctionCallReplacementsFromExamples(diagnostic);
 
-    if (!(replacements instanceof Map) || replacements.size === 0) {
+    if (!isMapLike(replacements) || !hasIterableItems(replacements)) {
         return [];
     }
 
@@ -17447,7 +17455,7 @@ function correctMissingFunctionCall(node, replacements, diagnostic) {
         return null;
     }
 
-    if (!(replacements instanceof Map) || replacements.size === 0) {
+    if (!isMapLike(replacements) || !hasIterableItems(replacements)) {
         return null;
     }
 

--- a/src/plugin/src/comments/line-comment-formatting.js
+++ b/src/plugin/src/comments/line-comment-formatting.js
@@ -4,6 +4,7 @@ import {
     normalizeLineCommentOptions
 } from "../options/line-comment-options.js";
 import { isObjectLike } from "./comment-boundary.js";
+import { isRegExpLike } from "../../../shared/utils/capability-probes.js";
 
 const JSDOC_REPLACEMENTS = {
     "@func": "@function",
@@ -403,11 +404,14 @@ function looksLikeCommentedOutCode(text, codeDetectionPatterns) {
         : DEFAULT_COMMENTED_OUT_CODE_PATTERNS;
 
     for (const pattern of patterns) {
-        if (!(pattern instanceof RegExp)) {
+        if (!isRegExpLike(pattern)) {
             continue;
         }
 
-        pattern.lastIndex = 0;
+        if (typeof pattern.lastIndex === "number") {
+            pattern.lastIndex = 0;
+        }
+
         if (pattern.test(trimmed)) {
             return true;
         }

--- a/src/plugin/src/identifier-case/local-plan.js
+++ b/src/plugin/src/identifier-case/local-plan.js
@@ -32,6 +32,10 @@ import {
     summarizeFileOccurrences
 } from "./common.js";
 import { planAssetRenames, applyAssetRenames } from "./asset-renames.js";
+import {
+    getIterableSize,
+    isMapLike
+} from "../../../shared/utils/capability-probes.js";
 
 function resolveRelativeFilePath(projectRoot, absoluteFilePath) {
     if (!isNonEmptyString(absoluteFilePath)) {
@@ -1264,7 +1268,10 @@ export async function prepareIdentifierCasePlan(options) {
         relativeFilePath,
         operationCount: operations.length,
         conflictCount: conflicts.length,
-        renameEntries: renameMap.size
+        renameEntries:
+            typeof renameMap.size === "number"
+                ? renameMap.size
+                : getIterableSize(renameMap)
     });
 
     if (options.__identifierCaseRenamePlan) {
@@ -1278,7 +1285,7 @@ export function getIdentifierCaseRenameForNode(node, options) {
     }
 
     const renameMap = options.__identifierCaseRenameMap;
-    if (!(renameMap instanceof Map)) {
+    if (!isMapLike(renameMap)) {
         return null;
     }
 

--- a/src/plugin/src/options/line-comment-options.js
+++ b/src/plugin/src/options/line-comment-options.js
@@ -6,6 +6,7 @@ import {
     coercePositiveIntegerOption,
     normalizeStringList
 } from "./option-utils.js";
+import { isRegExpLike } from "../../../shared/utils/capability-probes.js";
 
 const DEFAULT_LINE_COMMENT_BANNER_MIN_SLASHES = 5;
 const DEFAULT_LINE_COMMENT_BANNER_AUTOFILL_THRESHOLD = 4;
@@ -225,7 +226,7 @@ function mergeCodeDetectionPatterns(
 
     if (Array.isArray(rawValue)) {
         entries = rawValue;
-    } else if (rawValue instanceof RegExp) {
+    } else if (isRegExpLike(rawValue)) {
         entries = [rawValue];
     } else if (allowStringLists) {
         entries = normalizeStringList(rawValue, { allowInvalidType: true });
@@ -237,12 +238,15 @@ function mergeCodeDetectionPatterns(
 
     return mergeUniqueValues(DEFAULT_COMMENTED_OUT_CODE_PATTERNS, entries, {
         coerce: coerceRegExp,
-        getKey: (pattern) => pattern.toString()
+        getKey: (pattern) =>
+            typeof pattern?.toString === "function"
+                ? pattern.toString()
+                : String(pattern)
     });
 }
 
 function coerceRegExp(value) {
-    if (value instanceof RegExp) {
+    if (isRegExpLike(value)) {
         return value;
     }
 
@@ -277,7 +281,7 @@ function hasCodeDetectionOverride(value) {
         return value.length > 0;
     }
 
-    if (value instanceof RegExp) {
+    if (isRegExpLike(value)) {
         return true;
     }
 

--- a/src/plugin/src/project-index/gml-parser-facade.js
+++ b/src/plugin/src/project-index/gml-parser-facade.js
@@ -1,7 +1,8 @@
 import path from "node:path";
 
-import GMLParser, { GameMakerSyntaxError } from "../../../parser/gml-parser.js";
+import GMLParser from "../../../parser/gml-parser.js";
 import { getNonEmptyString } from "../../../shared/string-utils.js";
+import { isSyntaxErrorWithLocation } from "../../../shared/utils/capability-probes.js";
 
 function parseProjectIndexSource(sourceText, context = {}) {
     try {
@@ -21,7 +22,7 @@ export function getDefaultProjectIndexParser() {
 }
 
 function enrichSyntaxError(error, sourceText, context) {
-    if (!(error instanceof GameMakerSyntaxError)) {
+    if (!isSyntaxErrorWithLocation(error)) {
         return error;
     }
 

--- a/src/shared/tests/capability-probes.test.js
+++ b/src/shared/tests/capability-probes.test.js
@@ -8,7 +8,8 @@ import {
     isErrorLike,
     isMapLike,
     isRegExpLike,
-    isSetLike
+    isSetLike,
+    isSyntaxErrorWithLocation
 } from "../utils/capability-probes.js";
 
 describe("capability probes", () => {
@@ -93,5 +94,27 @@ describe("capability probes", () => {
         };
 
         assert.equal(getIterableSize(iterable), 2);
+    });
+
+    it("identifies syntax errors with location metadata", () => {
+        const syntaxErrorLike = {
+            message: "boom",
+            line: 4,
+            column: 2,
+            rule: "expression",
+            wrongSymbol: "token",
+            offendingText: "x"
+        };
+
+        assert.equal(isSyntaxErrorWithLocation(syntaxErrorLike), true);
+        assert.equal(
+            isSyntaxErrorWithLocation({ message: "boom", line: "3" }),
+            true
+        );
+        assert.equal(
+            isSyntaxErrorWithLocation({ message: "boom", line: 4, rule: 5 }),
+            false
+        );
+        assert.equal(isSyntaxErrorWithLocation({ message: "boom" }), false);
     });
 });

--- a/src/shared/tests/capability-probes.test.js
+++ b/src/shared/tests/capability-probes.test.js
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    getIterableSize,
+    hasIterableItems,
+    isAggregateErrorLike,
+    isErrorLike,
+    isMapLike,
+    isRegExpLike,
+    isSetLike
+} from "../utils/capability-probes.js";
+
+describe("capability probes", () => {
+    it("detects error-like values", () => {
+        assert.equal(isErrorLike(new Error("boom")), true);
+        assert.equal(isErrorLike({ message: "boom", name: "Custom" }), true);
+        assert.equal(isErrorLike({ message: 42 }), false);
+        assert.equal(
+            isAggregateErrorLike(new AggregateError([], "boom")),
+            true
+        );
+        assert.equal(
+            isAggregateErrorLike({ message: "boom", errors: [new Error("x")] }),
+            true
+        );
+        assert.equal(isAggregateErrorLike({ message: "boom" }), false);
+    });
+
+    it("identifies regexp-like inputs", () => {
+        assert.equal(isRegExpLike(/abc/), true);
+        const regExpLike = {
+            exec: () => null,
+            test: () => true
+        };
+        assert.equal(isRegExpLike(regExpLike), true);
+        assert.equal(isRegExpLike({ test: () => true }), false);
+    });
+
+    it("guards map-like collaborators", () => {
+        const base = new Map([["key", 1]]);
+        const mapLike = {
+            get(key) {
+                return base.get(key);
+            },
+            set(key, value) {
+                base.set(key, value);
+                return this;
+            },
+            has(key) {
+                return base.has(key);
+            },
+            [Symbol.iterator]() {
+                return base[Symbol.iterator]();
+            }
+        };
+
+        assert.equal(isMapLike(base), true);
+        assert.equal(isMapLike(mapLike), true);
+        assert.equal(hasIterableItems(mapLike), true);
+        assert.equal(hasIterableItems(new Map()), false);
+        assert.equal(getIterableSize(mapLike), 1);
+    });
+
+    it("guards set-like collaborators", () => {
+        const base = new Set(["value"]);
+        const setLike = {
+            add(value) {
+                base.add(value);
+                return this;
+            },
+            has(value) {
+                return base.has(value);
+            },
+            [Symbol.iterator]() {
+                return base[Symbol.iterator]();
+            }
+        };
+
+        assert.equal(isSetLike(base), true);
+        assert.equal(isSetLike(setLike), true);
+        assert.equal(hasIterableItems(setLike), true);
+        assert.equal(hasIterableItems(new Set()), false);
+        assert.equal(getIterableSize(setLike), 1);
+    });
+
+    it("counts iterables without explicit size", () => {
+        const iterable = {
+            *[Symbol.iterator]() {
+                yield "a";
+                yield "b";
+            }
+        };
+
+        assert.equal(getIterableSize(iterable), 2);
+    });
+});

--- a/src/shared/utils/capability-probes.js
+++ b/src/shared/utils/capability-probes.js
@@ -148,3 +148,36 @@ export function getIterableSize(iterable) {
 
     return count;
 }
+
+export function isSyntaxErrorWithLocation(value) {
+    if (!isErrorLike(value)) {
+        return false;
+    }
+
+    const hasFiniteLine = Number.isFinite(Number(value.line));
+    const hasFiniteColumn = Number.isFinite(Number(value.column));
+
+    if (!hasFiniteLine && !hasFiniteColumn) {
+        return false;
+    }
+
+    if (value.rule != undefined && typeof value.rule !== "string") {
+        return false;
+    }
+
+    if (
+        value.wrongSymbol != undefined &&
+        typeof value.wrongSymbol !== "string"
+    ) {
+        return false;
+    }
+
+    if (
+        value.offendingText != undefined &&
+        typeof value.offendingText !== "string"
+    ) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/shared/utils/capability-probes.js
+++ b/src/shared/utils/capability-probes.js
@@ -1,0 +1,150 @@
+import { isObjectLike } from "./object.js";
+
+function hasFunction(value, property) {
+    return typeof value?.[property] === "function";
+}
+
+function getIteratorFactory(value) {
+    if (typeof value?.[Symbol.iterator] === "function") {
+        return () => value[Symbol.iterator]();
+    }
+
+    if (hasFunction(value, "entries")) {
+        return () => value.entries();
+    }
+
+    if (hasFunction(value, "values")) {
+        return () => value.values();
+    }
+
+    return null;
+}
+
+export function isErrorLike(value) {
+    if (!isObjectLike(value)) {
+        return false;
+    }
+
+    if (typeof value.message !== "string") {
+        return false;
+    }
+
+    if (value.name != undefined && typeof value.name !== "string") {
+        return false;
+    }
+
+    return true;
+}
+
+export function isAggregateErrorLike(value) {
+    return isErrorLike(value) && Array.isArray(value.errors);
+}
+
+export function isRegExpLike(value) {
+    if (!isObjectLike(value)) {
+        return false;
+    }
+
+    return hasFunction(value, "test") && hasFunction(value, "exec");
+}
+
+export function isMapLike(value) {
+    if (!isObjectLike(value)) {
+        return false;
+    }
+
+    if (!hasFunction(value, "get") || !hasFunction(value, "set")) {
+        return false;
+    }
+
+    if (!hasFunction(value, "has")) {
+        return false;
+    }
+
+    return Boolean(getIteratorFactory(value));
+}
+
+export function isSetLike(value) {
+    if (!isObjectLike(value)) {
+        return false;
+    }
+
+    if (!hasFunction(value, "has") || !hasFunction(value, "add")) {
+        return false;
+    }
+
+    return Boolean(getIteratorFactory(value));
+}
+
+export function hasIterableItems(iterable) {
+    if (!iterable) {
+        return false;
+    }
+
+    if (typeof iterable.size === "number" && Number.isFinite(iterable.size)) {
+        return iterable.size > 0;
+    }
+
+    if (
+        typeof iterable.length === "number" &&
+        Number.isFinite(iterable.length)
+    ) {
+        return iterable.length > 0;
+    }
+
+    const iteratorFactory = getIteratorFactory(iterable);
+    if (!iteratorFactory) {
+        return false;
+    }
+
+    const iterator = iteratorFactory();
+    if (!iterator || typeof iterator.next !== "function") {
+        return false;
+    }
+
+    const { done } = iterator.next();
+
+    if (typeof iterator.return === "function") {
+        try {
+            iterator.return();
+        } catch {
+            // Ignore iterator close errors.
+        }
+    }
+
+    return done === false;
+}
+
+export function getIterableSize(iterable) {
+    if (typeof iterable.size === "number" && Number.isFinite(iterable.size)) {
+        return iterable.size;
+    }
+
+    if (
+        typeof iterable.length === "number" &&
+        Number.isFinite(iterable.length)
+    ) {
+        return iterable.length;
+    }
+
+    const iteratorFactory = getIteratorFactory(iterable);
+    if (!iteratorFactory) {
+        return 0;
+    }
+
+    const iterator = iteratorFactory();
+    if (!iterator || typeof iterator.next !== "function") {
+        return 0;
+    }
+
+    let count = 0;
+    while (true) {
+        const { done } = iterator.next();
+        if (done) {
+            break;
+        }
+        count += 1;
+    }
+
+    return count;
+}

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -1,4 +1,5 @@
 export * from "./array.js";
+export * from "./capability-probes.js";
 export * from "./json.js";
 export * from "./line-breaks.js";
 export * from "./number.js";

--- a/src/shared/utils/json.js
+++ b/src/shared/utils/json.js
@@ -1,4 +1,5 @@
 import { isNonEmptyString, toTrimmedString } from "./string.js";
+import { isErrorLike } from "./capability-probes.js";
 
 function getErrorMessage(value) {
     if (typeof value === "string") {
@@ -21,7 +22,7 @@ function getErrorMessage(value) {
 }
 
 function toError(value) {
-    if (value instanceof Error) {
+    if (isErrorLike(value)) {
         return value;
     }
 


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
