### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -123,3 +123,17 @@ no code changes were required.
   `resolveManualGitHubRefResolver`, and
   `resolveManualGitHubFileClient`). Updated the CLI unit test to import the
   specialised helpers so consumers opt into only the collaborator they require.
+
+## Follow-up audit (2025-04-09)
+
+- Audited `createManualAccessContext` in
+  `src/cli/features/manual/context.js` and found it still returned a combined
+  `ManualAccessContext` interface that bundled manual file fetching with
+  reference resolution. CLI commands that only needed to download manual pages
+  were forced to depend on reference helpers (and vice versa), violating the
+  Interface Segregation Principle.
+- Split the contract into `ManualFileAccessContext` and
+  `ManualReferenceAccessContext`, plus a helper that produces both specialised
+  views without rebuilding the underlying GitHub wiring. Updated the manual CLI
+  commands and unit tests to import the targeted contexts so each call site
+  depends only on the collaborators it requires.

--- a/src/cli/commands/generate-feather-metadata.js
+++ b/src/cli/commands/generate-feather-metadata.js
@@ -35,7 +35,7 @@ import {
     applySharedManualCommandOptions,
     resolveManualCommandOptions
 } from "../features/manual/command-options.js";
-import { createManualAccessContext } from "../features/manual/context.js";
+import { createManualAccessContexts } from "../features/manual/context.js";
 
 /** @typedef {ReturnType<typeof resolveManualCommandOptions>} ManualCommandOptions */
 
