### PR TITLE
Codex: Separate policy evaluators from mechanisms

### DIFF
--- a/src/plugin/src/identifier-case/asset-rename-policy.js
+++ b/src/plugin/src/identifier-case/asset-rename-policy.js
@@ -1,0 +1,89 @@
+import { asArray, isNonEmptyArray } from "../../../shared/array-utils.js";
+
+// The asset rename mechanism (filesystem mutations, logging, metrics) depends
+// on this policy object to decide if it should run. Keeping the rules here lets
+// us exercise and extend the heuristics without touching the operational code.
+
+const IdentifierCaseAssetRenamePolicyReason = Object.freeze({
+    DRY_RUN_ENABLED: "dry-run-enabled",
+    NO_RENAMES: "no-renames",
+    HAS_CONFLICTS: "has-conflicts",
+    MISSING_PROJECT_INDEX: "missing-project-index",
+    ALREADY_APPLIED: "already-applied",
+    APPLY: "apply"
+});
+
+class IdentifierCaseAssetRenamePolicy {
+    evaluate(context = {}) {
+        const {
+            options = {},
+            projectIndex = null,
+            assetRenames = [],
+            assetConflicts = []
+        } = context;
+
+        if (options?.__identifierCaseDryRun !== false) {
+            return {
+                shouldApply: false,
+                reason: IdentifierCaseAssetRenamePolicyReason.DRY_RUN_ENABLED,
+                renames: [],
+                conflicts: []
+            };
+        }
+
+        const renames = asArray(assetRenames);
+        if (!isNonEmptyArray(renames)) {
+            return {
+                shouldApply: false,
+                reason: IdentifierCaseAssetRenamePolicyReason.NO_RENAMES,
+                renames: [],
+                conflicts: []
+            };
+        }
+
+        const conflicts = asArray(assetConflicts);
+        if (isNonEmptyArray(conflicts)) {
+            return {
+                shouldApply: false,
+                reason: IdentifierCaseAssetRenamePolicyReason.HAS_CONFLICTS,
+                renames: [],
+                conflicts
+            };
+        }
+
+        if (!projectIndex) {
+            return {
+                shouldApply: false,
+                reason: IdentifierCaseAssetRenamePolicyReason.MISSING_PROJECT_INDEX,
+                renames,
+                conflicts
+            };
+        }
+
+        if (options?.__identifierCaseAssetRenamesApplied === true) {
+            return {
+                shouldApply: false,
+                reason: IdentifierCaseAssetRenamePolicyReason.ALREADY_APPLIED,
+                renames,
+                conflicts
+            };
+        }
+
+        return {
+            shouldApply: true,
+            reason: IdentifierCaseAssetRenamePolicyReason.APPLY,
+            renames,
+            conflicts
+        };
+    }
+}
+
+function createIdentifierCaseAssetRenamePolicy() {
+    return new IdentifierCaseAssetRenamePolicy();
+}
+
+export {
+    IdentifierCaseAssetRenamePolicy,
+    IdentifierCaseAssetRenamePolicyReason,
+    createIdentifierCaseAssetRenamePolicy
+};

--- a/src/plugin/tests/identifier-case-asset-rename-policy.test.js
+++ b/src/plugin/tests/identifier-case-asset-rename-policy.test.js
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    createIdentifierCaseAssetRenamePolicy,
+    IdentifierCaseAssetRenamePolicyReason
+} from "../src/identifier-case/asset-rename-policy.js";
+
+function evaluate(context) {
+    const policy = createIdentifierCaseAssetRenamePolicy();
+    return policy.evaluate(context);
+}
+
+describe("identifier case asset rename policy", () => {
+    it("requires explicit opt-in when dry run is enabled", () => {
+        const result = evaluate({
+            options: {},
+            assetRenames: [{ name: "demo" }]
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: false,
+            reason: IdentifierCaseAssetRenamePolicyReason.DRY_RUN_ENABLED,
+            renames: [],
+            conflicts: []
+        });
+    });
+
+    it("skips when no renames are planned", () => {
+        const result = evaluate({
+            options: { __identifierCaseDryRun: false },
+            assetRenames: [],
+            projectIndex: {}
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: false,
+            reason: IdentifierCaseAssetRenamePolicyReason.NO_RENAMES,
+            renames: [],
+            conflicts: []
+        });
+    });
+
+    it("skips when conflicts are present", () => {
+        const result = evaluate({
+            options: { __identifierCaseDryRun: false },
+            assetRenames: [{ name: "demo" }],
+            assetConflicts: [{ resourcePath: "foo.yy" }],
+            projectIndex: {}
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: false,
+            reason: IdentifierCaseAssetRenamePolicyReason.HAS_CONFLICTS,
+            renames: [],
+            conflicts: [{ resourcePath: "foo.yy" }]
+        });
+    });
+
+    it("skips when the project index is unavailable", () => {
+        const result = evaluate({
+            options: { __identifierCaseDryRun: false },
+            assetRenames: [{ name: "demo" }]
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: false,
+            reason: IdentifierCaseAssetRenamePolicyReason.MISSING_PROJECT_INDEX,
+            renames: [{ name: "demo" }],
+            conflicts: []
+        });
+    });
+
+    it("skips when renames were already applied", () => {
+        const result = evaluate({
+            options: {
+                __identifierCaseDryRun: false,
+                __identifierCaseAssetRenamesApplied: true
+            },
+            assetRenames: [{ name: "demo" }],
+            projectIndex: {}
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: false,
+            reason: IdentifierCaseAssetRenamePolicyReason.ALREADY_APPLIED,
+            renames: [{ name: "demo" }],
+            conflicts: []
+        });
+    });
+
+    it("approves the rename when all conditions are satisfied", () => {
+        const result = evaluate({
+            options: { __identifierCaseDryRun: false },
+            assetRenames: [{ name: "demo" }],
+            projectIndex: { id: "project" }
+        });
+
+        assert.deepStrictEqual(result, {
+            shouldApply: true,
+            reason: IdentifierCaseAssetRenamePolicyReason.APPLY,
+            renames: [{ name: "demo" }],
+            conflicts: []
+        });
+    });
+});


### PR DESCRIPTION
## Summary
* Identify formatter modules where policy heuristics are intertwined with operational logic.
* Extract policy evaluators or strategy objects so that formatting actions can delegate to them.

## Testing
* npm test
