### PR TITLE
Codex: normalize manual utils exports

### DIFF
--- a/src/cli/lib/manual/utils.js
+++ b/src/cli/lib/manual/utils.js
@@ -11,7 +11,6 @@ import { formatDuration } from "../time-utils.js";
 import { formatBytes } from "../byte-format.js";
 import { writeManualFile } from "../manual-file-helpers.js";
 
-
 const MANUAL_CACHE_ROOT_ENV_VAR = "GML_MANUAL_CACHE_ROOT";
 
 /**
@@ -377,18 +376,19 @@ function createManualGitHubFileClient({
 }
 
 export {
-    
     MANUAL_CACHE_ROOT_ENV_VAR,
-    
-    
     createManualVerboseState,
-    
-    
-    
     resolveManualCacheRoot,
     createManualGitHubRequestDispatcher,
     createManualGitHubCommitResolver,
     createManualGitHubRefResolver,
     createManualGitHubFileClient
 };
-export {DEFAULT_MANUAL_REPO, MANUAL_REPO_ENV_VAR, MANUAL_REPO_REQUIREMENT_SOURCE, buildManualRepositoryEndpoints, normalizeManualRepository, resolveManualRepoValue} from "./repository.js";
+export {
+    DEFAULT_MANUAL_REPO,
+    MANUAL_REPO_ENV_VAR,
+    MANUAL_REPO_REQUIREMENT_SOURCE,
+    buildManualRepositoryEndpoints,
+    normalizeManualRepository,
+    resolveManualRepoValue
+} from "./repository.js";


### PR DESCRIPTION
## Summary
- normalize the manual utilities export block with Prettier so the PR branch cleanly formats after resolving merge artifacts

## Testing
- npm run format:check
- npm run lint *(fails: repository still has 1,286 pre-existing lint warnings)*
- npm test *(fails: repository still has 12 pre-existing failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68f9945fff14832f893dd0ebb762119e