@@ -45,9 +45,13 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    files: { fetchManualFile },
-    refs: { resolveManualRef }
-} = createManualAccessContext({
+    fileAccess: {
+        files: { fetchManualFile }
+    },
+    referenceAccess: {
+        refs: { resolveManualRef }
+    }
+} = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml feather metadata generator",
     outputFileName: "feather-metadata.json"

--- a/src/cli/commands/generate-gml-identifiers.js
+++ b/src/cli/commands/generate-gml-identifiers.js
@@ -36,7 +36,7 @@ import {
     resolveManualCommandOptions
 } from "../features/manual/command-options.js";
 import { wrapInvalidArgumentResolver } from "../core/command-parsing.js";
-import { createManualAccessContext } from "../features/manual/context.js";
+import { createManualAccessContexts } from "../features/manual/context.js";
 import {
     decodeManualKeywordsPayload,
     decodeManualTagsPayload
@@ -48,9 +48,13 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    files: { fetchManualFile },
-    refs: { resolveManualRef }
-} = createManualAccessContext({
+    fileAccess: {
+        files: { fetchManualFile }
+    },
+    referenceAccess: {
+        refs: { resolveManualRef }
+    }
+} = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml identifier generator",
     outputFileName: "gml-identifiers.json"

--- a/src/cli/features/manual/context.js
+++ b/src/cli/features/manual/context.js
@@ -82,10 +82,22 @@ function resolveOutputPath(repoRoot, fileName) {
  */
 
 /**
- * @typedef {object} ManualAccessContext
+ * @typedef {object} ManualFileAccessContext
  * @property {ManualCommandEnvironment} environment
  * @property {ManualCommandFileService} files
+ */
+
+/**
+ * @typedef {object} ManualReferenceAccessContext
+ * @property {ManualCommandEnvironment} environment
  * @property {ManualCommandRefResolutionService} refs
+ */
+
+/**
+ * @typedef {object} ManualAccessContexts
+ * @property {ManualCommandEnvironment} environment
+ * @property {ManualFileAccessContext} fileAccess
+ * @property {ManualReferenceAccessContext} referenceAccess
  */
 
 function buildManualCommandContext({
@@ -155,6 +167,14 @@ function buildManualCommandContext({
     });
 }
 
+function mapManualFileAccessContext({ environment, files }) {
+    return Object.freeze({ environment, files });
+}
+
+function mapManualReferenceAccessContext({ environment, refs }) {
+    return Object.freeze({ environment, refs });
+}
+
 /**
  * Resolve only the repository environment metadata shared by manual commands.
  *
@@ -171,11 +191,36 @@ export function createManualEnvironmentContext(options = {}) {
  * information commonly needed by artefact generators.
  *
  * @param {Parameters<typeof buildManualCommandContext>[0]} options
- * @returns {ManualAccessContext}
+ * @returns {ManualFileAccessContext}
  */
-export function createManualAccessContext(options = {}) {
-    const { environment, files, refs } = buildManualCommandContext(options);
-    return Object.freeze({ environment, files, refs });
+export function createManualFileAccessContext(options = {}) {
+    return mapManualFileAccessContext(buildManualCommandContext(options));
+}
+
+/**
+ * Resolve manual reference helpers along with the shared environment metadata.
+ *
+ * @param {Parameters<typeof buildManualCommandContext>[0]} options
+ * @returns {ManualReferenceAccessContext}
+ */
+export function createManualReferenceAccessContext(options = {}) {
+    return mapManualReferenceAccessContext(buildManualCommandContext(options));
+}
+
+/**
+ * Resolve both manual file and reference collaborators while reusing the
+ * underlying GitHub wiring and shared environment metadata.
+ *
+ * @param {Parameters<typeof buildManualCommandContext>[0]} options
+ * @returns {ManualAccessContexts}
+ */
+export function createManualAccessContexts(options = {}) {
+    const context = buildManualCommandContext(options);
+    return Object.freeze({
+        environment: context.environment,
+        fileAccess: mapManualFileAccessContext(context),
+        referenceAccess: mapManualReferenceAccessContext(context)
+    });
 }
 
 /**

--- a/src/cli/tests/manual-command-context.test.js
+++ b/src/cli/tests/manual-command-context.test.js
@@ -5,7 +5,9 @@ import test from "node:test";
 
 import {
     createManualEnvironmentContext,
-    createManualAccessContext,
+    createManualAccessContexts,
+    createManualFileAccessContext,
+    createManualReferenceAccessContext,
     resolveManualGitHubRequestService,
     resolveManualGitHubRequestExecutor,
     resolveManualGitHubCommitService,
@@ -18,36 +20,59 @@ import {
     resolveManualCacheRoot
 } from "../features/manual/utils.js";
 
-test("createManualAccessContext centralizes manual access defaults", () => {
+test("createManualAccessContexts centralizes manual access defaults", () => {
     const commandUrl = pathToFileURL(
         path.resolve("src/cli/commands/generate-gml-identifiers.js")
     ).href;
 
-    const context = createManualAccessContext({
-        importMetaUrl: commandUrl,
-        userAgent: "manual-context-test",
-        outputFileName: "example.json"
-    });
+    const { environment, fileAccess, referenceAccess } =
+        createManualAccessContexts({
+            importMetaUrl: commandUrl,
+            userAgent: "manual-context-test",
+            outputFileName: "example.json"
+        });
 
     const expectedRepoRoot = path.resolve("src/cli/commands", "..", "..");
-    assert.equal(context.environment.repoRoot, expectedRepoRoot);
+    assert.equal(environment.repoRoot, expectedRepoRoot);
     assert.equal(
-        context.environment.defaultCacheRoot,
+        environment.defaultCacheRoot,
         resolveManualCacheRoot({ repoRoot: expectedRepoRoot })
     );
     assert.equal(
-        context.environment.defaultOutputPath,
+        environment.defaultOutputPath,
         path.join(expectedRepoRoot, "resources", "example.json")
     );
     assert.equal(
-        context.environment.defaultManualRawRoot,
+        environment.defaultManualRawRoot,
         buildManualRepositoryEndpoints().rawRoot
     );
-    assert.ok(Object.isFrozen(context.environment));
-    assert.ok(Object.isFrozen(context.files));
-    assert.ok(Object.isFrozen(context.refs));
-    assert.equal(typeof context.files.fetchManualFile, "function");
-    assert.equal(typeof context.refs.resolveManualRef, "function");
+    assert.ok(Object.isFrozen(environment));
+    assert.ok(Object.isFrozen(fileAccess));
+    assert.ok(Object.isFrozen(referenceAccess));
+    assert.equal(fileAccess.environment, environment);
+    assert.equal(referenceAccess.environment, environment);
+    assert.equal(typeof fileAccess.files.fetchManualFile, "function");
+    assert.equal(typeof referenceAccess.refs.resolveManualRef, "function");
+});
+
+test("manual access helpers expose focused contexts", () => {
+    const commandUrl = pathToFileURL(
+        path.resolve("src/cli/commands/generate-feather-metadata.js")
+    ).href;
+
+    const fileAccess = createManualFileAccessContext({
+        importMetaUrl: commandUrl,
+        userAgent: "manual-context-test"
+    });
+
+    const referenceAccess = createManualReferenceAccessContext({
+        importMetaUrl: commandUrl,
+        userAgent: "manual-context-test"
+    });
+
+    assert.deepStrictEqual(fileAccess.environment, referenceAccess.environment);
+    assert.equal(typeof fileAccess.files.fetchManualFile, "function");
+    assert.equal(typeof referenceAccess.refs.resolveManualRef, "function");
 });
 
 test("manual GitHub helpers expose narrow collaborators", () => {
@@ -100,7 +125,7 @@ test("createManualEnvironmentContext isolates repository metadata", () => {
 
 test("manual command context builders validate required arguments", () => {
     assert.throws(
-        () => createManualAccessContext({ userAgent: "missing-url" }),
+        () => createManualFileAccessContext({ userAgent: "missing-url" }),
         /importMetaUrl must be provided/i
     );
 
@@ -109,7 +134,7 @@ test("manual command context builders validate required arguments", () => {
     ).href;
 
     assert.throws(
-        () => createManualAccessContext({ importMetaUrl: commandUrl }),
+        () => createManualFileAccessContext({ importMetaUrl: commandUrl }),
         /userAgent must be provided/i
     );
 });


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
