### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -177,3 +177,14 @@ no code changes were required.
   the wide manager surface.
 - Updated the unit tests to assert against the segregated services, ensuring
   each interface exposes only the behaviour it owns.
+
+## Follow-up audit (2025-11-19)
+
+- Re-audited the CLI plugin default services and found the
+  `CliIdentifierCaseServices` bundle lingering in
+  `src/cli/plugin/service-providers/default.js`. The bundle coupled the
+  preparation and cache collaborators into a single "services" interface,
+  forcing callers that only needed one helper to depend on both behaviours.
+- Removed the aggregated contract and now return only the focused preparation
+  and cache services. Updated the accompanying unit tests to assert against the
+  specialised collaborators and verify the bundle property no longer exists.

--- a/src/cli/plugin/service-providers/default.js
+++ b/src/cli/plugin/service-providers/default.js
@@ -29,20 +29,6 @@ import { defaultCliPluginServiceDependencies } from "./default-service-dependenc
  * @property {() => void} clearIdentifierCaseCaches
  */
 
-/**
- * Earlier iterations shipped a `defaultCliPluginServices` registry that
- * coupled the project index helpers with identifier case collaborators. That
- * umbrella forced consumers that only needed one family to depend on the other
- * as well. We now expose the specialised bundles separately so callers can
- * wire the exact behaviour they require.
- */
-
-/**
- * @typedef {object} CliIdentifierCaseServices
- * @property {CliIdentifierCasePlanPreparationService} preparation
- * @property {CliIdentifierCasePlanCacheService} cache
- */
-
 function resolveDescriptorSource(descriptorSource) {
     if (descriptorSource == null) {
         return {};
@@ -111,12 +97,13 @@ export function createDefaultCliPluginServices(descriptorSource) {
         })
     );
 
-    const identifierCaseServices = Object.freeze(
-        /** @type {CliIdentifierCaseServices} */ ({
-            preparation: identifierCasePlanPreparationService,
-            cache: identifierCasePlanCacheService
-        })
-    );
+    /**
+     * Earlier iterations exposed a `CliIdentifierCaseServices` bundle that
+     * coupled the preparation and cache collaborators behind one "services"
+     * contract. That umbrella forced consumers that only needed one helper to
+     * depend on both. We now return only the focused services so call sites can
+     * opt into the precise collaborator they require.
+     */
 
     return {
         projectIndexBuilder,
@@ -124,8 +111,7 @@ export function createDefaultCliPluginServices(descriptorSource) {
         identifierCaseCacheClearer,
         projectIndexService,
         identifierCasePlanPreparationService,
-        identifierCasePlanCacheService,
-        identifierCaseServices
+        identifierCasePlanCacheService
     };
 }
 
@@ -136,8 +122,7 @@ const {
     projectIndexService: defaultCliProjectIndexService,
     identifierCasePlanPreparationService:
         defaultCliIdentifierCasePlanPreparationService,
-    identifierCasePlanCacheService: defaultCliIdentifierCaseCacheService,
-    identifierCaseServices: defaultCliIdentifierCaseServices
+    identifierCasePlanCacheService: defaultCliIdentifierCaseCacheService
 } = createDefaultCliPluginServices();
 
 export { defaultProjectIndexBuilder };
@@ -147,4 +132,3 @@ export { defaultIdentifierCaseCacheClearer };
 export { defaultCliProjectIndexService };
 export { defaultCliIdentifierCasePlanPreparationService };
 export { defaultCliIdentifierCaseCacheService };
-export { defaultCliIdentifierCaseServices };

