### PR TITLE
Codex: Defensive Input Hardening

### DIFF
--- a/src/cli/commands/generate-gml-identifiers.js
+++ b/src/cli/commands/generate-gml-identifiers.js
@@ -31,6 +31,10 @@ import {
 } from "../lib/manual-command-options.js";
 import { wrapInvalidArgumentResolver } from "../lib/command-parsing.js";
 import { createManualCommandContext } from "../lib/manual-command-context.js";
+import {
+    decodeManualKeywordsPayload,
+    decodeManualTagsPayload
+} from "../lib/manual-payload-validation.js";
 
 const {
     repoRoot: REPO_ROOT,
@@ -572,12 +576,18 @@ export async function runGenerateGmlIdentifiers({ command } = {}) {
 
         const manualKeywords = timeSync(
             "Decoding ZeusDocs keywords",
-            () => JSON.parse(keywordsJson),
+            () =>
+                decodeManualKeywordsPayload(keywordsJson, {
+                    source: "ZeusDocs_keywords.json"
+                }),
             { verbose }
         );
         const manualTags = timeSync(
             "Decoding ZeusDocs tags",
-            () => JSON.parse(tagsJsonText),
+            () =>
+                decodeManualTagsPayload(tagsJsonText, {
+                    source: "ZeusDocs_tags.json"
+                }),
             { verbose }
         );
 

--- a/src/cli/lib/manual-payload-validation.js
+++ b/src/cli/lib/manual-payload-validation.js
@@ -1,0 +1,42 @@
+import { assertPlainObject, parseJsonWithContext } from "./shared-deps.js";
+
+function validateManualMapping(record, { valueDescription }) {
+    for (const [key, value] of Object.entries(record)) {
+        if (typeof value !== "string") {
+            const formattedKey = key ? `'${key}'` : "<empty key>";
+            throw new TypeError(
+                `${valueDescription} entry ${formattedKey} must map to a string value.`
+            );
+        }
+    }
+
+    return record;
+}
+
+export function decodeManualKeywordsPayload(jsonText, { source } = {}) {
+    const payload = parseJsonWithContext(jsonText, {
+        description: "manual keywords payload",
+        source
+    });
+    const record = assertPlainObject(payload, {
+        errorMessage: "Manual keywords payload must be a JSON object."
+    });
+
+    return validateManualMapping(record, {
+        valueDescription: "Manual keywords"
+    });
+}
+
+export function decodeManualTagsPayload(jsonText, { source } = {}) {
+    const payload = parseJsonWithContext(jsonText, {
+        description: "manual tags payload",
+        source
+    });
+    const record = assertPlainObject(payload, {
+        errorMessage: "Manual tags payload must be a JSON object."
+    });
+
+    return validateManualMapping(record, {
+        valueDescription: "Manual tags"
+    });
+}

--- a/src/cli/tests/manual-payload-validation.test.js
+++ b/src/cli/tests/manual-payload-validation.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    decodeManualKeywordsPayload,
+    decodeManualTagsPayload
+} from "../lib/manual-payload-validation.js";
+import { isJsonParseError } from "../../shared/json-utils.js";
+
+test("decodeManualKeywordsPayload validates keyword mappings", () => {
+    const payload = decodeManualKeywordsPayload('{"foo": "bar"}');
+    assert.deepEqual(payload, { foo: "bar" });
+});
+
+test("decodeManualKeywordsPayload wraps JSON syntax errors", () => {
+    assert.throws(
+        () => decodeManualKeywordsPayload("not json"),
+        (error) => {
+            assert.ok(isJsonParseError(error));
+            assert.match(
+                error.message,
+                /Failed to parse manual keywords payload/i
+            );
+            return true;
+        }
+    );
+});
+
+test("decodeManualKeywordsPayload rejects non-string entries", () => {
+    assert.throws(
+        () => decodeManualKeywordsPayload('{"foo": 42}'),
+        /Manual keywords entry 'foo' must map to a string value\./
+    );
+});
+
+test("decodeManualTagsPayload validates tag mappings", () => {
+    const payload = decodeManualTagsPayload('{"foo.html": "tag"}');
+    assert.deepEqual(payload, { "foo.html": "tag" });
+});
+
+test("decodeManualTagsPayload enforces object shape", () => {
+    assert.throws(
+        () => decodeManualTagsPayload("[]"),
+        /Manual tags payload must be a JSON object\./
+    );
+});
+
+test("decodeManualTagsPayload rejects non-string entries", () => {
+    assert.throws(
+        () => decodeManualTagsPayload('{"foo": null}'),
+        /Manual tags entry 'foo' must map to a string value\./
+    );
+});


### PR DESCRIPTION
Seed PR for Codex to reinforce defensive programming anywhere external data is accepted without validation or functions rely on `any`/loosely typed parameters. Tighten inputs before they can propagate invalid states.
