### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/cli/lib/plugin-service-providers/default-plugin-services.js
+++ b/src/cli/lib/plugin-service-providers/default-plugin-services.js
@@ -35,12 +35,6 @@ import { assertFunction } from "../shared-deps.js";
  */
 
 /**
- * @typedef {object} CliIdentifierCasePlanService
- * @property {(options: object) => Promise<void>} prepareIdentifierCasePlan
- * @property {() => void} clearIdentifierCaseCaches
- */
-
-/**
  * The previous default CLI plugin services registry combined the raw builder
  * functions with their scoped service facades under a single
  * `defaultCliPluginServices` object. That catch-all contract forced callers
@@ -126,13 +120,6 @@ export function createDefaultCliPluginServices(descriptorSource) {
         })
     );
 
-    const identifierCasePlanService = Object.freeze(
-        /** @type {CliIdentifierCasePlanService} */ ({
-            ...identifierCasePlanPreparationService,
-            ...identifierCasePlanCacheService
-        })
-    );
-
     const identifierCaseServices = Object.freeze(
         /** @type {CliIdentifierCaseServices} */ ({
             preparation: identifierCasePlanPreparationService,
@@ -152,7 +139,6 @@ export function createDefaultCliPluginServices(descriptorSource) {
         identifierCasePlanPreparer,
         identifierCaseCacheClearer,
         projectIndexService,
-        identifierCasePlanService,
         identifierCasePlanPreparationService,
         identifierCasePlanCacheService,
         identifierCaseServices,
@@ -165,7 +151,6 @@ const {
     identifierCasePlanPreparer: defaultIdentifierCasePlanPreparer,
     identifierCaseCacheClearer: defaultIdentifierCaseCacheClearer,
     projectIndexService: defaultCliProjectIndexService,
-    identifierCasePlanService: defaultCliIdentifierCasePlanService,
     identifierCasePlanPreparationService:
         defaultCliIdentifierCasePlanPreparationService,
     identifierCasePlanCacheService: defaultCliIdentifierCaseCacheService,
@@ -178,7 +163,6 @@ export { defaultIdentifierCasePlanPreparer };
 export { defaultIdentifierCaseCacheClearer };
 
 export { defaultCliProjectIndexService };
-export { defaultCliIdentifierCasePlanService };
 export { defaultCliIdentifierCasePlanPreparationService };
 export { defaultCliIdentifierCaseCacheService };
 export { defaultCliIdentifierCaseServices };

--- a/src/cli/tests/cli-plugin-service-registry.test.js
+++ b/src/cli/tests/cli-plugin-service-registry.test.js
@@ -3,7 +3,6 @@ import test from "node:test";
 
 import {
     createDefaultCliPluginServices,
-    defaultCliIdentifierCasePlanService,
     defaultCliIdentifierCasePlanPreparationService,
     defaultCliIdentifierCaseCacheService,
     defaultCliIdentifierCaseServices,
@@ -44,22 +43,6 @@ test("CLI plugin services expose validated defaults", () => {
         services.identifierCase,
         identifierCaseServices,
         "root registry should expose the identifier case bundle"
-    );
-
-    const identifierCasePlanService = defaultCliIdentifierCasePlanService;
-    assert.ok(
-        Object.isFrozen(identifierCasePlanService),
-        "identifier case plan service should be frozen"
-    );
-    assert.strictEqual(
-        identifierCasePlanService.prepareIdentifierCasePlan,
-        defaultIdentifierCasePlanPreparer,
-        "plan service should expose the default preparer"
-    );
-    assert.strictEqual(
-        identifierCasePlanService.clearIdentifierCaseCaches,
-        defaultIdentifierCaseCacheClearer,
-        "plan service should expose the default cache clearer"
     );
 
     const identifierCasePlanPreparationService =
@@ -104,6 +87,13 @@ test("CLI plugin services expose validated defaults", () => {
         identifierCaseServices.cache.clearIdentifierCaseCaches,
         defaultIdentifierCaseCacheClearer,
         "cache bundle should expose the default clearer"
+    );
+    assert.ok(
+        Object.prototype.hasOwnProperty.call(
+            services,
+            "identifierCasePlanService"
+        ) === false,
+        "root registry should no longer expose the combined plan service"
     );
     assert.strictEqual(
         projectIndexService.buildProjectIndex,
@@ -185,14 +175,14 @@ test("default plugin services can be customized with overrides", () => {
         "project index service should wrap override builder"
     );
     assert.strictEqual(
-        services.identifierCasePlanService.prepareIdentifierCasePlan,
+        services.identifierCasePlanPreparationService.prepareIdentifierCasePlan,
         identifierCasePlanPreparer,
-        "identifier case plan service should wrap override preparer"
+        "preparation service should wrap override preparer"
     );
     assert.strictEqual(
-        services.identifierCasePlanService.clearIdentifierCaseCaches,
+        services.identifierCasePlanCacheService.clearIdentifierCaseCaches,
         identifierCaseCacheClearer,
-        "identifier case plan service should wrap override clearer"
+        "cache service should wrap override clearer"
     );
     assert.ok(
         Object.isFrozen(services.pluginServiceRegistry),


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
