### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/plugin/src/options/line-comment-options.js
+++ b/src/plugin/src/options/line-comment-options.js
@@ -1,3 +1,5 @@
+import { isRegExpLike } from "../shared/index.js";
+
 const LINE_COMMENT_BANNER_DETECTION_MIN_SLASHES = 5;
 const LINE_COMMENT_BANNER_STANDARD_LENGTH = 60;
 
@@ -67,7 +69,7 @@ function normalizeBoilerplateFragments(fragments) {
 function normalizeCodeDetectionPatterns(patterns) {
     return normalizeArrayOption(patterns, {
         defaultValue: DEFAULT_LINE_COMMENT_OPTIONS.codeDetectionPatterns,
-        filter: (value) => value instanceof RegExp
+        filter: (value) => isRegExpLike(value)
     });
 }
 

--- a/src/plugin/src/plugin-components.js
+++ b/src/plugin/src/plugin-components.js
@@ -1,4 +1,4 @@
-import { resolveAbortSignalFromOptions } from "./shared/index.js";
+import { isAbortError, resolveAbortSignalFromOptions } from "./shared/index.js";
 import { createDefaultGmlPluginComponents } from "./component-providers/default-plugin-components.js";
 import { normalizeGmlPluginComponents } from "./component-providers/plugin-component-normalizer.js";
 
@@ -75,7 +75,7 @@ export function addGmlPluginComponentObserver(observer, options = {}) {
             fallbackMessage: OBSERVER_ABORT_MESSAGE
         });
     } catch (error) {
-        if (error?.name === "AbortError") {
+        if (isAbortError(error)) {
             return () => {};
         }
 

--- a/src/shared/tests/abort-utils.test.js
+++ b/src/shared/tests/abort-utils.test.js
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
     createAbortError,
     createAbortGuard,
+    isAbortError,
     throwIfAborted
 } from "../utils/abort.js";
 
@@ -49,6 +50,27 @@ describe("createAbortError", () => {
         const signal = { aborted: true, reason: undefined };
         const error = createAbortError(signal, "custom abort message");
         assert.equal(error.message, "custom abort message");
+    });
+});
+
+describe("isAbortError", () => {
+    it("identifies errors produced by createAbortError", () => {
+        const signal = { aborted: true, reason: "stop" };
+        const error = createAbortError(signal, "fallback");
+        assert.equal(isAbortError(error), true);
+    });
+
+    it("brands reused abort reasons", () => {
+        const reason = new Error("cancelled");
+        const signal = { aborted: true, reason };
+        const error = createAbortError(signal, "fallback");
+        assert.strictEqual(error, reason);
+        assert.equal(isAbortError(error), true);
+    });
+
+    it("returns false for non-abort errors", () => {
+        assert.equal(isAbortError(new Error("boom")), false);
+        assert.equal(isAbortError(null), false);
     });
 });
 

--- a/src/shared/utils/abort.js
+++ b/src/shared/utils/abort.js
@@ -1,5 +1,7 @@
 import { getNonEmptyString } from "./string.js";
 
+const abortErrorBrand = new WeakSet();
+
 const DEFAULT_ABORT_MESSAGE = "Operation aborted.";
 const ERROR_METADATA_KEYS = ["message", "name", "stack"];
 
@@ -50,6 +52,13 @@ function normalizeAbortError(reason, fallbackMessage) {
         error.message = fallback;
     }
 
+    if (
+        (typeof error === "object" && error !== null) ||
+        typeof error === "function"
+    ) {
+        abortErrorBrand.add(error);
+    }
+
     return error;
 }
 
@@ -77,6 +86,18 @@ export function createAbortError(
     }
 
     return normalizeAbortError(signal.reason, fallbackMessage);
+}
+
+export function isAbortError(value) {
+    if (value == null) {
+        return false;
+    }
+
+    if (abortErrorBrand.has(value)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
