### PR TITLE
Codex: Preserve blank lines after sanitized enums

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -2003,9 +2003,15 @@ function printStatements(path, options, print, childrenAttribute) {
 
         const currentNodeRequiresNewline =
             shouldAddNewlinesAroundStatement(node, options) && isTopLevel;
+        const isAtStartOfProgram =
+            isTopLevel && (nodeStartIndex == null || nodeStartIndex <= 0);
 
         // Check if a newline should be added BEFORE the statement
-        if (currentNodeRequiresNewline && !previousNodeHadNewlineAddedAfter) {
+        if (
+            currentNodeRequiresNewline &&
+            !previousNodeHadNewlineAddedAfter &&
+            !isAtStartOfProgram
+        ) {
             const hasLeadingComment = isTopLevel
                 ? hasCommentImmediatelyBefore(originalTextCache, nodeStartIndex)
                 : false;

--- a/src/plugin/src/printer/util.js
+++ b/src/plugin/src/printer/util.js
@@ -71,7 +71,8 @@ const NODE_TYPES_WITH_SURROUNDING_NEWLINES = new Set([
     "FunctionDeclaration",
     "ConstructorDeclaration",
     "RegionStatement",
-    "EndRegionStatement"
+    "EndRegionStatement",
+    "EnumDeclaration"
 ]);
 
 /**

--- a/src/plugin/tests/feather-enum-spacing.test.js
+++ b/src/plugin/tests/feather-enum-spacing.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import prettier from "prettier";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+
+const source = [
+    "enum First {",
+    '    A = "0",',
+    '    B = "1"',
+    "}",
+    "",
+    "enum Second {",
+    '    VALUE = "2"',
+    "}",
+    "",
+    "// marker",
+    "enum Third {",
+    '    FINAL = "3"',
+    "}",
+    ""
+].join("\n");
+
+test("preserves blank lines between sanitized enums when Feather fixes normalize initializers", async () => {
+    const formatted = await prettier.format(source, {
+        parser: "gml-parse",
+        plugins: [pluginPath],
+        applyFeatherFixes: true
+    });
+
+    assert.match(
+        formatted,
+        /}\n\nenum Second \{/,
+        "Expected a blank line between the first and second enums."
+    );
+
+    assert.match(
+        formatted,
+        /marker\n\nenum Third \{/,
+        "Expected a blank line between the comment marker and the third enum."
+    );
+});


### PR DESCRIPTION
## Summary
- ensure enum declarations participate in the printer's surrounding-blank-line logic without adding an extra blank line at the top of files
- add a focused test that demonstrates Feather fixes keep blank lines between sanitized enums

## Testing
- node --test src/plugin/tests/feather-enum-spacing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fa0eb0f964832f868d6babed8273bf