### PR TITLE
Improve lexer syntax error diagnostics

### DIFF
--- a/src/parser/src/gml-parser.js
+++ b/src/parser/src/gml-parser.js
@@ -3,7 +3,9 @@ import { PredictionMode } from "antlr4";
 import GameMakerLanguageLexer from "./generated/GameMakerLanguageLexer.js";
 import GameMakerLanguageParser from "./generated/GameMakerLanguageParser.js";
 import GameMakerASTBuilder from "./gml-ast-builder.js";
-import GameMakerParseErrorListener from "./gml-syntax-error.js";
+import GameMakerParseErrorListener, {
+    GameMakerLexerErrorListener
+} from "./gml-syntax-error.js";
 import { getLineBreakCount } from "../../shared/utils/line-breaks.js";
 import { isErrorLike } from "../../shared/utils/capability-probes.js";
 import { isObjectLike } from "../../shared/object-utils.js";
@@ -59,6 +61,8 @@ export default class GMLParser {
     parse() {
         const chars = new antlr4.InputStream(this.text);
         const lexer = new GameMakerLanguageLexer(chars);
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(new GameMakerLexerErrorListener());
         lexer.strictMode = false;
         const tokens = new antlr4.CommonTokenStream(lexer);
         const parser = new GameMakerLanguageParser(tokens);
@@ -158,16 +162,14 @@ export default class GMLParser {
                         endIndex + 1
                     );
                 }
-            } else if (node.type === "TemplateStringText" && 
-                    Number.isInteger(startIndex) &&
-                    Number.isInteger(endIndex) &&
-                    endIndex >= startIndex
-                ) {
-                    node.value = this.originalText.slice(
-                        startIndex,
-                        endIndex + 1
-                    );
-                }
+            } else if (
+                node.type === "TemplateStringText" &&
+                Number.isInteger(startIndex) &&
+                Number.isInteger(endIndex) &&
+                endIndex >= startIndex
+            ) {
+                node.value = this.originalText.slice(startIndex, endIndex + 1);
+            }
 
             for (const value of Object.values(node)) {
                 if (!value || typeof value !== "object") {

--- a/src/parser/tests/parser.test.js
+++ b/src/parser/tests/parser.test.js
@@ -332,6 +332,29 @@ describe("GameMaker parser fixtures", () => {
         });
     });
 
+    it("promotes lexer token recognition errors to syntax errors with context", () => {
+        const source = "\\";
+
+        assert.throws(
+            () => GMLParser.parse(source),
+            (error) => {
+                assert.ok(
+                    error instanceof Error,
+                    "Expected a syntax error to be thrown for invalid lexer input."
+                );
+                assert.match(
+                    error.message,
+                    /Syntax Error \(line 1, column 0\): unexpected symbol '\\'/
+                );
+                assert.strictEqual(error.line, 1);
+                assert.strictEqual(error.column, 0);
+                assert.strictEqual(error.wrongSymbol, String.raw`symbol '\'`);
+                assert.strictEqual(error.offendingText, "\\");
+                return true;
+            }
+        );
+    });
+
     it("tracks comment locations correctly when using CRLF", () => {
         const source = "/*first\r\nsecond*/";
         const ast = GMLParser.parse(source, {


### PR DESCRIPTION
## Summary
- add a lexer error listener that wraps token recognition failures in GameMakerSyntaxError with location details
- wire the parser to install the listener so token errors include file context
- add a parser test asserting lexer token errors surface as syntax errors

## Testing
- npm run test:parser

------
https://chatgpt.com/codex/tasks/task_e_68f5582cef44832f8c1f613edd0ebbe2