### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/cli/lib/command-parsing.js
+++ b/src/cli/lib/command-parsing.js
@@ -1,11 +1,9 @@
 import { CliUsageError } from "./cli-errors.js";
-import { isErrorLike } from "../../shared/utils/capability-probes.js";
+import { isCommanderErrorLike } from "../../shared/utils/capability-probes.js";
 
 function isCommanderError(error) {
     return (
-        isErrorLike(error) &&
-        error.name === "CommanderError" &&
-        typeof error.code === "string"
+        isCommanderErrorLike(error) && error.code !== "commander.helpDisplayed"
     );
 }
 

--- a/src/cli/tests/cli-errors.test.js
+++ b/src/cli/tests/cli-errors.test.js
@@ -4,12 +4,30 @@ import { describe, it, mock } from "node:test";
 import {
     CliUsageError,
     formatCliError,
-    handleCliError
+    handleCliError,
+    markAsCliUsageError
 } from "../lib/cli-errors.js";
 
 describe("cli error formatting", () => {
     it("omits stack traces and prefixes for usage errors", () => {
         const error = new CliUsageError("Missing project path");
+
+        const output = formatCliError(error);
+
+        assert.equal(output, "Missing project path");
+    });
+
+    it("recognizes branded usage errors even if renamed", () => {
+        const error = new CliUsageError("Missing project path");
+        error.name = "OtherCliError";
+
+        const output = formatCliError(error);
+
+        assert.equal(output, "Missing project path");
+    });
+
+    it("brands external error-like values", () => {
+        const error = markAsCliUsageError({ message: "Missing project path" });
 
         const output = formatCliError(error);
 

--- a/src/shared/tests/capability-probes.test.js
+++ b/src/shared/tests/capability-probes.test.js
@@ -5,6 +5,7 @@ import {
     getIterableSize,
     hasIterableItems,
     isAggregateErrorLike,
+    isCommanderErrorLike,
     isErrorLike,
     isMapLike,
     isRegExpLike,
@@ -35,6 +36,36 @@ describe("capability probes", () => {
         };
         assert.equal(isRegExpLike(regExpLike), true);
         assert.equal(isRegExpLike({ test: () => true }), false);
+    });
+
+    it("recognizes commander-style errors by capability", () => {
+        const error = new Error("bad option");
+        error.code = "commander.invalidOption";
+        error.exitCode = 2;
+
+        assert.equal(isCommanderErrorLike(error), true);
+        assert.equal(
+            isCommanderErrorLike({
+                message: "bad option",
+                code: "commander.invalidOption"
+            }),
+            true
+        );
+        assert.equal(
+            isCommanderErrorLike({
+                message: "bad option",
+                code: "ERR_GENERIC"
+            }),
+            false
+        );
+        assert.equal(
+            isCommanderErrorLike({
+                message: "bad option",
+                code: "commander.invalidOption",
+                exitCode: "2"
+            }),
+            false
+        );
     });
 
     it("guards map-like collaborators", () => {
@@ -94,5 +125,4 @@ describe("capability probes", () => {
 
         assert.equal(getIterableSize(iterable), 2);
     });
-
 });

--- a/src/shared/utils/capability-probes.js
+++ b/src/shared/utils/capability-probes.js
@@ -68,6 +68,25 @@ export function isAggregateErrorLike(value) {
     return isErrorLike(value) && Array.isArray(value.errors);
 }
 
+const COMMANDER_ERROR_CODE_PREFIX = "commander.";
+
+export function isCommanderErrorLike(value) {
+    if (!isErrorLike(value)) {
+        return false;
+    }
+
+    const code = typeof value.code === "string" ? value.code : null;
+    if (!code || !code.startsWith(COMMANDER_ERROR_CODE_PREFIX)) {
+        return false;
+    }
+
+    if ("exitCode" in value && typeof value.exitCode !== "number") {
+        return false;
+    }
+
+    return true;
+}
+
 export function isRegExpLike(value) {
     if (!isObjectLike(value)) {
         return false;
@@ -166,4 +185,3 @@ export function getIterableSize(iterable) {
 
     return count;
 }
-


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
