### PR TITLE
Codex: POLA Behaviour Audit

### DIFF
--- a/src/plugin/src/project-index/cache.js
+++ b/src/plugin/src/project-index/cache.js
@@ -53,6 +53,19 @@ function resolveCacheFilePath(projectRoot, cacheFilePath) {
     );
 }
 
+function normalizeMaxSizeBytes(maxSizeBytes) {
+    if (maxSizeBytes == null) {
+        return null;
+    }
+
+    const numericLimit = Number(maxSizeBytes);
+    if (!Number.isFinite(numericLimit) || numericLimit <= 0) {
+        return null;
+    }
+
+    return numericLimit;
+}
+
 function cloneMtimeMap(source) {
     if (!source || typeof source !== "object") {
         return {};
@@ -338,7 +351,8 @@ export async function saveProjectIndexCache(
     const serialized = JSON.stringify(payload);
     const byteLength = Buffer.byteLength(serialized, "utf8");
 
-    if (maxSizeBytes != undefined && byteLength > maxSizeBytes) {
+    const effectiveMaxSize = normalizeMaxSizeBytes(maxSizeBytes);
+    if (effectiveMaxSize !== null && byteLength > effectiveMaxSize) {
         return {
             status: "skipped",
             cacheFilePath,

--- a/src/plugin/tests/project-index-cache.test.js
+++ b/src/plugin/tests/project-index-cache.test.js
@@ -138,6 +138,33 @@ test("saveProjectIndexCache respects maxSizeBytes overrides", async () => {
     });
 });
 
+test("saveProjectIndexCache allows unlimited size when maxSizeBytes is 0", async () => {
+    await withTempDir(async (projectRoot) => {
+        const projectIndex = createProjectIndex(projectRoot);
+
+        const saveResult = await saveProjectIndexCache({
+            projectRoot,
+            formatterVersion: "1.0.0",
+            pluginVersion: "0.1.0",
+            manifestMtimes: {},
+            sourceMtimes: {},
+            projectIndex,
+            maxSizeBytes: 0
+        });
+
+        assert.equal(saveResult.status, "written");
+
+        const loadResult = await loadProjectIndexCache({
+            projectRoot,
+            formatterVersion: "1.0.0",
+            pluginVersion: "0.1.0"
+        });
+
+        assert.equal(loadResult.status, "hit");
+        assert.deepEqual(loadResult.projectIndex, projectIndex);
+    });
+});
+
 test("bootstrapProjectIndex normalizes cache max size overrides", async () => {
     await withTempDir(async (projectRoot) => {
         const manifestPath = path.join(projectRoot, "project.yyp");


### PR DESCRIPTION
Seed PR for Codex to reconcile option documentation and inline comments with the behaviours the formatter actually ships.
