### PR TITLE
Refactor CLI into centralized command manager

### DIFF
--- a/src/cli/commands/bench-get-identifier-text.js
+++ b/src/cli/commands/bench-get-identifier-text.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
-import { runPerformanceCli } from "../lib/performance-cli.js";
+import {
+    createPerformanceCommand,
+    runPerformanceCommand
+} from "../lib/performance-cli.js";
 
-const exitCode = await runPerformanceCli({
-    argv: ["--suite", "identifier-text"]
-});
+const command = createPerformanceCommand();
+command.parse(["--suite", "identifier-text"], { from: "user" });
+
+const exitCode = await runPerformanceCommand({ command });
 if (typeof exitCode === "number") {
     process.exitCode = exitCode;
 }

--- a/src/cli/commands/command-parsing.js
+++ b/src/cli/commands/command-parsing.js
@@ -1,0 +1,1 @@
+export * from "../lib/command-parsing.js";

--- a/src/cli/commands/generate-gml-identifiers.js
+++ b/src/cli/commands/generate-gml-identifiers.js
@@ -5,7 +5,7 @@ import vm from "node:vm";
 
 import { Command, InvalidArgumentError } from "commander";
 
-import { handleCliError } from "../lib/cli-errors.js";
+import { CliUsageError } from "../lib/cli-errors.js";
 import { assertSupportedNodeVersion } from "../lib/node-version.js";
 import { toNormalizedLowerCaseSet, toPosixPath } from "../../shared/utils.js";
 import { ensureDir } from "../lib/file-system.js";
@@ -27,7 +27,6 @@ import {
     resolveVmEvalTimeout,
     getDefaultVmEvalTimeoutMs
 } from "../lib/vm-eval-timeout.js";
