### PR TITLE
Fix fallback handling for implicit argument doc comments

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -2768,12 +2768,37 @@ function mergeSyntheticDocComments(
     }
     const usedParamLineIndices = new Set();
 
+    const implicitEntriesForMerge =
+        node?.type === "FunctionDeclaration"
+            ? collectImplicitArgumentDocNames(node, options)
+            : [];
+    const implicitEntryByCanonical = new Map();
+    for (const entry of implicitEntriesForMerge) {
+        if (entry?.canonical) {
+            implicitEntryByCanonical.set(entry.canonical, entry);
+        }
+    }
+
     if (otherLines.length > 0) {
         const normalizedOtherLines = [];
 
         for (const line of otherLines) {
             const metadata = parseDocCommentMetadata(line);
             const canonical = getParamCanonicalName(line, metadata);
+            const implicitEntry =
+                canonical && implicitEntryByCanonical.has(canonical)
+                    ? implicitEntryByCanonical.get(canonical)
+                    : null;
+
+            if (
+                implicitEntry &&
+                implicitEntry.canonical === implicitEntry.fallbackCanonical &&
+                Array.isArray(node?.params) &&
+                node.params.length > 0 &&
+                paramLineIndices.size >= node.params.length
+            ) {
+                continue;
+            }
 
             if (
                 canonical &&
@@ -2798,7 +2823,12 @@ function mergeSyntheticDocComments(
             if (
                 metadata?.tag === "param" &&
                 typeof metadata?.name === "string" &&
-                metadata.name.length > 0
+                metadata.name.length > 0 &&
+                !/^\s*argument\d+\s*$/i.test(metadata.name) &&
+                Array.isArray(node?.params) &&
+                node.params.length > 0 &&
+                paramLineIndices.size >= node.params.length &&
+                implicitEntry?.hasDirectReference !== true
             ) {
                 let fallbackLineIndex = null;
 
@@ -2823,6 +2853,15 @@ function mergeSyntheticDocComments(
                     usedParamLineIndices.add(fallbackLineIndex);
                     continue;
                 }
+            }
+
+            if (
+                implicitEntry?.hasDirectReference === true &&
+                Array.isArray(node?.params) &&
+                node.params.length > 0 &&
+                paramLineIndices.size >= node.params.length
+            ) {
+                continue;
             }
 
             normalizedOtherLines.push(line);


### PR DESCRIPTION
## Summary
- skip reassigning doc comment lines to fallback argument names when implicit references already have explicit docs
- avoid reusing ordinal doc comment lines for implicit arguments in functions without parameters
- ignore synthetic implicit-doc entries with direct references once existing docs cover their parameters

## Testing
- node --test src/plugin/tests/doc-comment-order.test.js
- node --test src/plugin/tests/doc-comment-implicit-params.test.js
- npm test *(fails: known fixture mismatches in src/plugin/tests/plugin.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f908fa1d88832f8b01cf418b958983