### PR TITLE
Improve regression summary comment messaging

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -404,6 +404,37 @@ jobs:
               return fragments.join('; ');
             }
 
+            function summarizeRegressedTests(regressions, limit = 5) {
+              if (!Array.isArray(regressions) || regressions.length === 0) {
+                return '';
+              }
+
+              const descriptors = [];
+              for (const item of regressions) {
+                const descriptor = (item?.detail?.displayName || item?.key || '').trim();
+                if (descriptor) {
+                  descriptors.push(descriptor);
+                }
+              }
+
+              if (descriptors.length === 0) {
+                return '';
+              }
+
+              const normalizedLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 5;
+              const maxItems = Math.max(1, normalizedLimit);
+              const visible = descriptors.slice(0, maxItems);
+              const remaining = descriptors.length - visible.length;
+              const label = descriptors.length === 1 ? 'Impacted test' : 'Impacted tests';
+              const formatted = visible.map(name => `\`${name}\``).join(', ');
+
+              if (remaining > 0) {
+                return `${label} (showing ${visible.length} of ${descriptors.length}): ${formatted}`;
+              }
+
+              return `${label}: ${formatted}`;
+            }
+
             for (const tgt of targets) {
               const dir = path.join(process.cwd(), `junit-${tgt}`);
               const files = listFilesRecursive(dir);
@@ -495,19 +526,33 @@ jobs:
               statusLine = '✅ No test regressions detected — this PR will be auto-merged.';
             } else if (statusFlag === 'regressions') {
               let causeDetails = '';
+              let regressions = [];
               if (testResults.base?.usedDir) {
                 const targetKey = testResults.merge?.usedDir ? 'merge' : 'head';
                 const targetResults = testResults[targetKey];
                 if (targetResults?.usedDir && typeof detectRegressions === 'function') {
-                  const regressions = detectRegressions(testResults.base, targetResults);
+                  const computed = detectRegressions(testResults.base, targetResults);
+                  if (Array.isArray(computed)) {
+                    regressions = computed;
+                  }
                   const description = describeRegressionCause(regressions, diffStats[targetKey]);
                   causeDetails = description || '';
                 }
               }
+              const regressionSummary = summarizeRegressedTests(regressions, 5);
+              const summaryPart = regressionSummary ? `${regressionSummary}.` : '';
               if (causeDetails) {
-                statusLine = `❌ Test regressions detected — auto-merge is disabled (${causeDetails}).`;
+                statusLine = [
+                  '❌ Test regressions detected — auto-merge is disabled.',
+                  summaryPart,
+                  `Cause: ${causeDetails}.`
+                ].filter(Boolean).join(' ');
               } else {
-                statusLine = '❌ Test regressions detected — auto-merge is disabled (cause could not be determined from available data).';
+                statusLine = [
+                  '❌ Test regressions detected — auto-merge is disabled.',
+                  summaryPart,
+                  'Cause could not be determined from available data.'
+                ].filter(Boolean).join(' ');
               }
             } else if (statusFlag === 'error') {
               statusLine = '⚠️ Regression checks did not complete — auto-merge is blocked.';


### PR DESCRIPTION
## Summary
- add a helper that summarizes regressed tests for the auto-merge summary comment
- update the regression status message to include up to five failing tests and clearer cause text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f844ff14d8832fabf7038d19924583