### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/plugin/tests/identifier-case-plan-service.test.js
+++ b/src/plugin/tests/identifier-case-plan-service.test.js
@@ -66,32 +66,40 @@ test(
     async () => {
         const calls = [];
 
-        const defaultService = resolveIdentifierCasePlanService();
+        const defaultServices = resolveIdentifierCasePlanService();
 
         registerIdentifierCasePlanServiceProvider(() => ({
-            prepareIdentifierCasePlan: async (options) => {
-                calls.push({ type: "prepare", options });
-                return defaultService.prepareIdentifierCasePlan(options);
+            preparation: {
+                async prepareIdentifierCasePlan(options) {
+                    calls.push({ type: "prepare", options });
+                    return defaultServices.preparation.prepareIdentifierCasePlan(
+                        options
+                    );
+                }
             },
-            getIdentifierCaseRenameForNode: (node, options) => {
-                calls.push({ type: "rename", node, options });
-                return defaultService.getIdentifierCaseRenameForNode(
-                    node,
-                    options
-                );
+            renameLookup: {
+                getIdentifierCaseRenameForNode(node, options) {
+                    calls.push({ type: "rename", node, options });
+                    return defaultServices.renameLookup.getIdentifierCaseRenameForNode(
+                        node,
+                        options
+                    );
+                }
             },
-            captureIdentifierCasePlanSnapshot: (options) => {
-                calls.push({ type: "capture", options });
-                return defaultService.captureIdentifierCasePlanSnapshot(
-                    options
-                );
-            },
-            applyIdentifierCasePlanSnapshot: (snapshot, options) => {
-                calls.push({ type: "apply", snapshot, options });
-                defaultService.applyIdentifierCasePlanSnapshot(
-                    snapshot,
-                    options
-                );
+            snapshot: {
+                captureIdentifierCasePlanSnapshot(options) {
+                    calls.push({ type: "capture", options });
+                    return defaultServices.snapshot.captureIdentifierCasePlanSnapshot(
+                        options
+                    );
+                },
+                applyIdentifierCasePlanSnapshot(snapshot, options) {
+                    calls.push({ type: "apply", snapshot, options });
+                    defaultServices.snapshot.applyIdentifierCasePlanSnapshot(
+                        snapshot,
+                        options
+                    );
+                }
             }
         }));
 


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
