### PR TITLE
Codex: POLA Behaviour Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 | `condenseUnaryBooleanReturns` | `false` | Converts unary boolean returns (such as `return !condition;`) into ternaries so condensed output preserves intent. |
 | `condenseReturnStatements` | `false` | Merges complementary `if` branches that return literal booleans into a single simplified return statement. |
 | `allowTrailingCallArguments` | `false` | Reserved for future use; currently has no effect because trailing arguments are normalised via `missingOptionalArgumentPlaceholder`. |
-| `preserveLineBreaks` | `false` | Keeps user-authored line breaks in supported constructs like chained calls instead of reflowing them. |
+| `preserveLineBreaks` | `false` | Reserved for future use; enabling currently has no effect while line-break preservation heuristics are evaluated. |
 | `maintainArrayIndentation` | `false` | Preserves the original indentation depth for array literals rather than applying Prettier's defaults. |
 | `maintainStructIndentation` | `false` | Preserves the original indentation depth for struct literals rather than applying Prettier's defaults. |
 | `maintainWithIndentation` | `false` | Retains the body indentation within `with` statements instead of reindenting relative to the `with` keyword. |

--- a/src/plugin/src/component-providers/default-plugin-components.js
+++ b/src/plugin/src/component-providers/default-plugin-components.js
@@ -238,7 +238,7 @@ export function createDefaultGmlPluginComponents() {
                 category: "gml",
                 default: false,
                 description:
-                    "Preserve user-authored line breaks in select syntactic constructs such as chained function calls."
+                    "Reserved for future use; enabling this option currently has no effect while line-break preservation heuristics are evaluated."
             },
             maintainArrayIndentation: {
                 since: "0.0.0",


### PR DESCRIPTION
Seed PR for Codex to reconcile option documentation and inline comments with the behaviours the formatter actually ships.
