### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -29,3 +29,13 @@ To re-validate the earlier conclusion, I reran a broader set of surveys:
 
 No new interface or type definition surfaced that violates the Interface Segregation Principle, so
 no code changes were required.
+
+## Follow-up audit (2025-02-17)
+
+- Surveyed CLI infrastructure for broad contracts and found `CliCommandManager`
+  coupled registration helpers with the command runner behind a single
+  "manager" API. That forced the CLI entry point to depend on both
+  responsibilities simultaneously.
+- Split the contract into `CliCommandRegistrar` and `CliProgramRunner`
+  interfaces that expose only the registration or execution concerns used by
+  each call site, then updated `cli.js` to rely on the specialized views.

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -247,14 +247,15 @@ const program = applyStandardCommandOptions(new Command())
         ].join(" \n")
     );
 
-const cliCommandManager = createCliCommandManager({
-    program,
-    onUnhandledError: (error) =>
-        handleCliError(error, {
-            prefix: "Failed to run prettier-plugin-gml CLI.",
-            exitCode: 1
-        })
-});
+const { registrar: cliCommandRegistrar, runner: cliProgramRunner } =
+    createCliCommandManager({
+        program,
+        onUnhandledError: (error) =>
+            handleCliError(error, {
+                prefix: "Failed to run prettier-plugin-gml CLI.",
+                exitCode: 1
+            })
+    });
 
 function createFormatCommand({ name = "prettier-plugin-gml" } = {}) {
     return applyStandardCommandOptions(
@@ -1058,7 +1059,7 @@ function logNoMatchingFiles({ targetPath, targetIsDirectory, extensions }) {
 
 const formatCommand = createFormatCommand({ name: "format" });
 
-cliCommandManager.registerDefaultCommand({
+cliCommandRegistrar.registerDefaultCommand({
     command: formatCommand,
     run: ({ command }) => executeFormatCommand(command),
     onError: (error) =>
@@ -1068,7 +1069,7 @@ cliCommandManager.registerDefaultCommand({
         })
 });
 
-cliCommandManager.registerCommand({
+cliCommandRegistrar.registerCommand({
     command: createPerformanceCommand(),
     run: ({ command }) => runPerformanceCommand({ command }),
     onError: (error) =>
@@ -1078,7 +1079,7 @@ cliCommandManager.registerCommand({
         })
 });
 
-cliCommandManager.registerCommand({
+cliCommandRegistrar.registerCommand({
     command: createMemoryCommand(),
     run: ({ command }) => runMemoryCommand({ command }),
     onError: (error) =>
@@ -1088,7 +1089,7 @@ cliCommandManager.registerCommand({
         })
 });
 
-cliCommandManager.registerCommand({
+cliCommandRegistrar.registerCommand({
     command: createGenerateIdentifiersCommand({ env: process.env }),
     run: ({ command }) => runGenerateGmlIdentifiers({ command }),
     onError: (error) =>
@@ -1098,7 +1099,7 @@ cliCommandManager.registerCommand({
         })
 });
 
-cliCommandManager.registerCommand({
+cliCommandRegistrar.registerCommand({
     command: createFeatherMetadataCommand({ env: process.env }),
     run: ({ command }) => runGenerateFeatherMetadata({ command }),
     onError: (error) =>
@@ -1108,7 +1109,7 @@ cliCommandManager.registerCommand({
         })
 });
 
-cliCommandManager.run(process.argv.slice(2)).catch((error) => {
+cliProgramRunner.run(process.argv.slice(2)).catch((error) => {
     handleCliError(error, {
         prefix: "Failed to run prettier-plugin-gml CLI.",
         exitCode: 1


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
