### PR TITLE
Ensure Codex regression pings use user token

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -528,9 +528,10 @@ jobs:
             }
 
       - name: Request Codex help for regressions
-        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' }}
+        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && secrets.GH_USER_TOKEN != '' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_USER_TOKEN }}
           script: |
             const marker = '<!-- automerge-pr-regression-codex -->';
             const { owner, repo } = context.repo;
@@ -590,6 +591,11 @@ jobs:
             }
 
             core.notice(`Requested Codex assistance for regressions on PR #${number}.`);
+
+      - name: Warn when Codex user token missing
+        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && secrets.GH_USER_TOKEN == '' }}
+        run: |
+          echo "::warning::GH_USER_TOKEN secret is not configured; skipping Codex regression comment."
 
   auto-merge:
     name: Auto-merge when green


### PR DESCRIPTION
## Summary
- ensure the auto-merge regression ping uses the GH_USER_TOKEN so Codex receives a user-authored comment
- add a warning fallback when the GH_USER_TOKEN secret is missing so the workflow explains why no ping occurred

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f756d9852c832fa98da665e99cdcf6