### PR TITLE
Add lint columns to automerge summary table

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -169,6 +169,7 @@ jobs:
             const targets = ['base','head','merge'];
             const totals = {};
             const coverage = {};
+            const lint = {};
             const notes = [];
 
             function listFilesRecursive(root) {
@@ -228,6 +229,21 @@ jobs:
               return { found, hit, pct: (hit / found) * 100 };
             }
 
+            function readCheckstyle(checkstyleFiles) {
+              if (checkstyleFiles.length === 0) return null;
+              let warnings = 0;
+              let errors = 0;
+              for (const file of checkstyleFiles) {
+                const xml = fs.readFileSync(file, 'utf8');
+                for (const match of xml.matchAll(/<error\b[^>]*severity="([^"]*)"/gi)) {
+                  const severity = (match[1] || '').toLowerCase();
+                  if (severity === 'warning') warnings += 1;
+                  else if (severity === 'error') errors += 1;
+                }
+              }
+              return { warnings, errors };
+            }
+
             const fmtCoverage = data => {
               if (!data || !Number.isFinite(data.pct)) return '—';
               return `${data.pct.toFixed(1)}%`;
@@ -238,10 +254,13 @@ jobs:
               const files = listFilesRecursive(dir);
               const xmlFiles = files.filter(f => f.endsWith('.xml'));
               const lcovFiles = files.filter(f => path.basename(f) === 'lcov.info');
+              const checkstyleFiles = files.filter(f => /checkstyle/i.test(path.basename(f)));
               totals[tgt] = readSuites(xmlFiles);
               coverage[tgt] = readCoverage(lcovFiles);
+              lint[tgt] = readCheckstyle(checkstyleFiles);
               if (xmlFiles.length === 0) notes.push(`No JUnit XML found for **${tgt}**.`);
               if (files.length > 0 && !coverage[tgt]) notes.push(`No coverage (LCOV) data found for **${tgt}**.`);
+              if (files.length > 0 && checkstyleFiles.length === 0) notes.push(`No lint (checkstyle) data found for **${tgt}**.`);
             }
 
             const fmtTime = s => !Number.isFinite(s) || s <= 0 ? '—'
@@ -249,13 +268,17 @@ jobs:
               : s >= 60 ? `${Math.floor(s/60)}m ${(s - Math.floor(s/60)*60).toFixed(1)}s`
               : `${s.toFixed(2)}s`;
 
-            const row = (label, t, cov) => {
+            const fmtLintCount = value => (value === null || value === undefined) ? '—' : `${value}`;
+
+            const row = (label, t, lintData, cov) => {
               const hasAny = (t.tests + t.failures + t.errors + t.skipped) > 0;
               const coverageCell = fmtCoverage(cov);
-              if (!hasAny) return `| ${label} | — | — | — | — | ${coverageCell} | — |`;
+              const lintWarningsCell = fmtLintCount(lintData?.warnings);
+              const lintErrorsCell = fmtLintCount(lintData?.errors);
+              if (!hasAny) return `| ${label} | — | — | — | — | ${lintWarningsCell} | ${lintErrorsCell} | ${coverageCell} | — |`;
               const failed = t.failures + t.errors;
               const passed = Math.max(0, t.tests - failed - t.skipped);
-              return `| ${label} | ${t.tests} | ${passed} | ${failed} | ${t.skipped} | ${coverageCell} | ${fmtTime(t.time)} |`;
+              return `| ${label} | ${t.tests} | ${passed} | ${failed} | ${t.skipped} | ${lintWarningsCell} | ${lintErrorsCell} | ${coverageCell} | ${fmtTime(t.time)} |`;
             };
 
             const baseRef = context.payload.pull_request?.base?.ref || 'base';
@@ -264,11 +287,11 @@ jobs:
             const headSha = (context.payload.pull_request?.head?.sha || context.sha || '').slice(0,7) || '???????';
 
             const table = [
-              '| Target | Total | Passed | Failed | Skipped | Coverage | Duration |',
-              '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
-              row(`Base (${baseRef} @ ${baseSha})`, totals.base, coverage.base),
-              row(`PR (${headRef} @ ${headSha})`, totals.head, coverage.head),
-              row('Merged (base+PR)', totals.merge, coverage.merge),
+              '| Target | Total | Passed | Failed | Skipped | Lint warnings | Lint errors | Coverage | Duration |',
+              '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+              row(`Base (${baseRef} @ ${baseSha})`, totals.base, lint.base, coverage.base),
+              row(`PR (${headRef} @ ${headSha})`, totals.head, lint.head, coverage.head),
+              row('Merged (base+PR)', totals.merge, lint.merge, coverage.merge),
               '',
               ...notes.map(n => `> ⚠️ ${n}`)
             ].join('\n');


### PR DESCRIPTION
## Summary
- parse ESLint checkstyle artifacts when summarizing the automerge workflow results
- include lint warning and error counts in the pull request regression summary table

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f53e83a628832f9eea0843fbfd09c5