### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/plugin/src/project-index/identifier-roles.js
+++ b/src/plugin/src/project-index/identifier-roles.js
@@ -1,0 +1,33 @@
+const IdentifierRole = Object.freeze({
+    Declaration: "declaration",
+    Reference: "reference"
+});
+
+const VALID_IDENTIFIER_ROLES = new Set(Object.values(IdentifierRole));
+
+function formatRoleForMessage(role) {
+    if (typeof role === "string") {
+        return JSON.stringify(role);
+    }
+
+    if (role === null) {
+        return "null";
+    }
+
+    return typeof role;
+}
+
+export function assertValidIdentifierRole(role, context = "identifier role") {
+    if (!VALID_IDENTIFIER_ROLES.has(role)) {
+        throw new TypeError(
+            `Invalid ${context}: ${formatRoleForMessage(role)}. ` +
+                `Expected one of: ${[...VALID_IDENTIFIER_ROLES]
+                    .map((value) => JSON.stringify(value))
+                    .join(", ")}`
+        );
+    }
+
+    return role;
+}
+
+export { IdentifierRole };

--- a/src/plugin/tests/project-index-identifier-roles.test.js
+++ b/src/plugin/tests/project-index-identifier-roles.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    IdentifierRole,
+    assertValidIdentifierRole
+} from "../src/project-index/identifier-roles.js";
+
+test("assertValidIdentifierRole accepts declared roles", () => {
+    assert.equal(
+        assertValidIdentifierRole(IdentifierRole.Declaration),
+        IdentifierRole.Declaration
+    );
+    assert.equal(
+        assertValidIdentifierRole(IdentifierRole.Reference),
+        IdentifierRole.Reference
+    );
+});
+
+test("assertValidIdentifierRole rejects unknown values", () => {
+    assert.throws(() => assertValidIdentifierRole("not-a-role"), {
+        name: "TypeError",
+        message: /Invalid identifier role/i
+    });
+});


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
