### PR TITLE
Codex: Add Extensibility Hook

### DIFF
--- a/docs/reserved-identifier-metadata-hook.md
+++ b/docs/reserved-identifier-metadata-hook.md
@@ -1,0 +1,28 @@
+# Reserved identifier metadata hook
+
+## Pre-change analysis
+- `loadReservedIdentifierNames` reads identifier metadata from
+  `resources/gml-identifiers.json` via a hard-coded `require` path. There is no
+  supported way to swap in alternate metadata when embedding the formatter in
+  tooling that works with bespoke GameMaker forks or staged rollouts.
+- Downstream modules such as identifier-case planning assume the metadata comes
+  from that bundled JSON file, so any consumer that needs to test or stage
+  different identifier inventories must patch modules in place.
+
+## Extension seam
+- Introduce a small configuration hook that allows callers to provide a
+  replacement metadata loader function. The hook will default back to the
+  bundled JSON loader so existing behaviour is preserved.
+- The loader override stays in-memory and is intentionally scoped to advanced
+  integrations (CLI experiments, editor previews, or testing fixtures). It keeps
+  the plugin opinionated by continuing to default to the shipped metadata.
+
+## Default behaviour and evolution
+- By default the loader continues to read `resources/gml-identifiers.json`.
+- Consumers should use the new `setReservedIdentifierMetadataLoader` helper in a
+  `try`/`finally` block alongside the provided reset function to stage custom
+  metadata for experiments or integration tests.
+- As the identifier metadata pipeline matures we can evolve the hook into a more
+  formal provider registry, but today it deliberately exposes the minimal surface
+  area needed to unblock alternate metadata sources without complicating the
+  public API.

--- a/src/plugin/src/resources/reserved-identifiers.js
+++ b/src/plugin/src/resources/reserved-identifiers.js
@@ -6,14 +6,61 @@ import { normalizeIdentifierMetadataEntries } from "../../../shared/identifier-m
 const require = createRequire(import.meta.url);
 
 const DEFAULT_EXCLUDED_TYPES = new Set(["literal", "keyword"]);
+const DEFAULT_IDENTIFIER_METADATA_PATH =
+    "../../../../resources/gml-identifiers.json";
 
-function loadIdentifierMetadata() {
+let metadataLoader = defaultLoadIdentifierMetadata;
+
+function defaultLoadIdentifierMetadata() {
     try {
-        const metadata = require("../../../../resources/gml-identifiers.json");
+        const metadata = require(DEFAULT_IDENTIFIER_METADATA_PATH);
         return metadata && typeof metadata === "object" ? metadata : null;
     } catch {
         return null;
     }
+}
+
+function loadIdentifierMetadata() {
+    try {
+        const metadata = metadataLoader();
+        return metadata && typeof metadata === "object" ? metadata : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Allow advanced integrations to supply alternate metadata at runtime while
+ * keeping the default loader pointed at the bundled JSON file.
+ *
+ * @param {() => unknown} loader
+ * @returns {() => void} Cleanup handler that restores the previous loader when
+ *          invoked. The handler is a no-op if the loader changed again.
+ */
+function setReservedIdentifierMetadataLoader(loader) {
+    if (typeof loader !== "function") {
+        resetReservedIdentifierMetadataLoader();
+        return () => {};
+    }
+
+    const previousLoader = metadataLoader;
+    const wrappedLoader = () => loader();
+
+    metadataLoader = wrappedLoader;
+
+    return () => {
+        if (metadataLoader === wrappedLoader) {
+            metadataLoader = previousLoader;
+        }
+    };
+}
+
+/**
+ * Restore the reserved identifier metadata loader back to the bundled JSON
+ * implementation.
+ */
+function resetReservedIdentifierMetadataLoader() {
+    metadataLoader = defaultLoadIdentifierMetadata;
 }
 
 function resolveExcludedTypes(types) {
@@ -45,3 +92,9 @@ export function loadReservedIdentifierNames({ disallowedTypes } = {}) {
 
     return names;
 }
+
+export {
+    DEFAULT_IDENTIFIER_METADATA_PATH,
+    resetReservedIdentifierMetadataLoader,
+    setReservedIdentifierMetadataLoader
+};

--- a/src/plugin/tests/reserved-identifiers.test.js
+++ b/src/plugin/tests/reserved-identifiers.test.js
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { loadReservedIdentifierNames } from "../src/resources/reserved-identifiers.js";
+import {
+    loadReservedIdentifierNames,
+    resetReservedIdentifierMetadataLoader,
+    setReservedIdentifierMetadataLoader
+} from "../src/resources/reserved-identifiers.js";
 
 test("loadReservedIdentifierNames returns lowercase reserved names", () => {
     const reserved = loadReservedIdentifierNames();
@@ -16,3 +20,33 @@ test("loadReservedIdentifierNames respects custom disallowed types", () => {
 
     assert.equal(reserved.has("if"), true);
 });
+
+test(
+    "loadReservedIdentifierNames allows overriding the metadata loader",
+    { concurrency: 1 },
+    () => {
+        const restore = setReservedIdentifierMetadataLoader(() => ({
+            identifiers: {
+                custom_keyword: { type: "keyword" },
+                custom_function: { type: "function" }
+            }
+        }));
+
+        try {
+            const reserved = loadReservedIdentifierNames({
+                disallowedTypes: ["keyword"]
+            });
+
+            assert.equal(reserved.has("custom_keyword"), false);
+            assert.equal(reserved.has("custom_function"), true);
+            assert.equal(reserved.has("abs"), false);
+        } finally {
+            restore();
+            resetReservedIdentifierMetadataLoader();
+        }
+
+        const reserved = loadReservedIdentifierNames();
+
+        assert.equal(reserved.has("abs"), true);
+    }
+);


### PR DESCRIPTION
Seed PR for Codex to implement a targeted extensibility improvement while
keeping the defaults opinionated.

## Requirements
- Document the rigid decision point that makes extension difficult today.
- Explain the minimal seam or hook you will add before touching code.
- Avoid exposing new end-user configuration unless it is indispensable;
  prefer sensible defaults and internal extension points.
- When a new hook or option is warranted, clearly state who should use
  it, the default value, and the guardrails that keep the behavior
  predictable for everyone else.
- Update any impacted docs or inline comments, and keep behavior
  unchanged by default.
