### PR TITLE
Codex: Defensive Input Hardening

### DIFF
--- a/src/plugin/src/project-index/resource-analysis.js
+++ b/src/plugin/src/project-index/resource-analysis.js
@@ -21,6 +21,20 @@ import { normalizeProjectResourcePath } from "./path-normalization.js";
 
 const RESOURCE_ANALYSIS_ABORT_MESSAGE = "Project index build was aborted.";
 
+function normalizeResourceDocumentMetadata(resourceData) {
+    if (!resourceData || typeof resourceData !== "object") {
+        return { name: null, resourceType: null };
+    }
+
+    const { name, resourceType } = resourceData;
+    const normalizedName = isNonEmptyTrimmedString(name) ? name : null;
+    const normalizedResourceType = isNonEmptyTrimmedString(resourceType)
+        ? resourceType
+        : null;
+
+    return { name: normalizedName, resourceType: normalizedResourceType };
+}
+
 function deriveScopeId(kind, parts) {
     const suffix = Array.isArray(parts)
         ? parts.join("::")
@@ -29,6 +43,8 @@ function deriveScopeId(kind, parts) {
 }
 
 function ensureResourceRecord(resourcesMap, resourcePath, resourceData = {}) {
+    const { name: normalizedName, resourceType: normalizedResourceType } =
+        normalizeResourceDocumentMetadata(resourceData);
     const record = getOrCreateMapEntry(resourcesMap, resourcePath, () => {
         const lowerPath = resourcePath.toLowerCase();
         let defaultName = path.posix.basename(resourcePath);
@@ -43,22 +59,22 @@ function ensureResourceRecord(resourcesMap, resourcePath, resourceData = {}) {
 
         return {
             path: resourcePath,
-            name: resourceData.name ?? defaultName,
-            resourceType: resourceData.resourceType ?? "unknown",
+            name: normalizedName ?? defaultName,
+            resourceType: normalizedResourceType ?? "unknown",
             scopes: [],
             gmlFiles: [],
             assetReferences: []
         };
     });
 
-    if (resourceData.name && record.name !== resourceData.name) {
-        record.name = resourceData.name;
+    if (normalizedName && record.name !== normalizedName) {
+        record.name = normalizedName;
     }
     if (
-        resourceData.resourceType &&
-        record.resourceType !== resourceData.resourceType
+        normalizedResourceType &&
+        record.resourceType !== normalizedResourceType
     ) {
-        record.resourceType = resourceData.resourceType;
+        record.resourceType = normalizedResourceType;
     }
 
     return record;

--- a/src/plugin/tests/project-index-resource-analysis.test.js
+++ b/src/plugin/tests/project-index-resource-analysis.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analyseResourceFiles } from "../src/project-index/resource-analysis.js";
+
+test("analyseResourceFiles normalizes invalid resource metadata", async () => {
+    const projectRoot = "/project";
+    const relativePath = "scripts/calc_damage/calc_damage.yy";
+    const absolutePath = `${projectRoot}/${relativePath}`;
+
+    const yyFiles = [
+        {
+            relativePath,
+            absolutePath
+        }
+    ];
+
+    const fsFacade = {
+        async readFile(path) {
+            assert.equal(
+                path,
+                absolutePath,
+                "expected resource document to be read"
+            );
+
+            return JSON.stringify({
+                name: { text: "calc_damage" },
+                resourceType: "GMScript"
+            });
+        }
+    };
+
+    const context = await analyseResourceFiles({
+        projectRoot,
+        yyFiles,
+        fsFacade
+    });
+
+    const resourceRecord = context.resourcesMap.get(relativePath);
+    assert.ok(resourceRecord, "expected resource record to be captured");
+    assert.equal(
+        resourceRecord.name,
+        "calc_damage",
+        "expected invalid resource name to fall back to the file stem"
+    );
+    assert.equal(
+        resourceRecord.resourceType,
+        "GMScript",
+        "expected resource type to remain intact"
+    );
+
+    const scopeId = context.scriptNameToScopeId.get("calc_damage");
+    assert.ok(
+        scopeId?.startsWith("scope:script:"),
+        "expected script scope identifier to be recorded with fallback name"
+    );
+
+    const resourcePath = context.scriptNameToResourcePath.get("calc_damage");
+    assert.equal(
+        resourcePath,
+        resourceRecord.path,
+        "expected script path lookup to reuse normalized resource name"
+    );
+});


### PR DESCRIPTION
Seed PR for Codex to reinforce defensive programming anywhere external data is accepted without validation or functions rely on `any`/loosely typed parameters. Tighten inputs before they can propagate invalid states.
