### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/parser/src/gml-ast-builder.js
+++ b/src/parser/src/gml-ast-builder.js
@@ -2,6 +2,7 @@ import GameMakerLanguageParserVisitor from "./generated/GameMakerLanguageParserV
 import { getLineBreakCount } from "../../shared/utils/line-breaks.js";
 import { getNonEmptyTrimmedString } from "../../shared/utils.js";
 import ScopeTracker from "./scope-tracker.js";
+import { ScopeOverrideKeyword } from "./scope-override-keywords.js";
 import BinaryExpressionDelegate from "./binary-expression-delegate.js";
 import {
     IdentifierRoleTracker,
@@ -568,7 +569,7 @@ export default class GameMakerASTBuilder extends GameMakerLanguageParserVisitor 
                         type: "declaration",
                         kind: "variable",
                         tags: ["global"],
-                        scopeOverride: "global"
+                        scopeOverride: ScopeOverrideKeyword.GLOBAL
                     },
                     () => this.visit(identifierCtx)
                 );
@@ -1283,7 +1284,7 @@ export default class GameMakerASTBuilder extends GameMakerLanguageParserVisitor 
                 type: "declaration",
                 kind: "macro",
                 tags: ["global"],
-                scopeOverride: "global"
+                scopeOverride: ScopeOverrideKeyword.GLOBAL
             },
             () => this.visit(ctx.identifier())
         );

--- a/src/parser/src/scope-override-keywords.js
+++ b/src/parser/src/scope-override-keywords.js
@@ -1,0 +1,17 @@
+const ScopeOverrideKeyword = Object.freeze({
+    GLOBAL: "global"
+});
+
+const SCOPE_OVERRIDE_KEYWORD_SET = new Set(
+    Object.values(ScopeOverrideKeyword)
+);
+
+export function isScopeOverrideKeyword(value) {
+    return typeof value === "string" && SCOPE_OVERRIDE_KEYWORD_SET.has(value);
+}
+
+export function formatKnownScopeOverrideKeywords() {
+    return [...SCOPE_OVERRIDE_KEYWORD_SET].join(", ");
+}
+
+export { ScopeOverrideKeyword };

--- a/src/parser/src/scope-tracker.js
+++ b/src/parser/src/scope-tracker.js
@@ -1,5 +1,10 @@
 import { cloneLocation } from "../../shared/ast.js";
 import { isObjectLike, toArray } from "../../shared/utils.js";
+import {
+    ScopeOverrideKeyword,
+    formatKnownScopeOverrideKeywords,
+    isScopeOverrideKeyword
+} from "./scope-override-keywords.js";
 
 class Scope {
     constructor(id, kind) {
@@ -68,10 +73,6 @@ export default class ScopeTracker {
             return currentScope;
         }
 
-        if (scopeOverride === "global") {
-            return this.rootScope ?? currentScope;
-        }
-
         if (
             isObjectLike(scopeOverride) &&
             typeof scopeOverride.id === "string"
@@ -80,12 +81,24 @@ export default class ScopeTracker {
         }
 
         if (typeof scopeOverride === "string") {
+            if (isScopeOverrideKeyword(scopeOverride)) {
+                if (scopeOverride === ScopeOverrideKeyword.GLOBAL) {
+                    return this.rootScope ?? currentScope;
+                }
+                return currentScope;
+            }
+
             const found = this.scopeStack.find(
                 (scope) => scope.id === scopeOverride
             );
             if (found) {
                 return found;
             }
+
+            const keywords = formatKnownScopeOverrideKeywords();
+            throw new RangeError(
+                `Unknown scope override string '${scopeOverride}'. Expected one of: ${keywords}, or a known scope identifier.`
+            );
         }
 
         return currentScope;

--- a/src/parser/tests/scope-tracker.test.js
+++ b/src/parser/tests/scope-tracker.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import ScopeTracker from "../src/scope-tracker.js";
+import { ScopeOverrideKeyword } from "../src/scope-override-keywords.js";
+
+test("resolveScopeOverride returns the root scope when using the global keyword", () => {
+    const tracker = new ScopeTracker({ enabled: true });
+    const rootScope = tracker.enterScope("root");
+    tracker.enterScope("child");
+
+    const result = tracker.resolveScopeOverride(ScopeOverrideKeyword.GLOBAL);
+
+    assert.strictEqual(result, rootScope);
+});
+
+test("resolveScopeOverride returns a scope that matches an explicit identifier", () => {
+    const tracker = new ScopeTracker({ enabled: true });
+    tracker.enterScope("root");
+    const explicitScope = tracker.enterScope("explicit");
+
+    const result = tracker.resolveScopeOverride(explicitScope.id);
+
+    assert.strictEqual(result, explicitScope);
+});
+
+test("resolveScopeOverride throws when given an unknown string keyword", () => {
+    const tracker = new ScopeTracker({ enabled: true });
+    tracker.enterScope("root");
+
+    assert.throws(
+        () => tracker.resolveScopeOverride("GLOBAL"),
+        (error) => {
+            assert.ok(error instanceof RangeError);
+            assert.match(
+                error.message,
+                /Unknown scope override string 'GLOBAL'.*scope identifier\./
+            );
+            return true;
+        }
+    );
+});


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
