### PR TITLE
Update failing test recovery workflow schedule

### DIFF
--- a/.github/workflows/codex-41-test-failure.yml
+++ b/.github/workflows/codex-41-test-failure.yml
@@ -1,7 +1,7 @@
 name: Codex 41 – Failing Test Recovery
 on:
   schedule:
-    - cron: "0 */2 * * *" # every 2 hours
+    - cron: "0 * * * *" # every hour
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- run the Codex failing test recovery workflow on an hourly schedule instead of every two hours

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f51a4ebdf0832faad479923f0bec13