### PR TITLE
Remove fixMissingDecimalZeroes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,6 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 | `applyFeatherFixes` | `false` | Applies opt-in fixes backed by GameMaker Feather metadata (e.g. drop trailing semicolons from `#macro`). |
 | `useStringInterpolation` | `false` | Upgrades eligible string concatenations to template strings (`$"Hello {name}"`). |
 | `missingOptionalArgumentPlaceholder` | `"undefined"` | Choose `"empty"` to leave missing optional arguments blank instead of inserting `undefined`. |
-| `fixMissingDecimalZeroes` | `true` | Pads bare decimal literals with leading/trailing zeroes; set to `false` to preserve the original text. |
 | `convertDivisionToMultiplication` | `false` | Rewrites division by literals into multiplication by the reciprocal when safe. |
 | `convertManualMathToBuiltins` | `false` | Collapses bespoke math expressions into their equivalent built-in helpers (for example, turn repeated multiplication into `sqr()`). |
 | `condenseUnaryBooleanReturns` | `false` | Converts unary boolean returns (such as `return !condition;`) into ternaries so condensed output preserves intent. |
@@ -429,6 +428,8 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 | `maintainStructIndentation` | `false` | Preserves the original indentation depth for struct literals rather than applying Prettier's defaults. |
 | `maintainWithIndentation` | `false` | Retains the body indentation within `with` statements instead of reindenting relative to the `with` keyword. |
 | `maintainSwitchIndentation` | `false` | Retains existing indentation inside `switch` statements instead of reindenting each case body. |
+
+Bare decimal literals are always padded with leading and trailing zeroes to improve readability.
 
 #### Identifier-case rollout
 

--- a/src/plugin/src/component-providers/default-plugin-components.js
+++ b/src/plugin/src/component-providers/default-plugin-components.js
@@ -184,14 +184,6 @@ export function createDefaultGmlPluginComponents() {
                     }
                 ]
             },
-            fixMissingDecimalZeroes: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: true,
-                description:
-                    "Pads bare decimal literals with leading or trailing zeroes to improve readability. Set to false to preserve the original literal text."
-            },
             convertDivisionToMultiplication: {
                 since: "0.0.0",
                 type: "boolean",

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1028,21 +1028,11 @@ export function print(path, options, print) {
         }
         case "Literal": {
             let value = node.value;
-            const shouldPadDecimalZeroes =
-                options.fixMissingDecimalZeroes !== false;
 
-            if (
-                shouldPadDecimalZeroes &&
-                value.startsWith(".") &&
-                !value.startsWith('"')
-            ) {
+            if (value.startsWith(".") && !value.startsWith('"')) {
                 value = "0" + value; // Fix decimals without a leading 0.
             }
-            if (
-                shouldPadDecimalZeroes &&
-                value.endsWith(".") &&
-                !value.endsWith('"')
-            ) {
+            if (value.endsWith(".") && !value.endsWith('"')) {
                 value = value + "0"; // Fix decimals without a trailing 0.
             }
             return concat(value);

--- a/src/plugin/tests/fix-missing-decimal-zeroes-option.test.js
+++ b/src/plugin/tests/fix-missing-decimal-zeroes-option.test.js
@@ -42,22 +42,11 @@ test("pads bare decimal literals by default", async () => {
     );
 });
 
-test("respects fixMissingDecimalZeroes=false", async () => {
-    const formatted = await format(SOURCE_LINES.join("\n"), {
-        fixMissingDecimalZeroes: false
-    });
+test("does not expose a fixMissingDecimalZeroes plugin option", async () => {
+    const pluginModule = await import(pluginPath);
 
-    assert.strictEqual(
-        formatted,
-        [
-            "",
-            "/// @function coefficients",
-            "function coefficients() {",
-            "    var a = .5;",
-            "    var b = 5.;",
-            "    return a + b;",
-            "}",
-            ""
-        ].join("\n")
+    assert.ok(
+        !Object.hasOwn(pluginModule.options, "fixMissingDecimalZeroes"),
+        "The fixMissingDecimalZeroes option should not be exported by the plugin."
     );
 });


### PR DESCRIPTION
## Summary
- remove the `fixMissingDecimalZeroes` option from the plugin metadata and always pad decimals in the printer
- document that decimal padding is an always-on behaviour
- refresh the regression test to ensure the option cannot be configured in the future

## Testing
- node --test src/plugin/tests/fix-missing-decimal-zeroes-option.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f56013a678832f9962fbb3fbd84d11