### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/cli/commands/detect-test-regressions.mjs
+++ b/src/cli/commands/detect-test-regressions.mjs
@@ -16,6 +16,7 @@ import {
     toTrimmedString
 } from "../lib/shared-deps.js";
 import { CliUsageError, handleCliError } from "../lib/cli-errors.js";
+import { ensureMap } from "../../shared/utils/capability-probes.js";
 
 let parser;
 
@@ -692,7 +693,7 @@ function shouldSkipRegressionDetection(baseStats, targetStats) {
  */
 function resolveResultsMap(resultSet) {
     const { results } = resultSet ?? {};
-    return results instanceof Map ? results : new Map();
+    return ensureMap(results);
 }
 
 function createRegressionRecord({ baseResults, key, targetRecord }) {

--- a/src/cli/tests/detect-test-regressions.test.js
+++ b/src/cli/tests/detect-test-regressions.test.js
@@ -376,3 +376,55 @@ test("detectResolvedFailures returns failures that now pass or are missing", () 
     assert.strictEqual(regressions.length, 1);
     assert.strictEqual(regressions[0].key, "sample :: test :: new failure");
 });
+
+test("detectRegressions accepts heterogeneous result containers", () => {
+    const base = {
+        results: {
+            "suite :: test :: scenario": {
+                key: "suite :: test :: scenario",
+                status: "passed"
+            }
+        },
+        stats: { total: 1, passed: 1, failed: 0, skipped: 0 }
+    };
+
+    const backing = new Map([
+        [
+            "suite :: test :: scenario",
+            {
+                key: "suite :: test :: scenario",
+                status: "failed",
+                displayName: "suite :: test :: scenario"
+            }
+        ]
+    ]);
+
+    const target = {
+        results: {
+            get(key) {
+                return backing.get(key);
+            },
+            set(key, value) {
+                backing.set(key, value);
+                return this;
+            },
+            entries() {
+                return backing.entries();
+            },
+            [Symbol.iterator]() {
+                return backing[Symbol.iterator]();
+            }
+        },
+        stats: { total: 1, passed: 0, failed: 1, skipped: 0 }
+    };
+
+    const regressions = detectRegressions(base, target);
+
+    assert.equal(regressions.length, 1);
+    assert.equal(regressions[0].from, "passed");
+    assert.equal(regressions[0].to, "failed");
+    assert.equal(
+        regressions[0].detail?.displayName,
+        "suite :: test :: scenario"
+    );
+});

--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -37,6 +37,7 @@ import {
     isArrayIndex,
     isNonEmptyArray
 } from "../../../shared/array-utils.js";
+import { ensureSet } from "../../../shared/utils/capability-probes.js";
 import {
     getOrCreateMapEntry,
     hasOwn,
@@ -6182,14 +6183,7 @@ function registerSanitizedMacroName(ast, macroName) {
         return;
     }
 
-    let registry = ast._featherSanitizedMacroNames;
-
-    if (registry instanceof Set) {
-        registry.add(macroName);
-        return;
-    }
-
-    registry = Array.isArray(registry) ? new Set(registry) : new Set();
+    const registry = ensureSet(ast._featherSanitizedMacroNames);
 
     registry.add(macroName);
     ast._featherSanitizedMacroNames = registry;

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -37,6 +37,7 @@ import {
     toTrimmedString
 } from "../../../shared/string-utils.js";
 import { isNonEmptyArray } from "../../../shared/array-utils.js";
+import { ensureSet } from "../../../shared/utils/capability-probes.js";
 import {
     getNodeStartIndex,
     getNodeEndIndex,
@@ -6253,21 +6254,13 @@ function getSanitizedMacroNames(path) {
                 return null;
             }
 
-            if (names instanceof Set) {
-                return names.size > 0 ? names : null;
-            }
+            const registry = ensureSet(names);
 
-            if (Array.isArray(names)) {
-                if (names.length === 0) {
-                    return null;
-                }
-
-                const registry = new Set(names);
+            if (registry !== names) {
                 ancestor._featherSanitizedMacroNames = registry;
-                return registry;
             }
 
-            return null;
+            return registry.size > 0 ? registry : null;
         }
 
         depth += 1;

--- a/src/shared/utils/capability-probes.js
+++ b/src/shared/utils/capability-probes.js
@@ -183,3 +183,62 @@ export function getIterableSize(iterable) {
 
     return count;
 }
+
+function getIteratorEntries(iterable) {
+    const iterator = getIterator(iterable);
+    if (!iterator) {
+        return [];
+    }
+
+    const entries = [];
+    for (const entry of iterator) {
+        if (!Array.isArray(entry) || entry.length < 2) {
+            return [];
+        }
+
+        entries.push([entry[0], entry[1]]);
+    }
+
+    return entries;
+}
+
+export function ensureSet(candidate) {
+    if (isSetLike(candidate)) {
+        return candidate;
+    }
+
+    if (Array.isArray(candidate)) {
+        return new Set(candidate);
+    }
+
+    if (candidate && typeof candidate !== "string" && hasIterator(candidate)) {
+        return new Set(candidate);
+    }
+
+    return new Set();
+}
+
+export function ensureMap(candidate) {
+    if (isMapLike(candidate)) {
+        return candidate;
+    }
+
+    if (isSetLike(candidate)) {
+        return new Map();
+    }
+
+    if (Array.isArray(candidate)) {
+        return new Map(candidate);
+    }
+
+    if (candidate && typeof candidate !== "string" && hasIterator(candidate)) {
+        const entries = getIteratorEntries(candidate);
+        return new Map(entries);
+    }
+
+    if (isObjectLike(candidate)) {
+        return new Map(Object.entries(candidate));
+    }
+
+    return new Map();
+}


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
