### PR TITLE
Remove legacy whitespace preservation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,11 +424,8 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 | `condenseUnaryBooleanReturns` | `false` | Converts unary boolean returns (such as `return !condition;`) into ternaries so condensed output preserves intent. |
 | `condenseReturnStatements` | `false` | Merges complementary `if` branches that return literal booleans into a single simplified return statement. |
 | `allowTrailingCallArguments` | `false` | Reserved for future use; currently has no effect because trailing arguments are normalised via `missingOptionalArgumentPlaceholder`. |
-| `preserveLineBreaks` | `false` | Reserved for future use; enabling currently has no effect while line-break preservation heuristics are evaluated. |
-| `maintainArrayIndentation` | `false` | Preserves the original indentation depth for array literals rather than applying Prettier's defaults. |
-| `maintainStructIndentation` | `false` | Preserves the original indentation depth for struct literals rather than applying Prettier's defaults. |
-| `maintainWithIndentation` | `false` | Retains the body indentation within `with` statements instead of reindenting relative to the `with` keyword. |
-| `maintainSwitchIndentation` | `false` | Retains existing indentation inside `switch` statements instead of reindenting each case body. |
+
+> **Note:** The formatter intentionally enforces canonical whitespace. Legacy escape hatches such as `preserveLineBreaks` and the `maintain*Indentation` toggles were removed to keep formatting deterministic.
 
 #### Identifier-case rollout
 

--- a/src/plugin/src/component-providers/default-plugin-components.js
+++ b/src/plugin/src/component-providers/default-plugin-components.js
@@ -231,47 +231,11 @@ export function createDefaultGmlPluginComponents() {
                 default: false,
                 description:
                     "Reserved for future use; enabling this option currently has no effect because trailing call commas are normalized into missing optional argument placeholders (see 'missingOptionalArgumentPlaceholder')."
-            },
-            preserveLineBreaks: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Reserved for future use; enabling this option currently has no effect while line-break preservation heuristics are evaluated."
-            },
-            maintainArrayIndentation: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Keep existing indentation for array literals instead of reindenting according to Prettier defaults."
-            },
-            maintainStructIndentation: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Keep existing indentation for struct literals instead of reindenting according to Prettier defaults."
-            },
-            maintainWithIndentation: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Preserve the indentation within 'with' statements rather than reindenting the body relative to the statement."
-            },
-            maintainSwitchIndentation: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Preserve the indentation inside 'switch' statements rather than reindenting cases relative to the switch body."
             }
+            // Legacy whitespace toggles (preserveLineBreaks, maintainArrayIndentation,
+            // maintainStructIndentation, maintainWithIndentation, maintainSwitchIndentation)
+            // were intentionally removed so the formatter can enforce a single opinionated
+            // indentation strategy. Avoid re-adding escape hatches that contradict that goal.
         }
     };
 }

--- a/src/plugin/tests/plugin-components.test.js
+++ b/src/plugin/tests/plugin-components.test.js
@@ -42,6 +42,20 @@ test("GML plugin components expose validated defaults", () => {
         "default options should be registered"
     );
 
+    // The formatter is intentionally opinionated—legacy indentation toggles must stay removed.
+    for (const removedOption of [
+        "preserveLineBreaks",
+        "maintainArrayIndentation",
+        "maintainStructIndentation",
+        "maintainWithIndentation",
+        "maintainSwitchIndentation"
+    ]) {
+        assert.ok(
+            !Object.hasOwn(resolved.options, removedOption),
+            `${removedOption} should stay unregistered`
+        );
+    }
+
     assert.strictEqual(
         resolveGmlPluginComponents(),
         resolved,


### PR DESCRIPTION
## Summary
- drop the unused preserveLineBreaks and maintain* indentation options from the plugin metadata
- document the removal so the formatter remains opinionated about whitespace
- lock a test to ensure the removed options stay unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f560d36ae0832fb8ea735a6f0c00fd