### PR TITLE
Run lint report in regression workflow

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -94,6 +94,10 @@ jobs:
           fail-on-empty: false
           use-actions-summary: false
 
+      - name: Run lint (checkstyle)
+        run: npm run lint:report
+        continue-on-error: true
+
       - name: Upload JUnit artifacts (${{ matrix.target }})
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run the lint:report script in each regression-test matrix leg so checkstyle XML gets uploaded alongside the junit data

## Testing
- npm run lint:report

------
https://chatgpt.com/codex/tasks/task_e_68f544ce4ff0832fb2c0ccc3b25ab88a