### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/shared/tests/abort-utils.test.js
+++ b/src/shared/tests/abort-utils.test.js
@@ -15,6 +15,21 @@ describe("createAbortError", () => {
         assert.strictEqual(createAbortError(signal, "ignored"), reason);
     });
 
+    it("reuses error-like reasons that are not native Error instances", () => {
+        const reason = { name: "AbortError", message: "custom", stack: "trace" };
+        const signal = { aborted: true, reason };
+        assert.strictEqual(createAbortError(signal, "ignored"), reason);
+    });
+
+    it("fills missing metadata on error-like reasons", () => {
+        const reason = { message: "" };
+        const signal = { aborted: true, reason };
+        const error = createAbortError(signal, "fallback message");
+        assert.strictEqual(error, reason);
+        assert.equal(error.name, "AbortError");
+        assert.equal(error.message, "fallback message");
+    });
+
     it("wraps non-error reasons using the fallback message", () => {
         const signal = { aborted: true, reason: "boom" };
         const error = createAbortError(signal, "fallback");


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
