### PR TITLE
Fix automerge workflow secret checks

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -114,6 +114,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       all_green: ${{ steps.regress.outputs.all_green }}
+    env:
+      GH_USER_TOKEN: ${{ secrets.GH_USER_TOKEN }}
     steps:
       - name: Checkout repo (for scripts)
         uses: actions/checkout@v4
@@ -528,10 +530,10 @@ jobs:
             }
 
       - name: Request Codex help for regressions
-        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && secrets.GH_USER_TOKEN != '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && env.GH_USER_TOKEN != '' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_USER_TOKEN }}
+          github-token: ${{ env.GH_USER_TOKEN }}
           script: |
             const marker = '<!-- automerge-pr-regression-codex -->';
             const { owner, repo } = context.repo;
@@ -593,7 +595,7 @@ jobs:
             core.notice(`Requested Codex assistance for regressions on PR #${number}.`);
 
       - name: Warn when Codex user token missing
-        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && secrets.GH_USER_TOKEN == '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.regress.outputs.status == 'regressions' && env.GH_USER_TOKEN == '' }}
         run: |
           echo "::warning::GH_USER_TOKEN secret is not configured; skipping Codex regression comment."
 


### PR DESCRIPTION
## Summary
- expose the GH_USER_TOKEN secret via job-level env for the summarize job
- update regression follow-up steps to rely on env.GH_USER_TOKEN instead of directly referencing the secrets context
- keep the Codex warning step working when the secret is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f83d126f7c832f8065b88e687e1755