### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/plugin/src/ast-transforms/apply-feather-fixes.js
+++ b/src/plugin/src/ast-transforms/apply-feather-fixes.js
@@ -53,7 +53,7 @@ import {
     collectCommentNodes,
     getCommentArray,
     hasComment,
-    resolveDocCommentInspectionService,
+    resolveDocCommentTraversalService,
     getCommentValue
 } from "../comments/index.js";
 import {
@@ -4168,11 +4168,11 @@ function normalizeArgumentBuiltinReferences({ ast, diagnostic, sourceText }) {
     }
 
     const fixes = [];
-    const docCommentInspection = resolveDocCommentInspectionService(ast);
+    const docCommentTraversal = resolveDocCommentTraversalService(ast);
     const documentedParamNamesByFunction = buildDocumentedParamNameLookup(
         ast,
         sourceText,
-        docCommentInspection
+        docCommentTraversal
     );
 
     const visit = (node) => {
@@ -4427,17 +4427,17 @@ function fixArgumentReferencesWithinFunction(
     return fixes;
 }
 
-function buildDocumentedParamNameLookup(ast, sourceText, docCommentInspection) {
+function buildDocumentedParamNameLookup(ast, sourceText, docCommentTraversal) {
     const lookup = new WeakMap();
 
     if (!ast || typeof ast !== "object") {
         return lookup;
     }
 
-    const inspection =
-        docCommentInspection ?? resolveDocCommentInspectionService(ast);
+    const traversal =
+        docCommentTraversal ?? resolveDocCommentTraversalService(ast);
 
-    inspection.forEach((node, comments = []) => {
+    traversal.forEach((node, comments = []) => {
         if (!isFunctionLikeNode(node)) {
             return;
         }
@@ -6601,11 +6601,11 @@ function captureDeprecatedFunctionManualFixes({ ast, sourceText, diagnostic }) {
         return [];
     }
 
-    const docCommentInspection = resolveDocCommentInspectionService(ast);
+    const docCommentTraversal = resolveDocCommentTraversalService(ast);
     const deprecatedFunctions = collectDeprecatedFunctionNames(
         ast,
         sourceText,
-        docCommentInspection
+        docCommentTraversal
     );
 
     if (!deprecatedFunctions || deprecatedFunctions.size === 0) {
@@ -6689,7 +6689,7 @@ function recordDeprecatedCallMetadata(node, deprecatedFunctions, diagnostic) {
     return fixDetail;
 }
 
-function collectDeprecatedFunctionNames(ast, sourceText, docCommentInspection) {
+function collectDeprecatedFunctionNames(ast, sourceText, docCommentTraversal) {
     const names = new Set();
 
     if (!ast || typeof ast !== "object" || typeof sourceText !== "string") {
@@ -6715,10 +6715,10 @@ function collectDeprecatedFunctionNames(ast, sourceText, docCommentInspection) {
         return names;
     }
 
-    const inspection =
-        docCommentInspection ?? resolveDocCommentInspectionService(ast);
+    const traversal =
+        docCommentTraversal ?? resolveDocCommentTraversalService(ast);
 
-    inspection.forEach((node, comments = []) => {
+    traversal.forEach((node, comments = []) => {
         if (!topLevelFunctions.has(node)) {
             return;
         }

--- a/src/plugin/src/ast-transforms/condense-logical-expressions.js
+++ b/src/plugin/src/ast-transforms/condense-logical-expressions.js
@@ -1,7 +1,8 @@
 import {
     hasComment as sharedHasComment,
     normalizeHasCommentHelpers,
-    resolveDocCommentInspectionService,
+    resolveDocCommentLookupService,
+    resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "../comments/index.js";
 import { cloneLocation } from "../../../shared/ast-locations.js";
@@ -48,14 +49,16 @@ export function condenseLogicalExpressions(ast, helpers) {
         return ast;
     }
 
-    const docCommentManager = resolveDocCommentInspectionService(ast);
+    const docCommentLookup = resolveDocCommentLookupService(ast);
+    const docCommentDescriptions = resolveDocCommentDescriptionService(ast);
     const docCommentUpdateService = resolveDocCommentUpdateService(ast);
     const normalizedHelpers = normalizeHasCommentHelpers(helpers);
     const context = {
         ast,
         helpers: normalizedHelpers,
         docUpdates: new Map(),
-        docCommentManager,
+        docCommentLookup,
+        docCommentDescriptions,
         docCommentUpdateService,
         expressionSignatures: new Map()
     };
@@ -186,7 +189,7 @@ function removeDuplicateCondensedFunctions(context) {
         return null;
     }
 
-    const docCommentManager = context.docCommentManager;
+    const docCommentLookup = context.docCommentLookup;
     const signatureToFunctions = new Map();
     for (const [fn, signature] of context.expressionSignatures.entries()) {
         if (!signature) {
@@ -226,7 +229,7 @@ function removeDuplicateCondensedFunctions(context) {
             const update = context.docUpdates.get(fn);
             const hasDocComment =
                 update?.hasDocComment ||
-                (docCommentManager?.hasDocComment(fn) ?? false);
+                (docCommentLookup?.hasDocComment(fn) ?? false);
             if (hasDocComment && !keeper) {
                 keeper = fn;
             }
@@ -241,7 +244,7 @@ function removeDuplicateCondensedFunctions(context) {
                 const update = context.docUpdates.get(fn);
                 const hasDocComment =
                     update?.hasDocComment ||
-                    (docCommentManager?.hasDocComment(fn) ?? false);
+                    (docCommentLookup?.hasDocComment(fn) ?? false);
                 if (!hasDocComment) {
                     toRemove.add(fn);
                 }
@@ -581,9 +584,10 @@ function tryCondenseIfStatement(
         activeTransformationContext
     ) {
         const docString = renderExpressionForDocComment(argumentAst);
-        const docCommentManager = activeTransformationContext.docCommentManager;
-        const description = docCommentManager
-            ? docCommentManager.extractDescription(parentNode)
+        const descriptionService =
+            activeTransformationContext.docCommentDescriptions;
+        const description = descriptionService
+            ? descriptionService.extractDescription(parentNode)
             : null;
 
         if (docString) {

--- a/src/plugin/src/comments/doc-comment-manager.js
+++ b/src/plugin/src/comments/doc-comment-manager.js
@@ -25,7 +25,9 @@ const DOC_COMMENT_TARGET_TYPES = new Set([
 ]);
 
 const DOC_COMMENT_MANAGERS = new WeakMap();
-const DOC_COMMENT_INSPECTION_SERVICES = new WeakMap();
+const DOC_COMMENT_TRAVERSAL_SERVICES = new WeakMap();
+const DOC_COMMENT_LOOKUP_SERVICES = new WeakMap();
+const DOC_COMMENT_DESCRIPTION_SERVICES = new WeakMap();
 const DOC_COMMENT_UPDATE_SERVICES = new WeakMap();
 
 const NOOP_DOC_COMMENT_MANAGER = Object.freeze({
@@ -63,11 +65,19 @@ export function getDocCommentManager(ast) {
 }
 
 /**
- * @typedef {object} DocCommentInspectionService
+ * @typedef {object} DocCommentTraversalService
  * @property {(callback: (node: object, comments: Array<object>) => void) => void} forEach
+ */
+
+/**
+ * @typedef {object} DocCommentLookupService
  * @property {(functionNode: object) => Array<object>} getComments
- * @property {(functionNode: object) => string | null} extractDescription
  * @property {(functionNode: object) => boolean} hasDocComment
+ */
+
+/**
+ * @typedef {object} DocCommentDescriptionService
+ * @property {(functionNode: object) => string | null} extractDescription
  */
 
 /**
@@ -79,21 +89,47 @@ export function getDocCommentManager(ast) {
  * }>) => void} applyUpdates
  */
 
-export function resolveDocCommentInspectionService(ast) {
+export function resolveDocCommentTraversalService(ast) {
     const manager = prepareDocCommentEnvironment(ast);
-    let inspection = DOC_COMMENT_INSPECTION_SERVICES.get(manager);
+    let traversal = DOC_COMMENT_TRAVERSAL_SERVICES.get(manager);
 
-    if (!inspection) {
-        inspection = Object.freeze({
-            forEach: manager.forEach.bind(manager),
-            getComments: manager.getComments.bind(manager),
-            extractDescription: manager.extractDescription.bind(manager),
-            hasDocComment: manager.hasDocComment.bind(manager)
+    if (!traversal) {
+        traversal = Object.freeze({
+            forEach: manager.forEach.bind(manager)
         });
-        DOC_COMMENT_INSPECTION_SERVICES.set(manager, inspection);
+        DOC_COMMENT_TRAVERSAL_SERVICES.set(manager, traversal);
     }
 
-    return inspection;
+    return traversal;
+}
+
+export function resolveDocCommentLookupService(ast) {
+    const manager = prepareDocCommentEnvironment(ast);
+    let lookup = DOC_COMMENT_LOOKUP_SERVICES.get(manager);
+
+    if (!lookup) {
+        lookup = Object.freeze({
+            getComments: manager.getComments.bind(manager),
+            hasDocComment: manager.hasDocComment.bind(manager)
+        });
+        DOC_COMMENT_LOOKUP_SERVICES.set(manager, lookup);
+    }
+
+    return lookup;
+}
+
+export function resolveDocCommentDescriptionService(ast) {
+    const manager = prepareDocCommentEnvironment(ast);
+    let description = DOC_COMMENT_DESCRIPTION_SERVICES.get(manager);
+
+    if (!description) {
+        description = Object.freeze({
+            extractDescription: manager.extractDescription.bind(manager)
+        });
+        DOC_COMMENT_DESCRIPTION_SERVICES.set(manager, description);
+    }
+
+    return description;
 }
 
 export function resolveDocCommentUpdateService(ast) {

--- a/src/plugin/src/comments/index.js
+++ b/src/plugin/src/comments/index.js
@@ -32,7 +32,9 @@ export {
 export {
     getDocCommentManager,
     prepareDocCommentEnvironment,
-    resolveDocCommentInspectionService,
+    resolveDocCommentTraversalService,
+    resolveDocCommentLookupService,
+    resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "./doc-comment-manager.js";
 export { getCommentValue } from "./comment-utils.js";

--- a/src/plugin/tests/doc-comment-manager.test.js
+++ b/src/plugin/tests/doc-comment-manager.test.js
@@ -3,7 +3,9 @@ import test from "node:test";
 
 import {
     getDocCommentManager,
-    resolveDocCommentInspectionService,
+    resolveDocCommentTraversalService,
+    resolveDocCommentLookupService,
+    resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "../src/comments/doc-comment-manager.js";
 
@@ -11,36 +13,40 @@ test("doc comment services expose segregated contracts", () => {
     const ast = { type: "Program", body: [] };
 
     const manager = getDocCommentManager(ast);
-    const inspection = resolveDocCommentInspectionService(ast);
+    const traversal = resolveDocCommentTraversalService(ast);
+    const lookup = resolveDocCommentLookupService(ast);
+    const descriptions = resolveDocCommentDescriptionService(ast);
     const updates = resolveDocCommentUpdateService(ast);
 
-    assert.ok(Object.isFrozen(inspection));
+    assert.ok(Object.isFrozen(traversal));
+    assert.ok(Object.isFrozen(lookup));
+    assert.ok(Object.isFrozen(descriptions));
     assert.ok(Object.isFrozen(updates));
 
-    assert.deepStrictEqual(Object.keys(inspection), [
-        "forEach",
+    assert.deepStrictEqual(Object.keys(traversal), ["forEach"]);
+    assert.deepStrictEqual(Object.keys(lookup), [
         "getComments",
-        "extractDescription",
         "hasDocComment"
     ]);
+    assert.deepStrictEqual(Object.keys(descriptions), ["extractDescription"]);
     assert.deepStrictEqual(Object.keys(updates), ["applyUpdates"]);
 
     assert.ok(
-        inspection.forEach.name.endsWith(manager.forEach.name),
+        traversal.forEach.name.endsWith(manager.forEach.name),
         "forEach binding should preserve original function name"
     );
     assert.ok(
-        inspection.getComments.name.endsWith(manager.getComments.name),
+        lookup.getComments.name.endsWith(manager.getComments.name),
         "getComments binding should preserve original function name"
     );
     assert.ok(
-        inspection.extractDescription.name.endsWith(
+        descriptions.extractDescription.name.endsWith(
             manager.extractDescription.name
         ),
         "extractDescription binding should preserve original function name"
     );
     assert.ok(
-        inspection.hasDocComment.name.endsWith(manager.hasDocComment.name),
+        lookup.hasDocComment.name.endsWith(manager.hasDocComment.name),
         "hasDocComment binding should preserve original function name"
     );
     assert.ok(
@@ -52,18 +58,33 @@ test("doc comment services expose segregated contracts", () => {
 test("doc comment services reuse cached views and tolerate missing AST", () => {
     const ast = { type: "Program", body: [] };
 
-    const firstInspection = resolveDocCommentInspectionService(ast);
-    const secondInspection = resolveDocCommentInspectionService(ast);
+    const firstTraversal = resolveDocCommentTraversalService(ast);
+    const secondTraversal = resolveDocCommentTraversalService(ast);
+    const firstLookup = resolveDocCommentLookupService(ast);
+    const secondLookup = resolveDocCommentLookupService(ast);
+    const firstDescriptions = resolveDocCommentDescriptionService(ast);
+    const secondDescriptions = resolveDocCommentDescriptionService(ast);
     const firstUpdates = resolveDocCommentUpdateService(ast);
     const secondUpdates = resolveDocCommentUpdateService(ast);
 
-    assert.strictEqual(firstInspection, secondInspection);
+    assert.strictEqual(firstTraversal, secondTraversal);
+    assert.strictEqual(firstLookup, secondLookup);
+    assert.strictEqual(firstDescriptions, secondDescriptions);
     assert.strictEqual(firstUpdates, secondUpdates);
 
-    const noopInspection = resolveDocCommentInspectionService(null);
+    const noopTraversal = resolveDocCommentTraversalService(null);
+    const noopLookup = resolveDocCommentLookupService(null);
+    const noopDescriptions = resolveDocCommentDescriptionService();
     const noopUpdates = resolveDocCommentUpdateService();
 
-    assert.deepStrictEqual(noopInspection.getComments({}), []);
-    assert.strictEqual(noopInspection.hasDocComment({}), false);
+    let visited = false;
+    noopTraversal.forEach(() => {
+        visited = true;
+    });
+    assert.strictEqual(visited, false);
+
+    assert.deepStrictEqual(noopLookup.getComments({}), []);
+    assert.strictEqual(noopLookup.hasDocComment({}), false);
+    assert.strictEqual(noopDescriptions.extractDescription({}), null);
     assert.doesNotThrow(() => noopUpdates.applyUpdates(new Map()));
 });


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
