### PR TITLE
Throw on unknown binary expression positions

### DIFF
--- a/src/parser/src/binary-expression-delegate.js
+++ b/src/parser/src/binary-expression-delegate.js
@@ -111,7 +111,9 @@ export default class BinaryExpressionDelegate {
             return parentOp.assoc === "left";
         }
 
-        return false;
+        throw new TypeError(
+            `Unknown parent binary position: ${String(parentBinary.position)}`
+        );
     }
 
     wrapInParentheses(ctx, node, astNode, position) {

--- a/src/plugin/src/project-index/index.js
+++ b/src/plugin/src/project-index/index.js
@@ -497,9 +497,13 @@ async function resolveDirectoryListing({
     signal
 }) {
     ensureNotAborted();
-    const entries = await listDirectory(fsFacade, directoryContext.absolutePath, {
-        signal
-    });
+    const entries = await listDirectory(
+        fsFacade,
+        directoryContext.absolutePath,
+        {
+            signal
+        }
+    );
     ensureNotAborted();
     metrics?.incrementCounter("io.directoriesScanned");
     return entries;


### PR DESCRIPTION
## Summary
- throw when the binary expression delegate receives an unexpected parent position to surface internal parser contract issues
- apply prettier's multiline formatting to the project index directory listing helper

## Testing
- npm test *(fails: 22 existing fixture assertions on baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68f8454a5800832f8111e6d148f3ad94