### PR TITLE
Codex: Add Extensibility Hook

### DIFF
--- a/docs/object-wrap-option-resolver-hook.md
+++ b/docs/object-wrap-option-resolver-hook.md
@@ -1,0 +1,33 @@
+# Object wrap option resolver hook
+
+## Pre-change analysis
+- `resolveObjectWrapOption` inside `printer/print.js` evaluates the Prettier
+  option bag directly and forces the default behaviour to `preserve` whenever the
+  user does not explicitly request `collapse`.
+- Advanced integrations (editor previews, CLI experiments) sometimes need to
+  stage alternate wrapping heuristics without exposing new public configuration.
+  Today they must fork the printer or patch `print.js` to experiment with
+  different wrapping policies.
+- Because `resolveObjectWrapOption` is hard-coded, downstream helpers cannot plug
+  in custom logic or stage gradual roll-outs that change the wrapping rule based
+  on project context.
+
+## Extension seam
+- Extract the object-wrap resolution logic into
+  `options/object-wrap-option.js` and introduce a small resolver registry.
+- Export `setObjectWrapOptionResolver` so advanced tooling can provide a custom
+  resolver while keeping the default behaviour intact.
+- Provide a paired `resetObjectWrapOptionResolver` helper so experiments can
+  restore the default resolver after executing, mirroring the pattern used by the
+  reserved identifier metadata hook.
+
+## Default behaviour and evolution
+- Without an override the formatter still resolves to `preserve`, only switching
+  to `collapse` when the Prettier option explicitly asks for it.
+- The hook is intended for integrators embedding the formatter (editor previews,
+  CLI migrations) who need to experiment with alternate wrapping rules without
+  widening the public option surface.
+- The resolver always normalizes invalid outputs back to `preserve`, keeping the
+  plugin opinionated and predictable. Future iterations can layer additional
+  hooks (for example, per-node object wrap strategies) on top of this registry if
+  the need arises.

--- a/src/plugin/src/options/object-wrap-option.js
+++ b/src/plugin/src/options/object-wrap-option.js
@@ -1,0 +1,62 @@
+const ObjectWrapOption = Object.freeze({
+    PRESERVE: "preserve",
+    COLLAPSE: "collapse"
+});
+
+const OBJECT_WRAP_VALUES = new Set(Object.values(ObjectWrapOption));
+
+const defaultResolveObjectWrapOption = (options) =>
+    options?.objectWrap === ObjectWrapOption.COLLAPSE
+        ? ObjectWrapOption.COLLAPSE
+        : ObjectWrapOption.PRESERVE;
+
+let objectWrapOptionResolver = null;
+
+function normalizeObjectWrapOption(value) {
+    if (!OBJECT_WRAP_VALUES.has(value)) {
+        return ObjectWrapOption.PRESERVE;
+    }
+
+    return value;
+}
+
+function resolveObjectWrapOption(options) {
+    if (typeof objectWrapOptionResolver !== "function") {
+        return defaultResolveObjectWrapOption(options);
+    }
+
+    try {
+        const resolved = objectWrapOptionResolver(options);
+        return normalizeObjectWrapOption(resolved);
+    } catch {
+        return defaultResolveObjectWrapOption(options);
+    }
+}
+
+function setObjectWrapOptionResolver(resolver) {
+    if (typeof resolver !== "function") {
+        resetObjectWrapOptionResolver();
+        return () => {};
+    }
+
+    const previousResolver = objectWrapOptionResolver;
+
+    objectWrapOptionResolver = resolver;
+
+    return () => {
+        if (objectWrapOptionResolver === resolver) {
+            objectWrapOptionResolver = previousResolver;
+        }
+    };
+}
+
+function resetObjectWrapOptionResolver() {
+    objectWrapOptionResolver = null;
+}
+
+export {
+    ObjectWrapOption,
+    resolveObjectWrapOption,
+    resetObjectWrapOptionResolver,
+    setObjectWrapOptionResolver
+};

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -66,6 +66,10 @@ import {
     LogicalOperatorsStyle,
     normalizeLogicalOperatorsStyle
 } from "../options/logical-operators-style.js";
+import {
+    ObjectWrapOption,
+    resolveObjectWrapOption
+} from "../options/object-wrap-option.js";
 
 const {
     breakParent,
@@ -88,17 +92,6 @@ const FEATHER_COMMENT_OUT_SYMBOL = Symbol.for(
 const FEATHER_COMMENT_TEXT_SYMBOL = Symbol.for(
     "prettier.gml.feather.commentText"
 );
-
-const ObjectWrapOption = Object.freeze({
-    PRESERVE: "preserve",
-    COLLAPSE: "collapse"
-});
-
-function resolveObjectWrapOption(options) {
-    return options?.objectWrap === ObjectWrapOption.COLLAPSE
-        ? ObjectWrapOption.COLLAPSE
-        : ObjectWrapOption.PRESERVE;
-}
 
 const preservedUndefinedDefaultParameters = new WeakSet();
 const ARGUMENT_IDENTIFIER_PATTERN = /^argument(\d+)$/;

--- a/src/plugin/tests/object-wrap-option-resolver.test.js
+++ b/src/plugin/tests/object-wrap-option-resolver.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import {
+    ObjectWrapOption,
+    resolveObjectWrapOption,
+    resetObjectWrapOptionResolver,
+    setObjectWrapOptionResolver
+} from "../src/options/object-wrap-option.js";
+
+afterEach(() => {
+    resetObjectWrapOptionResolver();
+});
+
+describe("resolveObjectWrapOption", () => {
+    it("preserves object wrapping by default", () => {
+        const resolved = resolveObjectWrapOption();
+
+        assert.equal(resolved, ObjectWrapOption.PRESERVE);
+    });
+
+    it("honours the collapse option provided by Prettier", () => {
+        const resolved = resolveObjectWrapOption({
+            objectWrap: ObjectWrapOption.COLLAPSE
+        });
+
+        assert.equal(resolved, ObjectWrapOption.COLLAPSE);
+    });
+
+    it("allows advanced integrations to override the resolver", () => {
+        const cleanup = setObjectWrapOptionResolver(
+            () => ObjectWrapOption.COLLAPSE
+        );
+
+        const resolved = resolveObjectWrapOption();
+
+        assert.equal(resolved, ObjectWrapOption.COLLAPSE);
+
+        cleanup();
+
+        assert.equal(resolveObjectWrapOption(), ObjectWrapOption.PRESERVE);
+    });
+
+    it("falls back to the default when the resolver returns an invalid value", () => {
+        setObjectWrapOptionResolver(() => "invalid");
+
+        const resolved = resolveObjectWrapOption({
+            objectWrap: ObjectWrapOption.COLLAPSE
+        });
+
+        assert.equal(resolved, ObjectWrapOption.PRESERVE);
+    });
+});


### PR DESCRIPTION
Seed PR for Codex to implement a targeted extensibility improvement while
keeping the defaults opinionated.

## Requirements
- Document the rigid decision point that makes extension difficult today.
- Explain the minimal seam or hook you will add before touching code.
- Avoid exposing new end-user configuration unless it is indispensable;
  prefer sensible defaults and internal extension points.
- When a new hook or option is warranted, clearly state who should use
  it, the default value, and the guardrails that keep the behavior
  predictable for everyone else.
- Update any impacted docs or inline comments, and keep behavior
  unchanged by default.
