### PR TITLE
Codex: POLA Behaviour Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Template strings that never interpolate expressions automatically collapse back 
 | `condenseLogicalExpressions` | `false` | Merges adjacent logical expressions that use the same operator. |
 | `preserveGlobalVarStatements` | `true` | Keeps `globalvar` declarations while still prefixing later assignments with `global.`. |
 | `alignAssignmentsMinGroupSize` | `3` | Aligns simple assignment operators across consecutive lines once the group size threshold is met. |
-| `maxParamsPerLine` | `0` | Forces argument wrapping after the specified count (`0` keeps the original layout). |
+| `maxParamsPerLine` | `0` | Forces argument wrapping after the specified count (set to `0` to remove the numeric limit; nested callbacks may still wrap for readability). |
 | `applyFeatherFixes` | `false` | Applies opt-in fixes backed by GameMaker Feather metadata (e.g. drop trailing semicolons from `#macro`). |
 | `useStringInterpolation` | `false` | Upgrades eligible string concatenations to template strings (`$"Hello {name}"`). |
 | `convertDivisionToMultiplication` | `false` | Rewrites division by literals into multiplication by the reciprocal when safe. |

--- a/src/plugin/src/component-providers/default-plugin-components.js
+++ b/src/plugin/src/component-providers/default-plugin-components.js
@@ -111,7 +111,7 @@ export function createDefaultGmlPluginComponents() {
                 default: 0,
                 range: { start: 0, end: Infinity },
                 description:
-                    "Maximum number of arguments allowed on a single line before a function call is forced to wrap. Set to 0 to disable."
+                    "Maximum number of arguments allowed on a single line before a function call is forced to wrap. Set to 0 to disable the numeric limit (nested callback arguments may still wrap for readability)."
             },
             applyFeatherFixes: {
                 since: "0.0.0",


### PR DESCRIPTION
Seed PR for Codex to reconcile option documentation and inline comments with the behaviours the formatter actually ships.