-import { parseCommandLine } from "./command-parsing.js";
 import {
     applyManualEnvOptionOverrides,
     IDENTIFIER_VM_TIMEOUT_ENV_VAR
@@ -54,7 +53,7 @@ const manualClient = createManualGitHubClient({
 
 const { fetchManualFile, resolveManualRef } = manualClient;
 
-function createGenerateIdentifiersCommand() {
+export function createGenerateIdentifiersCommand({ env = process.env } = {}) {
     const command = applyStandardCommandOptions(
         new Command()
             .name("generate-gml-identifiers")
@@ -121,16 +120,6 @@ function createGenerateIdentifiersCommand() {
             DEFAULT_CACHE_ROOT
         );
 
-    return command;
-}
-
-function parseArgs({
-    argv = process.argv.slice(2),
-    env = process.env,
-    isTty = process.stdout.isTTY === true
-} = {}) {
-    const command = createGenerateIdentifiersCommand();
-
     applyManualEnvOptionOverrides({
         command,
         env,
@@ -143,22 +132,19 @@ function parseArgs({
         ]
     });
 
+    return command;
+}
+
+function resolveGenerateIdentifierOptions(command) {
+    const options = command.opts();
+    const isTty = process.stdout.isTTY === true;
+
     const verbose = {
         resolveRef: true,
         downloads: true,
         parsing: true,
         progressBar: isTty
     };
-
-    const { helpRequested, usage } = parseCommandLine(command, argv);
-    if (helpRequested) {
-        return {
-            helpRequested: true,
-            usage
-        };
-    }
-
-    const options = command.opts();
 
     if (options.quiet) {
         verbose.resolveRef = false;
@@ -180,8 +166,7 @@ function parseArgs({
             options.progressBarWidth ?? getDefaultProgressBarWidth(),
         cacheRoot: options.cacheRoot ?? DEFAULT_CACHE_ROOT,
         manualRepo: options.manualRepo ?? DEFAULT_MANUAL_REPO,
-        helpRequested: false,
-        usage
+        usage: command.helpInformation()
     };
 }
 
@@ -289,8 +274,7 @@ function classifyFromPath(manualPath, tagList) {
         segments.some((segment) => segment.includes(needle));
     const tagMatches = (needle) => normalizedTags.has(needle);
 
-    const matchesAny = (needles = [], matcher) =>
-        needles.length > 0 && needles.some(matcher);
+    const matchesAny = (needles = [], matcher) => needles.some(matcher);
     const matchesAllGroups = (groups = []) =>
         groups.length > 0 &&
         groups.every((needles) => matchesAny(needles, segmentMatches));
@@ -374,7 +358,7 @@ function normaliseIdentifier(name) {
     return name.trim();
 }
 
-async function main({ argv, env, isTty } = {}) {
+export async function runGenerateGmlIdentifiers({ command } = {}) {
     try {
         assertSupportedNodeVersion();
 
@@ -387,19 +371,17 @@ async function main({ argv, env, isTty } = {}) {
             progressBarWidth,
             cacheRoot,
             manualRepo,
-            helpRequested
-        } = parseArgs({ argv, env, isTty });
+            usage
+        } = resolveGenerateIdentifierOptions(command);
 
-        if (helpRequested) {
-            return 0;
-        }
         const { apiRoot, rawRoot } = buildManualRepositoryEndpoints(manualRepo);
         const logCompletion = createVerboseDurationLogger({ verbose });
 
         const manualRef = await resolveManualRef(ref, { verbose, apiRoot });
         if (!manualRef.sha) {
-            throw new Error(
-                `Unable to resolve manual commit SHA for ref '${manualRef.ref}'.`
+            throw new CliUsageError(
+                `Unable to resolve manual commit SHA for ref '${manualRef.ref}'.`,
+                { usage }
             );
         }
 
@@ -643,20 +625,5 @@ async function main({ argv, env, isTty } = {}) {
         return 0;
     } finally {
         disposeProgressBars();
-    }
-}
-
-export async function runGenerateGmlIdentifiersCli({
-    argv = process.argv.slice(2),
-    env = process.env,
-    isTty = process.stdout.isTTY === true
-} = {}) {
-    try {
-        return await main({ argv, env, isTty });
-    } catch (error) {
-        handleCliError(error, {
-            prefix: "Failed to generate GML identifiers."
-        });
-        return 1;
     }
 }

--- a/src/cli/lib/cli-command-manager.js
+++ b/src/cli/lib/cli-command-manager.js
@@ -1,0 +1,163 @@
+import { CliUsageError, handleCliError } from "./cli-errors.js";
+import { isCommanderErrorLike } from "./commander-error-utils.js";
+
+class CliCommandManager {
+    /**
+     * @param {{
+     *   program: import("commander").Command,
+     *   onUnhandledError?: (error: unknown, context: { command: import("commander").Command }) => void
+     * }} options
+     */
+    constructor({ program, onUnhandledError } = {}) {
+        if (!program || typeof program.parseAsync !== "function") {
+            throw new TypeError(
+                "CliCommandManager requires a Commander program instance."
+            );
+        }
+
+        this._program = program;
+        this._entries = new Set();
+        this._commandEntryLookup = new WeakMap();
+        this._defaultErrorHandler =
+            typeof onUnhandledError === "function"
+                ? onUnhandledError
+                : (error) =>
+                      handleCliError(error, {
+                          prefix: "Failed to run CLI command.",
+                          exitCode: 1
+                      });
+
+        this._registerEntry(program, {
+            handleError: this._defaultErrorHandler
+        });
+    }
+
+    /**
+     * Register the default command used when no subcommand is provided.
+     *
+     * @param {{
+     *   command: import("commander").Command,
+     *   run: (context: { command: import("commander").Command }) =>
+     *       Promise<number | void> | number | void,
+     *   onError?: (error: unknown, context: { command: import("commander").Command }) => void
+     * }} options
+     */
+    registerDefaultCommand({ command, run, onError } = {}) {
+        const entry = this._registerEntry(command, {
+            run,
+            handleError: onError
+        });
+        this._program.addCommand(command, { isDefault: true });
+        return entry;
+    }
+
+    /**
+     * Register an additional subcommand with the CLI.
+     *
+     * @param {{
+     *   command: import("commander").Command,
+     *   run: (context: { command: import("commander").Command }) =>
+     *       Promise<number | void> | number | void,
+     *   onError?: (error: unknown, context: { command: import("commander").Command }) => void
+     * }} options
+     */
+    registerCommand({ command, run, onError } = {}) {
+        const entry = this._registerEntry(command, {
+            run,
+            handleError: onError
+        });
+        this._program.addCommand(command);
+        return entry;
+    }
+
+    /**
+     * Execute the registered CLI program with the provided argv.
+     *
+     * @param {Array<string>} argv
+     */
+    async run(argv) {
+        try {
+            await this._program.parseAsync(argv, { from: "user" });
+        } catch (error) {
+            if (this._handleCommanderError(error)) {
+                return;
+            }
+            throw error;
+        }
+    }
+
+    _registerEntry(command, { run, handleError } = {}) {
+        if (!command || typeof command.name !== "function") {
+            throw new TypeError(
+                "registerCommand expects a Commander Command instance."
+            );
+        }
+        if (run && typeof run !== "function") {
+            throw new TypeError("Command run handlers must be functions.");
+        }
+
+        const entry = {
+            command,
+            run: run ?? null,
+            handleError:
+                typeof handleError === "function"
+                    ? handleError
+                    : this._defaultErrorHandler
+        };
+
+        this._entries.add(entry);
+        this._commandEntryLookup.set(command, entry);
+
+        if (entry.run) {
+            command.action(async (...actionArgs) => {
+                const invokedCommand = actionArgs.at(-1);
+                const contextCommand =
+                    invokedCommand &&
+                    typeof invokedCommand.helpInformation === "function"
+                        ? invokedCommand
+                        : command;
+                try {
+                    const result = await entry.run({ command: contextCommand });
+                    if (typeof result === "number") {
+                        process.exitCode = result;
+                    }
+                } catch (error) {
+                    this._handleCommandError(error, contextCommand);
+                }
+            });
+        }
+
+        return entry;
+    }
+
+    _handleCommanderError(error) {
+        if (!isCommanderErrorLike(error)) {
+            return false;
+        }
+
+        if (error.code === "commander.helpDisplayed") {
+            return true;
+        }
+
+        const command = error.command ?? this._program;
+        const usage =
+            typeof command?.helpInformation === "function"
+                ? command.helpInformation()
+                : this._program.helpInformation();
+        const usageError = new CliUsageError(error.message.trim(), { usage });
+        this._handleCommandError(usageError, command);
+        return true;
+    }
+
+    _handleCommandError(error, command) {
+        const entry = this._commandEntryLookup.get(command);
+        const handler = entry?.handleError ?? this._defaultErrorHandler;
+        handler(error, { command });
+    }
+}
+
+export { CliCommandManager };
+
+export function createCliCommandManager(options) {
+    return new CliCommandManager(options);
+}

--- a/src/cli/lib/memory-cli.js
+++ b/src/cli/lib/memory-cli.js
@@ -4,8 +4,8 @@ import { Command, InvalidArgumentError } from "commander";
 
 import { normalizeStringList } from "../../shared/utils/string.js";
 import { applyStandardCommandOptions } from "./command-standard-options.js";
-import { parseCommandLine, coercePositiveInteger } from "./command-parsing.js";
-import { CliUsageError, handleCliError } from "./cli-errors.js";
+import { coercePositiveInteger } from "./command-parsing.js";
+import { CliUsageError } from "./cli-errors.js";
 
 const DEFAULT_ITERATIONS = 500_000;
 
@@ -56,7 +56,7 @@ function resolveRequestedSuites(options) {
     return requested.map((name) => name.toLowerCase());
 }
 
-function createMemoryCommand() {
+export function createMemoryCommand() {
     return applyStandardCommandOptions(
         new Command()
             .name("memory")
@@ -82,11 +82,6 @@ function createMemoryCommand() {
             "json"
         )
         .option("--pretty", "Pretty-print JSON output.");
-}
-
-function helpWasRequested(command, argv) {
-    const { helpRequested } = parseCommandLine(command, argv);
-    return helpRequested;
 }
 
 function collectSuiteOptions(options) {
@@ -216,14 +211,8 @@ function emitSuiteResults(results, options) {
     printHumanReadable(results);
 }
 
-async function main(argv = process.argv.slice(2)) {
-    const command = createMemoryCommand();
-
-    if (helpWasRequested(command, argv)) {
-        return 0;
-    }
-
-    const options = command.opts();
+export async function runMemoryCommand({ command } = {}) {
+    const options = command?.opts?.() ?? {};
 
     const requestedSuites = resolveRequestedSuites(options);
     ensureSuitesAreKnown(requestedSuites, command);
@@ -236,17 +225,6 @@ async function main(argv = process.argv.slice(2)) {
     emitSuiteResults(suiteResults, options);
 
     return 0;
-}
-
-export async function runMemoryCli({ argv = process.argv.slice(2) } = {}) {
-    try {
-        return await main(argv);
-    } catch (error) {
-        handleCliError(error, {
-            prefix: "Failed to run memory diagnostics."
-        });
-        return 1;
-    }
 }
 
 export { DEFAULT_ITERATIONS };

--- a/src/cli/lib/performance-cli.js
+++ b/src/cli/lib/performance-cli.js
@@ -4,8 +4,7 @@ import process from "node:process";
 
 import { Command, InvalidArgumentError } from "commander";
 
-import { CliUsageError, handleCliError } from "./cli-errors.js";
-import { parseCommandLine } from "./command-parsing.js";
+import { CliUsageError } from "./cli-errors.js";
 import { applyStandardCommandOptions } from "./command-standard-options.js";
 import {
     resolveCliProjectIndexBuilder,
@@ -336,7 +335,7 @@ AVAILABLE_SUITES.set("identifier-pipeline", runIdentifierPipelineBenchmark);
 AVAILABLE_SUITES.set("identifier-text", () => runIdentifierTextBenchmark());
 AVAILABLE_SUITES.set("project-index-memory", runProjectIndexMemoryMeasurement);
 
-function createPerformanceCommand() {
+export function createPerformanceCommand() {
     return applyStandardCommandOptions(
         new Command()
             .name("performance")
@@ -411,11 +410,6 @@ function printHumanReadable(results) {
  * @param {Array<string>} argv
  * @returns {boolean}
  */
-function helpWasRequested(command, argv) {
-    const { helpRequested } = parseCommandLine(command, argv);
-    return helpRequested;
-}
-
 /**
  * Normalize the requested benchmark suite names.
  *
@@ -468,14 +462,8 @@ function emitSuiteResults(results, options) {
     printHumanReadable(results);
 }
 
-async function main(argv = process.argv.slice(2)) {
-    const command = createPerformanceCommand();
-
-    if (helpWasRequested(command, argv)) {
-        return 0;
-    }
-
-    const options = command.opts();
+export async function runPerformanceCommand({ command } = {}) {
+    const options = command?.opts?.() ?? {};
 
     const requestedSuites = resolveRequestedSuites(options);
     ensureSuitesAreKnown(requestedSuites, command);
@@ -488,15 +476,4 @@ async function main(argv = process.argv.slice(2)) {
     emitSuiteResults(suiteResults, options);
 
     return 0;
-}
-
-export async function runPerformanceCli({ argv = process.argv.slice(2) } = {}) {
-    try {
-        return await main(argv);
-    } catch (error) {
-        handleCliError(error, {
-            prefix: "Failed to run performance benchmarks."
-        });
-        return 1;
-    }
 }

--- a/src/cli/tests/prettier-wrapper.test.js
+++ b/src/cli/tests/prettier-wrapper.test.js
@@ -700,7 +700,7 @@ describe("Prettier wrapper CLI", () => {
                     "Expected stderr to mention the inaccessible target"
                 );
                 assert.ok(
-                    /Usage: prettier-wrapper/.test(error.stderr),
+                    /Usage: prettier-plugin-gml/.test(error.stderr),
                     "Expected stderr to include the CLI usage information"
                 );
             }


### PR DESCRIPTION
## Summary
- convert the CLI entry point into a Commander program that registers the formatter as the default command alongside performance, memory, and manual data generators
- replace the command manager with a dispatcher that wires command actions, error handling, and usage conversion for Commander subcommands
- update delegated command modules and helper scripts to expose command handlers that operate on parsed Commander instances

## Testing
- npm --prefix src/cli test

------
https://chatgpt.com/codex/tasks/task_e_68f3a66da1f8832f89eaa2f8e2880874