### PR TITLE
Respect Prettier objectWrap for struct literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,22 @@ Line comments automatically drop YoYo Games' generated banner message (`Script a
 
 > **Note:** The formatter intentionally enforces canonical whitespace. Legacy escape hatches such as `preserveLineBreaks` and the `maintain*Indentation` toggles were removed to keep formatting deterministic.
 
+Bare struct literals now respect Prettier's [`objectWrap`](https://prettier.io/docs/en/options.html#object-wrap) option introduced in v3.5.0. When formatting GML, the plugin maps the behaviour directly onto struct literals:
+
+- `objectWrap: "preserve"` (default) keeps the literal multi-line when the original source placed a newline immediately after `{`.
+- `objectWrap: "collapse"` inlines eligible literals onto a single line when they fit within the configured `printWidth`.
+
+```gml
+// objectWrap: "preserve"
+var enemy = {
+    name: "Slime",
+    hp: 5
+};
+
+// objectWrap: "collapse"
+var enemy = {name: "Slime", hp: 5};
+```
+
 Bare decimal literals are always padded with leading and trailing zeroes to improve readability.
 
 Banner line comments are automatically detected when they contain five or more consecutive `/` characters. Once identified, the formatter rewrites the banner prefix to 60 slashes so mixed-width comment markers settle on a single, readable standard.

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -77,6 +77,17 @@ const {
 } = builders;
 const { willBreak } = utils;
 
+const ObjectWrapOption = Object.freeze({
+    PRESERVE: "preserve",
+    COLLAPSE: "collapse"
+});
+
+function resolveObjectWrapOption(options) {
+    return options?.objectWrap === ObjectWrapOption.COLLAPSE
+        ? ObjectWrapOption.COLLAPSE
+        : ObjectWrapOption.PRESERVE;
+}
+
 const preservedUndefinedDefaultParameters = new WeakSet();
 const suppressedImplicitDocCanonicalByNode = new WeakMap();
 const preferredParamDocNamesByNode = new WeakMap();