--- a/src/cli/tests/plugin-service-registry.test.js
+++ b/src/cli/tests/plugin-service-registry.test.js
@@ -5,7 +5,6 @@ import {
     createDefaultCliPluginServices,
     defaultCliIdentifierCasePlanPreparationService,
     defaultCliIdentifierCaseCacheService,
-    defaultCliIdentifierCaseServices,
     defaultCliProjectIndexService,
     defaultIdentifierCaseCacheClearer,
     defaultIdentifierCasePlanPreparer,
@@ -25,12 +24,6 @@ test("CLI plugin services expose validated defaults", () => {
         defaultProjectIndexBuilder,
         "project index service should expose the default builder"
     );
-    const identifierCaseServices = defaultCliIdentifierCaseServices;
-    assert.ok(
-        Object.isFrozen(identifierCaseServices),
-        "identifier case service bundle should be frozen"
-    );
-
     const identifierCasePlanPreparationService =
         defaultCliIdentifierCasePlanPreparationService;
     assert.ok(
@@ -43,14 +36,13 @@ test("CLI plugin services expose validated defaults", () => {
         "preparation service should expose the default preparer"
     );
     assert.strictEqual(
-        identifierCaseServices.preparation,
-        identifierCasePlanPreparationService,
-        "identifier case bundle should expose the preparation service"
-    );
-    assert.strictEqual(
         services.identifierCasePlanPreparationService.prepareIdentifierCasePlan,
         identifierCasePlanPreparationService.prepareIdentifierCasePlan,
         "service factory should expose the preparation function"
+    );
+    assert.ok(
+        Object.isFrozen(services.identifierCasePlanPreparationService),
+        "service factory should expose a frozen preparation service"
     );
 
     const identifierCasePlanCacheService = defaultCliIdentifierCaseCacheService;
@@ -64,26 +56,15 @@ test("CLI plugin services expose validated defaults", () => {
         "cache service should expose the default cache clearer"
     );
     assert.strictEqual(
-        identifierCaseServices.cache,
-        identifierCasePlanCacheService,
-        "identifier case bundle should expose the cache service"
-    );
-    assert.strictEqual(
         services.identifierCasePlanCacheService.clearIdentifierCaseCaches,
         identifierCasePlanCacheService.clearIdentifierCaseCaches,
         "service factory should expose the cache function"
     );
+    assert.ok(
+        Object.isFrozen(services.identifierCasePlanCacheService),
+        "service factory should expose a frozen cache service"
+    );
 
-    assert.strictEqual(
-        identifierCaseServices.preparation.prepareIdentifierCasePlan,
-        defaultIdentifierCasePlanPreparer,
-        "preparation bundle should expose the default preparer"
-    );
-    assert.strictEqual(
-        identifierCaseServices.cache.clearIdentifierCaseCaches,
-        defaultIdentifierCaseCacheClearer,
-        "cache bundle should expose the default clearer"
-    );
     assert.ok(
         Object.prototype.hasOwnProperty.call(
             services,
@@ -92,18 +73,11 @@ test("CLI plugin services expose validated defaults", () => {
         "root registry should no longer expose the combined plan service"
     );
     assert.ok(
-        Object.isFrozen(services.identifierCaseServices),
-        "service factory should expose a frozen identifier case bundle"
-    );
-    assert.strictEqual(
-        services.identifierCaseServices.preparation.prepareIdentifierCasePlan,
-        identifierCaseServices.preparation.prepareIdentifierCasePlan,
-        "identifier case bundle should expose the preparation function"
-    );
-    assert.strictEqual(
-        services.identifierCaseServices.cache.clearIdentifierCaseCaches,
-        identifierCaseServices.cache.clearIdentifierCaseCaches,
-        "identifier case bundle should expose the cache function"
+        Object.prototype.hasOwnProperty.call(
+            services,
+            "identifierCaseServices"
+        ) === false,
+        "service factory should not expose an identifier case services bundle"
     );
     assert.strictEqual(
         projectIndexService.buildProjectIndex,
@@ -194,18 +168,11 @@ test("default plugin services can be customized with overrides", () => {
         "cache service should wrap override clearer"
     );
     assert.ok(
-        Object.isFrozen(services.identifierCaseServices),
-        "identifier case service bundle should remain frozen"
-    );
-    assert.strictEqual(
-        services.identifierCaseServices.preparation,
-        services.identifierCasePlanPreparationService,
-        "identifier case services should reuse the preparation bundle"
-    );
-    assert.strictEqual(
-        services.identifierCaseServices.cache,
-        services.identifierCasePlanCacheService,
-        "identifier case services should reuse the cache bundle"
+        Object.prototype.hasOwnProperty.call(
+            services,
+            "identifierCaseServices"
+        ) === false,
+        "service factory overrides should not add an identifier case bundle"
     );
 });
 


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
