### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/cli/lib/manual-command-context.js
+++ b/src/cli/lib/manual-command-context.js
@@ -47,7 +47,11 @@ export function createManualCommandContext({
     const defaultCacheRoot = resolveManualCacheRoot({ repoRoot });
     const { rawRoot: defaultManualRawRoot } = buildManualRepositoryEndpoints();
 
-    const manualClient = createManualGitHubClient({
+    const {
+        requestDispatcher: manualRequests,
+        references: manualReferences,
+        fileFetcher: manualFileFetcher
+    } = createManualGitHubClient({
         userAgent: assertUserAgent(userAgent),
         defaultCacheRoot,
         defaultRawRoot: defaultManualRawRoot
@@ -58,8 +62,10 @@ export function createManualCommandContext({
         defaultCacheRoot,
         defaultManualRawRoot,
         defaultOutputPath: resolveOutputPath(repoRoot, outputFileName),
-        manualClient,
-        fetchManualFile: manualClient.fileFetcher.fetchManualFile,
-        resolveManualRef: manualClient.references.resolveManualRef
+        manualRequests,
+        manualReferences,
+        manualFileFetcher,
+        fetchManualFile: manualFileFetcher.fetchManualFile,
+        resolveManualRef: manualReferences.resolveManualRef
     };
 }

--- a/src/cli/tests/manual-command-context.test.js
+++ b/src/cli/tests/manual-command-context.test.js
@@ -27,6 +27,9 @@ test("createManualCommandContext centralizes manual command defaults", () => {
         context.defaultOutputPath,
         path.join(expectedRepoRoot, "resources", "example.json")
     );
+    assert.equal(typeof context.manualRequests.execute, "function");
+    assert.equal(typeof context.manualReferences.resolveManualRef, "function");
+    assert.equal(typeof context.manualFileFetcher.fetchManualFile, "function");
     assert.equal(typeof context.fetchManualFile, "function");
     assert.equal(typeof context.resolveManualRef, "function");
 });


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
