### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/plugin/tests/project-index-file-category.test.js
+++ b/src/plugin/tests/project-index-file-category.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    ProjectFileCategory,
+    normalizeProjectFileCategory,
+    resolveProjectFileCategory
+} from "../src/project-index/index.js";
+
+test("normalizeProjectFileCategory accepts known categories", () => {
+    assert.equal(
+        normalizeProjectFileCategory(ProjectFileCategory.SOURCE),
+        ProjectFileCategory.SOURCE
+    );
+    assert.equal(
+        normalizeProjectFileCategory(ProjectFileCategory.RESOURCE_METADATA),
+        ProjectFileCategory.RESOURCE_METADATA
+    );
+});
+
+test("normalizeProjectFileCategory rejects unknown categories", () => {
+    assert.throws(
+        () => normalizeProjectFileCategory("yaml"),
+        /Project file category must be one of: /
+    );
+});
+
+test("resolveProjectFileCategory recognises GML source files", () => {
+    assert.equal(
+        resolveProjectFileCategory("scripts/player/move.gml"),
+        ProjectFileCategory.SOURCE
+    );
+});
+
+test("resolveProjectFileCategory recognises resource manifests", () => {
+    assert.equal(
+        resolveProjectFileCategory("objects/player/player.yy"),
+        ProjectFileCategory.RESOURCE_METADATA
+    );
+    assert.equal(
+        resolveProjectFileCategory("project/GameProject.yyp"),
+        ProjectFileCategory.RESOURCE_METADATA
+    );
+});
+
+test("resolveProjectFileCategory returns null for unrelated files", () => {
+    assert.equal(resolveProjectFileCategory("notes/readme.md"), null);
+});


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
