### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/cli/lib/memory-cli.js
+++ b/src/cli/lib/memory-cli.js
@@ -10,6 +10,9 @@ import {
 } from "./command-parsing.js";
 import { applyEnvOptionOverrides } from "./env-overrides.js";
 import {
+    SuiteOutputFormat,
+    formatSuiteOutputFormatList,
+    normalizeSuiteOutputFormat,
     emitSuiteResults as emitSuiteResultsJson,
     ensureSuitesAreKnown,
     resolveRequestedSuites
@@ -100,12 +103,14 @@ function collectSuite(value, previous = []) {
 }
 
 function validateFormat(value) {
-    const normalized = value?.toLowerCase();
-    if (normalized === "json" || normalized === "human") {
+    const normalized = normalizeSuiteOutputFormat(value);
+    if (normalized) {
         return normalized;
     }
 
-    throw new InvalidArgumentError("Format must be either 'json' or 'human'.");
+    throw new InvalidArgumentError(
+        `Format must be one of: ${formatSuiteOutputFormatList()}.`
+    );
 }
 
 export function createMemoryCommand({ env = process.env } = {}) {
@@ -139,7 +144,7 @@ export function createMemoryCommand({ env = process.env } = {}) {
             "--format <format>",
             "Output format: json (default) or human.",
             validateFormat,
-            "json"
+            SuiteOutputFormat.JSON
         )
         .option("--pretty", "Pretty-print JSON output.");
     applyMemoryEnvOptionOverrides({ command, env });

--- a/src/cli/lib/performance-cli.js
+++ b/src/cli/lib/performance-cli.js
@@ -9,12 +9,12 @@ import {
     resolveCliProjectIndexBuilder,
     resolveCliIdentifierCasePlanPreparer
 } from "./plugin-services.js";
-import {
-    getIdentifierText,
-    toNormalizedLowerCaseString
-} from "./shared-deps.js";
+import { getIdentifierText } from "./shared-deps.js";
 import { formatByteSize } from "./byte-format.js";
 import {
+    SuiteOutputFormat,
+    formatSuiteOutputFormatList,
+    normalizeSuiteOutputFormat,
     emitSuiteResults as emitSuiteResultsJson,
     ensureSuitesAreKnown,
     resolveRequestedSuites
@@ -28,11 +28,14 @@ function collectSuite(value, previous = []) {
 }
 
 function validateFormat(value) {
-    const normalized = toNormalizedLowerCaseString(value);
-    if (normalized === "json" || normalized === "human") {
+    const normalized = normalizeSuiteOutputFormat(value);
+    if (normalized) {
         return normalized;
     }
-    throw new InvalidArgumentError("Format must be either 'json' or 'human'.");
+
+    throw new InvalidArgumentError(
+        `Format must be one of: ${formatSuiteOutputFormatList()}.`
+    );
 }
 
 function formatErrorDetails(error) {
@@ -367,7 +370,7 @@ export function createPerformanceCommand() {
             "--format <format>",
             "Output format: json (default) or human.",
             validateFormat,
-            "json"
+            SuiteOutputFormat.JSON
         )
         .option("--pretty", "Pretty-print JSON output.")
         .option(

--- a/src/cli/tests/memory-command-format.test.js
+++ b/src/cli/tests/memory-command-format.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMemoryCommand } from "../lib/memory-cli.js";
+import { SuiteOutputFormat } from "../lib/command-suite-helpers.js";
+
+test("memory command accepts valid format values", () => {
+    const command = createMemoryCommand({ env: {} });
+
+    command.parse(["--format", SuiteOutputFormat.HUMAN], {
+        from: "user"
+    });
+
+    assert.equal(command.opts().format, SuiteOutputFormat.HUMAN);
+});
+
+test("memory command rejects invalid format values", () => {
+    const command = createMemoryCommand({ env: {} });
+
+    assert.throws(
+        () =>
+            command.parse(["--format", "xml"], {
+                from: "user"
+            }),
+        (error) => {
+            assert.equal(error?.code, "commander.invalidArgument");
+            assert.match(error.message, /format must be one of/i);
+            return true;
+        }
+    );
+});


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
