### PR TITLE
Remove deprecated call argument options

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 
 #### Core formatter behaviour
 
+Optional arguments without explicit defaults always render as `undefined` in formatted output.
+
 | Option | Default | Summary |
 | --- | --- | --- |
 | `optimizeLoopLengthHoisting` | `true` | Hoists supported collection length checks out of `for` loop conditions and caches them in a temporary variable. |
@@ -417,13 +419,11 @@ Refer to the [Prettier configuration guide](https://prettier.io/docs/en/configur
 | `maxParamsPerLine` | `0` | Forces argument wrapping after the specified count (`0` keeps the original layout). |
 | `applyFeatherFixes` | `false` | Applies opt-in fixes backed by GameMaker Feather metadata (e.g. drop trailing semicolons from `#macro`). |
 | `useStringInterpolation` | `false` | Upgrades eligible string concatenations to template strings (`$"Hello {name}"`). |
-| `missingOptionalArgumentPlaceholder` | `"undefined"` | Choose `"empty"` to leave missing optional arguments blank instead of inserting `undefined`. |
 | `fixMissingDecimalZeroes` | `true` | Pads bare decimal literals with leading/trailing zeroes; set to `false` to preserve the original text. |
 | `convertDivisionToMultiplication` | `false` | Rewrites division by literals into multiplication by the reciprocal when safe. |
 | `convertManualMathToBuiltins` | `false` | Collapses bespoke math expressions into their equivalent built-in helpers (for example, turn repeated multiplication into `sqr()`). |
 | `condenseUnaryBooleanReturns` | `false` | Converts unary boolean returns (such as `return !condition;`) into ternaries so condensed output preserves intent. |
 | `condenseReturnStatements` | `false` | Merges complementary `if` branches that return literal booleans into a single simplified return statement. |
-| `allowTrailingCallArguments` | `false` | Reserved for future use; currently has no effect because trailing arguments are normalised via `missingOptionalArgumentPlaceholder`. |
 | `preserveLineBreaks` | `false` | Reserved for future use; enabling currently has no effect while line-break preservation heuristics are evaluated. |
 | `maintainArrayIndentation` | `false` | Preserves the original indentation depth for array literals rather than applying Prettier's defaults. |
 | `maintainStructIndentation` | `false` | Preserves the original indentation depth for struct literals rather than applying Prettier's defaults. |

--- a/src/plugin/src/component-providers/default-plugin-components.js
+++ b/src/plugin/src/component-providers/default-plugin-components.js
@@ -3,7 +3,6 @@ import { print } from "../printer/print.js";
 import { handleComments, printComment } from "../comments/comment-printer.js";
 import { identifierCaseOptions } from "../options/identifier-case.js";
 import { LogicalOperatorsStyle } from "../options/logical-operators-style.js";
-import { MissingOptionalArgumentPlaceholder } from "../options/missing-optional-argument-placeholder.js";
 
 export function createDefaultGmlPluginComponents() {
     return {
@@ -164,26 +163,6 @@ export function createDefaultGmlPluginComponents() {
                 description:
                     'Rewrite string concatenations like "Hello " + name + "!" into template strings such as $"Hello {name}!" when all parts are safely composable.'
             },
-            missingOptionalArgumentPlaceholder: {
-                since: "0.0.0",
-                type: "choice",
-                category: "gml",
-                default: MissingOptionalArgumentPlaceholder.UNDEFINED,
-                description:
-                    "Controls how omitted optional arguments are printed. Set to 'empty' to leave the slot blank instead of inserting 'undefined'.",
-                choices: [
-                    {
-                        value: MissingOptionalArgumentPlaceholder.UNDEFINED,
-                        description:
-                            "Fill missing optional arguments with the literal 'undefined'."
-                    },
-                    {
-                        value: MissingOptionalArgumentPlaceholder.EMPTY,
-                        description:
-                            "Leave missing optional arguments empty so calls render as consecutive commas."
-                    }
-                ]
-            },
             fixMissingDecimalZeroes: {
                 since: "0.0.0",
                 type: "boolean",
@@ -223,14 +202,6 @@ export function createDefaultGmlPluginComponents() {
                 default: false,
                 description:
                     "Combine complementary 'if' branches that return literal booleans into a single return statement with the simplified expression."
-            },
-            allowTrailingCallArguments: {
-                since: "0.0.0",
-                type: "boolean",
-                category: "gml",
-                default: false,
-                description:
-                    "Reserved for future use; enabling this option currently has no effect because trailing call commas are normalized into missing optional argument placeholders (see 'missingOptionalArgumentPlaceholder')."
             },
             preserveLineBreaks: {
                 since: "0.0.0",

--- a/src/plugin/src/options/missing-optional-argument-placeholder.js
+++ b/src/plugin/src/options/missing-optional-argument-placeholder.js
@@ -1,4 +1,0 @@
-export const MissingOptionalArgumentPlaceholder = Object.freeze({
-    UNDEFINED: "undefined",
-    EMPTY: "empty"
-});

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -61,7 +61,6 @@ import {
     LogicalOperatorsStyle,
     normalizeLogicalOperatorsStyle
 } from "../options/logical-operators-style.js";
-import { MissingOptionalArgumentPlaceholder } from "../options/missing-optional-argument-placeholder.js";
 
 const {
     breakParent,
@@ -1059,14 +1058,6 @@ export function print(path, options, print) {
             return concat(node.value);
         }
         case "MissingOptionalArgument": {
-            const placeholder =
-                options.missingOptionalArgumentPlaceholder ??
-                MissingOptionalArgumentPlaceholder.UNDEFINED;
-
-            if (placeholder === MissingOptionalArgumentPlaceholder.EMPTY) {
-                return concat("");
-            }
-
             return concat("undefined");
         }
         case "NewExpression": {

--- a/src/plugin/tests/missing-optional-arguments.test.js
+++ b/src/plugin/tests/missing-optional-arguments.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { test } from "node:test";
 import prettier from "prettier";
 
@@ -32,20 +32,20 @@ test("prints undefined for missing optional arguments by default", async () => {
     assert.strictEqual(formatted, DEFAULT_FORMATTED);
 });
 
-test("respects missingOptionalArgumentPlaceholder='empty'", async () => {
-    const formatted = await format(SOURCE_LINES.join("\n"), {
-        missingOptionalArgumentPlaceholder: "empty"
-    });
+test("plugin no longer exposes removed options", async () => {
+    const pluginModule = await import(pathToFileURL(pluginPath).href);
 
-    assert.strictEqual(
-        formatted,
-        [
-            "",
-            "/// @function demo",
-            "function demo() {",
-            "    return func(1, , 3);",
-            "}",
-            ""
-        ].join("\n")
-    );
+    for (const optionName of [
+        "missingOptionalArgumentPlaceholder",
+        "allowTrailingCallArguments"
+    ]) {
+        assert.ok(
+            !Object.hasOwn(pluginModule.options, optionName),
+            `${optionName} must be absent from plugin metadata`
+        );
+        assert.ok(
+            !Object.hasOwn(pluginModule.defaultOptions, optionName),
+            `${optionName} must be absent from plugin defaults`
+        );
+    }
 });


### PR DESCRIPTION
## Summary
- remove the `missingOptionalArgumentPlaceholder` and `allowTrailingCallArguments` plugin options, and update the docs to note optional arguments print as `undefined`
- simplify the printer so missing optional arguments always render as `undefined`
- replace the option-specific test with regression coverage that ensures the options stay removed and the default behaviour persists

## Testing
- node --test src/plugin/tests/missing-optional-arguments.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f55fbf6690832f8ca5a53d76994625