@@ -966,6 +977,12 @@ export function print(path, options, print) {
             if (node.properties.length === 0) {
                 return concat(printEmptyBlock(path, options, print));
             }
+
+            const objectWrapOption = resolveObjectWrapOption(options);
+            const shouldPreserveStructWrap =
+                objectWrapOption === ObjectWrapOption.PRESERVE &&
+                structLiteralHasLeadingLineBreak(node, options);
+
             return concat(
                 printCommaSeparatedList(
                     path,
@@ -975,7 +992,8 @@ export function print(path, options, print) {
                     "}",
                     options,
                     {
-                        forceBreak: node.hasTrailingComma,
+                        forceBreak:
+                            node.hasTrailingComma || shouldPreserveStructWrap,
                         // TODO: Keep struct literals flush with their braces for
                         // now. GameMaker's runtime formatter and the examples in
                         // the manual (https://manual.gamemaker.io/monthly/en/#t=GameMaker_Language%2FGML_Reference%2FVariable_Functions%2FStructs.htm)
@@ -4442,6 +4460,103 @@ function shouldPreserveCompactUpdateAssignmentSpacing(path, options) {
     }
 
     return true;
+}
+
+function structLiteralHasLeadingLineBreak(node, options) {
+    if (!node || !options || typeof options.originalText !== "string") {
+        return false;
+    }
+
+    if (!Array.isArray(node.properties) || node.properties.length === 0) {
+        return false;
+    }
+
+    const { start, end } = getNodeRangeIndices(node);
+    if (start == null || end == null || end <= start) {
+        return false;
+    }
+
+    const source = options.originalText.slice(start, end);
+    const openBraceIndex = source.indexOf("{");
+    if (openBraceIndex === -1) {
+        return false;
+    }
+
+    for (let index = openBraceIndex + 1; index < source.length; index += 1) {
+        const character = source[index];
+
+        if (character === "\n") {
+            return true;
+        }
+
+        if (character === "\r") {
+            if (source[index + 1] === "\n") {
+                return true;
+            }
+            return true;
+        }
+
+        if (character.trim() === "") {
+            continue;
+        }
+
+        if (character === "/") {
+            const lookahead = source[index + 1];
+
+            if (lookahead === "/") {
+                index += 2;
+                while (index < source.length) {
+                    const commentChar = source[index];
+                    if (commentChar === "\n") {
+                        return true;
+                    }
+                    if (commentChar === "\r") {
+                        if (source[index + 1] === "\n") {
+                            return true;
+                        }
+                        return true;
+                    }
+
+                    index += 1;
+                }
+
+                return false;
+            }
+
+            if (lookahead === "*") {
+                index += 2;
+                while (index < source.length - 1) {
+                    const commentChar = source[index];
+                    if (commentChar === "\n") {
+                        return true;
+                    }
+                    if (commentChar === "\r") {
+                        if (source[index + 1] === "\n") {
+                            return true;
+                        }
+                        return true;
+                    }
+
+                    if (commentChar === "*" && source[index + 1] === "/") {
+                        index += 1;
+                        break;
+                    }
+
+                    index += 1;
+                }
+
+                continue;
+            }
+        }
+
+        if (character === "}") {
+            return false;
+        }
+
+        return false;
+    }
+
+    return false;
 }
 
 function getStructPropertyPrefix(node, options) {

--- a/src/plugin/tests/object-wrap-option.test.js
+++ b/src/plugin/tests/object-wrap-option.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import prettier from "prettier";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+
+async function format(source, options = {}) {
+    return prettier.format(source, {
+        parser: "gml-parse",
+        plugins: [pluginPath],
+        ...options
+    });
+}
+
+test("struct literals stay multi-line when objectWrap preserves the leading break", async () => {
+    const source = [
+        "var enemy = {",
+        '    name: "Slime",',
+        "    hp: 5",
+        "};"
+    ].join("\n");
+
+    const formatted = await format(source, { objectWrap: "preserve" });
+
+    assert.strictEqual(
+        formatted,
+        ["var enemy = {", '    name: "Slime",', "    hp: 5", "};", ""].join(
+            "\n"
+        )
+    );
+});
+
+test("struct literals collapse to a single line when objectWrap is set to collapse", async () => {
+    const source = [
+        "var enemy = {",
+        '    name: "Slime",',
+        "    hp: 5",
+        "};"
+    ].join("\n");
+
+    const formatted = await format(source, { objectWrap: "collapse" });
+
+    assert.strictEqual(
+        formatted,
+        ['var enemy = {name: "Slime", hp: 5};', ""].join("\n")
+    );
+});
+
+test("collapsed structs still wrap when the literal exceeds the print width", async () => {
+    const source = [
+        "var config = {",
+        '    title: "a very very very long title that exceeds the configured print width",',
+        "    enabled: true",
+        "};"
+    ].join("\n");
+
+    const formatted = await format(source, {
+        objectWrap: "collapse",
+        printWidth: 60
+    });
+
+    assert.strictEqual(
+        formatted,
+        [
+            "var config = {",
+            '    title: "a very very very long title that exceeds the configured print width",',
+            "    enabled: true",
+            "};",
+            ""
+        ].join("\n")
+    );
+});


### PR DESCRIPTION
## Summary
- honor Prettier's `objectWrap` option when deciding whether struct literals should stay multi-line or collapse
- add coverage for both `objectWrap` modes plus long-value wrapping to the plugin test suite
- document how the option maps onto GML structs in the configuration reference

## Testing
- node --test src/plugin/tests/object-wrap-option.test.js
- npm run test:plugin *(fails: existing fixture expectations differ from formatter output)*

------
https://chatgpt.com/codex/tasks/task_e_68f8e8040cd0832f8cc9050b95eb1bb3