### PR TITLE
Add eslint unused imports plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ import pluginPromise from "eslint-plugin-promise";
 import pluginRegexp from "eslint-plugin-regexp";
 import pluginNoSecrets from "eslint-plugin-no-secrets";
 import pluginEslintComments from "eslint-plugin-eslint-comments";
+import pluginUnusedImports from "eslint-plugin-unused-imports";
 
 /* Config */
 import eslintConfigPrettier from "eslint-config-prettier";
@@ -59,7 +60,8 @@ export default [
             import: pluginImport,
             regexp: pluginRegexp,
             "no-secrets": pluginNoSecrets,
-            "eslint-comments": pluginEslintComments
+            "eslint-comments": pluginEslintComments,
+            "unused-imports": pluginUnusedImports
         },
 
         /* Helpful for import/plugin-import */
@@ -73,7 +75,17 @@ export default [
             indent: ["error", 4, { SwitchCase: 1 }],
             quotes: ["warn", "double", { avoidEscape: true }],
             semi: ["error", "always"],
-            "no-unused-vars": ["warn"],
+            "no-unused-vars": "off",
+            "unused-imports/no-unused-imports": "error",
+            "unused-imports/no-unused-vars": [
+                "warn",
+                {
+                    vars: "all",
+                    varsIgnorePattern: "^_",
+                    args: "after-used",
+                    argsIgnorePattern: "^_"
+                }
+            ],
             "no-console": ["off"],
             "comma-dangle": ["off", "never"],
             "no-prototype-builtins": ["warn"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-sonarjs": "^3.0.5",
         "eslint-plugin-unicorn": "^61.0.2",
+        "eslint-plugin-unused-imports": "^4.3.0",
         "globals": "^16.4.0",
         "husky": "^9.1.7",
         "prettier": "^3.6.2"
@@ -1711,6 +1712,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz",
+      "integrity": "sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-security": "^3.0.1",
     "eslint-plugin-sonarjs": "^3.0.5",
     "eslint-plugin-unicorn": "^61.0.2",
+    "eslint-plugin-unused-imports": "^4.3.0",
     "globals": "^16.4.0",
     "husky": "^9.1.7",
     "prettier": "^3.6.2"

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -32,18 +32,15 @@ import { fileURLToPath } from "node:url";
 import { Command, InvalidArgumentError, Option } from "commander";
 
 import {
-    coerceNonNegativeInteger,
     getErrorMessage,
     getErrorMessageOrFallback,
     getNonEmptyTrimmedString,
     isErrorWithCode,
     normalizeEnumeratedOption,
     normalizeStringList,
-    resolveIntegerOption,
     toArray,
     mergeUniqueValues,
     toNormalizedLowerCaseSet,
-    toNormalizedLowerCaseString,
     uniqueArray,
     withObjectLike
 } from "../shared/utils.js";

--- a/src/cli/plugin/services.js
+++ b/src/cli/plugin/services.js
@@ -1,7 +1,5 @@
 import {
     defaultCliProjectIndexService,
-    defaultCliIdentifierCasePlanPreparationService,
-    defaultCliIdentifierCaseCacheService,
     defaultCliIdentifierCaseServices
 } from "./service-providers/default.js";
 import { assertFunction } from "../shared/dependencies.js";

--- a/src/parser/src/scope-tracker.js
+++ b/src/parser/src/scope-tracker.js
@@ -1,4 +1,4 @@
-import { assignClonedLocation, cloneLocation } from "./shared/ast.js";
+import { assignClonedLocation } from "./shared/ast.js";
 import { isObjectLike, toArray } from "./shared/utils.js";
 import {
     ScopeOverrideKeyword,

--- a/src/plugin/src/project-index/cache.js
+++ b/src/plugin/src/project-index/cache.js
@@ -8,10 +8,7 @@ import {
 } from "../../../shared/number-utils.js";
 import { isObjectLike } from "../../../shared/object-utils.js";
 import { createEnvConfiguredValueWithFallback } from "../../../shared/environment-utils.js";
-import {
-    PROJECT_MANIFEST_EXTENSION,
-    isProjectManifestPath
-} from "./constants.js";
+import { isProjectManifestPath } from "./constants.js";
 import { defaultFsFacade } from "./fs-facade.js";
 import { createAbortGuard } from "../../../shared/abort-utils.js";
 import {

--- a/src/plugin/src/project-index/index.js
+++ b/src/plugin/src/project-index/index.js
@@ -19,10 +19,7 @@ import {
 } from "../../../shared/location-keys.js";
 import { resolveProjectIndexParser } from "./parser-override.js";
 import { clampConcurrency } from "./concurrency.js";
-import {
-    PROJECT_MANIFEST_EXTENSION,
-    isProjectManifestPath
-} from "./constants.js";
+import { isProjectManifestPath } from "./constants.js";
 import { defaultFsFacade } from "./fs-facade.js";
 import { isFsErrorCode, listDirectory } from "../../../shared/fs-utils.js";
 import {
@@ -34,7 +31,6 @@ import {
     createProjectIndexMetrics,
     finalizeProjectIndexMetrics
 } from "./metrics.js";
-import { throwIfAborted } from "../../../shared/abort-utils.js";
 import {
     analyseResourceFiles,
     createFileScopeDescriptor


### PR DESCRIPTION
## Summary
- add eslint-plugin-unused-imports so eslint --fix cleans up dead imports
- wire the plugin into the flat config and disable the core no-unused-vars rule
- remove unused imports that the new rule reports

## Testing
- npm run lint:fix

------
https://chatgpt.com/codex/tasks/task_e_68fbe77e7d5c832fbedf4427ce7fb1fe