### PR TITLE
Fix GM2009 vertex batch fixer inserting begin call

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -11269,7 +11269,6 @@ function ensureVertexBeginBeforeVertexEndCall(
     }
 
     parent.splice(property, 1);
-    attachFeatherFixMetadata(node, [fixDetail]);
 
     return fixDetail;
 }

--- a/src/plugin/tests/feather-fixes.test.js
+++ b/src/plugin/tests/feather-fixes.test.js
@@ -4873,7 +4873,7 @@ describe("applyFeatherFixes transform", () => {
         );
     });
 
-    it("inserts vertex_begin before vertex_end flagged by GM2009 and records metadata", () => {
+    it("removes standalone vertex_end calls flagged by GM2009 and records metadata", () => {
         const source = "vertex_end(vb);";
 
         const ast = GMLParser.parse(source, {
@@ -4886,25 +4886,9 @@ describe("applyFeatherFixes transform", () => {
         const body = Array.isArray(ast.body) ? ast.body : [];
         assert.strictEqual(
             body.length,
-            2,
-            "Expected vertex_begin to be inserted before vertex_end."
+            0,
+            "Expected standalone vertex_end call to be removed."
         );
-
-        const vertexBegin = body[0];
-        const vertexEnd = body[1];
-
-        assert.ok(vertexBegin?.type === "CallExpression");
-        assert.strictEqual(vertexBegin.object?.name, "vertex_begin");
-
-        const beginArgs = Array.isArray(vertexBegin.arguments)
-            ? vertexBegin.arguments
-            : [];
-        assert.strictEqual(beginArgs.length > 0, true);
-        assert.strictEqual(beginArgs[0]?.name, "vb");
-        assert.strictEqual(beginArgs[1]?.name, "format");
-
-        assert.ok(vertexEnd?.type === "CallExpression");
-        assert.strictEqual(vertexEnd.object?.name, "vertex_end");
 
         const appliedDiagnostics = Array.isArray(ast._appliedFeatherDiagnostics)
             ? ast._appliedFeatherDiagnostics
@@ -4922,18 +4906,6 @@ describe("applyFeatherFixes transform", () => {
         assert.ok(gm2009.range);
         assert.strictEqual(typeof gm2009.range.start, "number");
         assert.strictEqual(typeof gm2009.range.end, "number");
-
-        const beginMetadata = vertexBegin?._appliedFeatherDiagnostics ?? [];
-        assert.strictEqual(
-            beginMetadata.some((entry) => entry.id === "GM2009"),
-            true
-        );
-
-        const endMetadata = vertexEnd?._appliedFeatherDiagnostics ?? [];
-        assert.strictEqual(
-            endMetadata.some((entry) => entry.id === "GM2009"),
-            true
-        );
     });
 
     it("inserts missing vertex_end calls flagged by GM2008 and records metadata", () => {


### PR DESCRIPTION
## Summary
- drop the GM2009 fixer insertion of vertex_begin and instead remove standalone vertex_end calls flagged by GM2009
- update the GM2009 feather fixer test to expect removal while still recording diagnostic metadata

## Testing
- npm test *(fails: existing formatter fixture regressions outside GM2009)*

------
https://chatgpt.com/codex/tasks/task_e_68f5a95d4f88832faed257d07d5ed9d5