### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -41,3 +41,15 @@ no code changes were required.
   each call site, then updated `cli.js` to rely on the specialized views.
 - The CLI now imports the registry to wire up commands and the runner to launch
   the program, so each call site depends only on the capability it needs.
+
+## Follow-up audit (2025-02-20)
+
+- Located the `IdentifierCasePlanServices` bundle in
+  `src/plugin/src/identifier-case/plan-service.js`. The wide "service" facade
+  forced providers to manufacture preparation, rename lookup, and snapshot
+  collaborators together even when a consumer only required one capability.
+- Removed the bundle contract in favour of the existing
+  `IdentifierCasePlanPreparationService`, `IdentifierCaseRenameLookupService`,
+  and `IdentifierCasePlanSnapshotService` roles. Call sites now request and
+  override the specific collaborator they need without depending on an
+  aggregated service container.

--- a/src/plugin/tests/identifier-case-plan-service.test.js
+++ b/src/plugin/tests/identifier-case-plan-service.test.js
@@ -10,7 +10,6 @@ import {
     registerIdentifierCasePlanSnapshotProvider,
     registerIdentifierCaseRenameLookupProvider,
     resetIdentifierCasePlanServiceProvider,
-    resolveIdentifierCasePlanService,
     resolveIdentifierCasePlanPreparationService,
     resolveIdentifierCasePlanSnapshotService,
     resolveIdentifierCaseRenameLookupService
@@ -68,21 +67,22 @@ test(
     async () => {
         const calls = [];
 
-        const defaultServices = resolveIdentifierCasePlanService();
+        const defaultPreparation =
+            resolveIdentifierCasePlanPreparationService();
+        const defaultRenameLookup = resolveIdentifierCaseRenameLookupService();
+        const defaultSnapshot = resolveIdentifierCasePlanSnapshotService();
 
         registerIdentifierCasePlanPreparationProvider(() => ({
             async prepareIdentifierCasePlan(options) {
                 calls.push({ type: "prepare", options });
-                return defaultServices.preparation.prepareIdentifierCasePlan(
-                    options
-                );
+                return defaultPreparation.prepareIdentifierCasePlan(options);
             }
         }));
 
         registerIdentifierCaseRenameLookupProvider(() => ({
             getIdentifierCaseRenameForNode(node, options) {
                 calls.push({ type: "rename", node, options });
-                return defaultServices.renameLookup.getIdentifierCaseRenameForNode(
+                return defaultRenameLookup.getIdentifierCaseRenameForNode(
                     node,
                     options
                 );
@@ -92,13 +92,13 @@ test(
         registerIdentifierCasePlanSnapshotProvider(() => ({
             captureIdentifierCasePlanSnapshot(options) {
                 calls.push({ type: "capture", options });
-                return defaultServices.snapshot.captureIdentifierCasePlanSnapshot(
+                return defaultSnapshot.captureIdentifierCasePlanSnapshot(
                     options
                 );
             },
             applyIdentifierCasePlanSnapshot(snapshot, options) {
                 calls.push({ type: "apply", snapshot, options });
-                defaultServices.snapshot.applyIdentifierCasePlanSnapshot(
+                defaultSnapshot.applyIdentifierCasePlanSnapshot(
                     snapshot,
                     options
                 );


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
