### PR TITLE
Codex: Restore enum spacing handling

### DIFF
--- a/src/plugin/src/printer/enum-alignment.js
+++ b/src/plugin/src/printer/enum-alignment.js
@@ -20,7 +20,9 @@ export function prepareEnumMembersForPrinting(enumNode, getNodeName) {
         resolveName
     );
 
-    const shouldAlignInitializers = maxInitializerNameLength > 0;
+    const shouldAlignInitializers =
+        maxInitializerNameLength > 0 &&
+        memberStats.every((entry) => entry.hasInitializer);
 
     const maxMemberWidth = applyEnumMemberAlignment({
         memberStats,

--- a/src/plugin/src/printer/util.js
+++ b/src/plugin/src/printer/util.js
@@ -71,7 +71,8 @@ const NODE_TYPES_WITH_SURROUNDING_NEWLINES = new Set([
     "FunctionDeclaration",
     "ConstructorDeclaration",
     "RegionStatement",
-    "EndRegionStatement"
+    "EndRegionStatement",
+    "EnumDeclaration"
 ]);
 
 /**

--- a/src/plugin/tests/enum-spacing.test.js
+++ b/src/plugin/tests/enum-spacing.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import prettier from "prettier";
+
+const currentDirectory = fileURLToPath(new URL(".", import.meta.url));
+const pluginPath = path.resolve(currentDirectory, "../src/gml.js");
+
+async function formatWithPlugin(source) {
+    return prettier.format(source, {
+        parser: "gml-parse",
+        plugins: [pluginPath]
+    });
+}
+
+test("inserts a blank line between top-level enum declarations", async () => {
+    const source = [
+        "enum First {",
+        "    one = 1,",
+        "    two",
+        "}",
+        "",
+        "enum Second {",
+        "    value = 2",
+        "}",
+        ""
+    ].join("\n");
+
+    const formatted = await formatWithPlugin(source);
+    const lines = formatted.trim().split("\n");
+
+    assert.equal(
+        lines[4],
+        "",
+        "Expected a blank line between consecutive top-level enum declarations."
+    );
+});
+
+test("does not align enum initializers when only some members declare values", async () => {
+    const source = [
+        "enum Mixed {",
+        "    short = 1,",
+        "    longer = 2,",
+        "    trailing",
+        "}",
+        ""
+    ].join("\n");
+
+    const formatted = await formatWithPlugin(source);
+    const lines = formatted.trim().split("\n");
+
+    assert.equal(
+        lines[1],
+        "    short = 1,",
+        "Expected enum members with initializers to keep a single space before '='."
+    );
+    assert.equal(
+        lines[2],
+        "    longer = 2,",
+        "Expected initializer alignment to be skipped when not all members declare values."
+    );
+});


### PR DESCRIPTION
## Summary
- ensure top-level enum declarations emit surrounding newlines so adjacent enums retain blank separators
- restrict enum initializer alignment to cases where all members define values to avoid padding mixed enums
- add focused regression tests covering enum spacing and alignment behavior

## Testing
- node --test src/plugin/tests/enum-spacing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68fa01a9bcbc832f8bcf2471ed4eb101