### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -188,3 +188,17 @@ no code changes were required.
 - Removed the aggregated contract and now return only the focused preparation
   and cache services. Updated the accompanying unit tests to assert against the
   specialised collaborators and verify the bundle property no longer exists.
+
+## Follow-up audit (2025-12-03)
+
+- Surveyed the manual command helpers and found the
+  `ManualCommandFileService`/`ManualCommandRefResolutionService` facades in
+  `src/cli/features/manual/context.js`. Each wrapped a single GitHub helper but
+  still forced consumers of the manual access context to depend on nested
+  service objects before they could reach the `fetchManualFile` or
+  `resolveManualRef` collaborators they actually needed.
+- Removed the indirection by updating the manual access helpers to expose the
+  direct functions alongside the environment metadata. CLI commands now import
+  the focused helpers (`fetchManualFile`, `resolveManualRef`) without going
+  through the broad service wrappers, and the unit tests assert the narrowed
+  surface.

--- a/src/cli/commands/generate-feather-metadata.js
+++ b/src/cli/commands/generate-feather-metadata.js
@@ -68,12 +68,8 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    fileAccess: {
-        files: { fetchManualFile }
-    },
-    referenceAccess: {
-        refs: { resolveManualRef }
-    }
+    fetchManualFile,
+    resolveManualRef
 } = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml feather metadata generator",

--- a/src/cli/commands/generate-gml-identifiers.js
+++ b/src/cli/commands/generate-gml-identifiers.js
@@ -45,12 +45,8 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    fileAccess: {
-        files: { fetchManualFile }
-    },
-    referenceAccess: {
-        refs: { resolveManualRef }
-    }
+    fetchManualFile,
+    resolveManualRef
 } = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml identifier generator",

--- a/src/cli/features/manual/context.js
+++ b/src/cli/features/manual/context.js
@@ -83,22 +83,22 @@ function resolveOutputPath(repoRoot, fileName) {
  */
 
 /**
- * @typedef {object} ManualFileAccessContext
+ * @typedef {object} ManualFileAccess
  * @property {ManualCommandEnvironment} environment
- * @property {ManualCommandFileService} files
+ * @property {ManualCommandFileService["fetchManualFile"]} fetchManualFile
  */
 
 /**
- * @typedef {object} ManualReferenceAccessContext
+ * @typedef {object} ManualReferenceAccess
  * @property {ManualCommandEnvironment} environment
- * @property {ManualCommandRefResolutionService} refs
+ * @property {ManualCommandRefResolutionService["resolveManualRef"]} resolveManualRef
  */
 
 /**
- * @typedef {object} ManualAccessContexts
+ * @typedef {object} ManualAccessBundle
  * @property {ManualCommandEnvironment} environment
- * @property {ManualFileAccessContext} fileAccess
- * @property {ManualReferenceAccessContext} referenceAccess
+ * @property {ManualCommandFileService["fetchManualFile"]} fetchManualFile
+ * @property {ManualCommandRefResolutionService["resolveManualRef"]} resolveManualRef
  */
 
 function buildManualCommandContext({
@@ -169,11 +169,17 @@ function buildManualCommandContext({
 }
 
 function mapManualFileAccessContext({ environment, files }) {
-    return Object.freeze({ environment, files });
+    return Object.freeze({
+        environment,
+        fetchManualFile: files.fetchManualFile
+    });
 }
 
 function mapManualReferenceAccessContext({ environment, refs }) {
-    return Object.freeze({ environment, refs });
+    return Object.freeze({
+        environment,
+        resolveManualRef: refs.resolveManualRef
+    });
 }
 
 function resolveManualContextSelection(options = {}, selector, { label } = {}) {
@@ -211,7 +217,7 @@ export function createManualEnvironmentContext(options = {}) {
  * information commonly needed by artefact generators.
  *
  * @param {Parameters<typeof buildManualCommandContext>[0]} options
- * @returns {ManualFileAccessContext}
+ * @returns {ManualFileAccess}
  */
 export function createManualFileAccessContext(options = {}) {
     return mapManualFileAccessContext(buildManualCommandContext(options));
@@ -221,7 +227,7 @@ export function createManualFileAccessContext(options = {}) {
  * Resolve manual reference helpers along with the shared environment metadata.
  *
  * @param {Parameters<typeof buildManualCommandContext>[0]} options
- * @returns {ManualReferenceAccessContext}
+ * @returns {ManualReferenceAccess}
  */
 export function createManualReferenceAccessContext(options = {}) {
     return mapManualReferenceAccessContext(buildManualCommandContext(options));
@@ -232,14 +238,16 @@ export function createManualReferenceAccessContext(options = {}) {
  * underlying GitHub wiring and shared environment metadata.
  *
  * @param {Parameters<typeof buildManualCommandContext>[0]} options
- * @returns {ManualAccessContexts}
+ * @returns {ManualAccessBundle}
  */
 export function createManualAccessContexts(options = {}) {
     const context = buildManualCommandContext(options);
+    const fileAccess = mapManualFileAccessContext(context);
+    const referenceAccess = mapManualReferenceAccessContext(context);
     return Object.freeze({
         environment: context.environment,
-        fileAccess: mapManualFileAccessContext(context),
-        referenceAccess: mapManualReferenceAccessContext(context)
+        fetchManualFile: fileAccess.fetchManualFile,
+        resolveManualRef: referenceAccess.resolveManualRef
     });
 }
 

--- a/src/cli/tests/manual-command-context.test.js
+++ b/src/cli/tests/manual-command-context.test.js
@@ -25,7 +25,7 @@ test("createManualAccessContexts centralizes manual access defaults", () => {
         path.resolve("src/cli/commands/generate-gml-identifiers.js")
     ).href;
 
-    const { environment, fileAccess, referenceAccess } =
+    const { environment, fetchManualFile, resolveManualRef } =
         createManualAccessContexts({
             importMetaUrl: commandUrl,
             userAgent: "manual-context-test",
@@ -47,12 +47,8 @@ test("createManualAccessContexts centralizes manual access defaults", () => {
         buildManualRepositoryEndpoints().rawRoot
     );
     assert.ok(Object.isFrozen(environment));
-    assert.ok(Object.isFrozen(fileAccess));
-    assert.ok(Object.isFrozen(referenceAccess));
-    assert.equal(fileAccess.environment, environment);
-    assert.equal(referenceAccess.environment, environment);
-    assert.equal(typeof fileAccess.files.fetchManualFile, "function");
-    assert.equal(typeof referenceAccess.refs.resolveManualRef, "function");
+    assert.equal(typeof fetchManualFile, "function");
+    assert.equal(typeof resolveManualRef, "function");
 });
 
 test("manual access helpers expose focused contexts", () => {
@@ -71,8 +67,8 @@ test("manual access helpers expose focused contexts", () => {
     });
 
     assert.deepStrictEqual(fileAccess.environment, referenceAccess.environment);
-    assert.equal(typeof fileAccess.files.fetchManualFile, "function");
-    assert.equal(typeof referenceAccess.refs.resolveManualRef, "function");
+    assert.equal(typeof fileAccess.fetchManualFile, "function");
+    assert.equal(typeof referenceAccess.resolveManualRef, "function");
 });
 
 test("manual GitHub helpers expose narrow collaborators", () => {


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
