### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/cli/lib/manual-command-context.js
+++ b/src/cli/lib/manual-command-context.js
@@ -60,6 +60,6 @@ export function createManualCommandContext({
         defaultOutputPath: resolveOutputPath(repoRoot, outputFileName),
         manualClient,
         fetchManualFile: manualClient.fileFetcher.fetchManualFile,
-        resolveManualRef: manualClient.refResolver.resolveManualRef
+        resolveManualRef: manualClient.references.resolveManualRef
     };
 }

--- a/src/cli/tests/manual-github-client.test.js
+++ b/src/cli/tests/manual-github-client.test.js
@@ -35,7 +35,7 @@ describe("manual GitHub client validation", () => {
             defaultCacheRoot: "/tmp/manual-cache",
             defaultRawRoot: "https://raw.github.com/example/manual"
         });
-        const { refResolver } = client;
+        const { references } = client;
 
         const responses = [
             {
@@ -53,7 +53,7 @@ describe("manual GitHub client validation", () => {
 
         await assert.rejects(
             () =>
-                refResolver.resolveManualRef("feature", {
+                references.resolveManualRef("feature", {
                     verbose: createManualVerboseState({ quiet: true }),
                     apiRoot: API_ROOT
                 }),
@@ -68,7 +68,7 @@ describe("manual GitHub client validation", () => {
             defaultCacheRoot: "/tmp/manual-cache",
             defaultRawRoot: "https://raw.github.com/example/manual"
         });
-        const { refResolver } = client;
+        const { references } = client;
 
         const responses = [
             {
@@ -88,7 +88,7 @@ describe("manual GitHub client validation", () => {
 
         await assert.rejects(
             () =>
-                refResolver.resolveManualRef(undefined, {
+                references.resolveManualRef(undefined, {
                     verbose: createManualVerboseState({
                         overrides: { resolveRef: false }
                     }),
@@ -105,7 +105,7 @@ describe("manual GitHub client validation", () => {
             defaultCacheRoot: "/tmp/manual-cache",
             defaultRawRoot: "https://raw.github.com/example/manual"
         });
-        const { refResolver } = client;
+        const { references } = client;
 
         const responses = [
             {
@@ -125,7 +125,7 @@ describe("manual GitHub client validation", () => {
             return next.response;
         };
 
-        const result = await refResolver.resolveManualRef(undefined, {
+        const result = await references.resolveManualRef(undefined, {
             verbose: createManualVerboseState({
                 overrides: { resolveRef: false }
             }),
@@ -159,7 +159,7 @@ describe("manual GitHub client validation", () => {
             return next.response;
         };
 
-        const result = await client.commitResolver.resolveCommitFromRef(
+        const result = await client.references.resolveCommitFromRef(
             "feature",
             { apiRoot: API_ROOT }
         );


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
