### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -202,3 +202,15 @@ no code changes were required.
   the focused helpers (`fetchManualFile`, `resolveManualRef`) without going
   through the broad service wrappers, and the unit tests assert the narrowed
   surface.
+
+## Follow-up audit (2025-12-10)
+
+- Revisited the manual access utilities and found the exported
+  `ManualAccessBundle` still coupled file fetching and reference resolution
+  behind one umbrella. CLI commands destructured both collaborators even when a
+  change only needed one of them.
+- Replaced the bundle with `ManualAccessContexts`, which surfaces the shared
+  environment plus the focused `ManualFileAccess` and `ManualReferenceAccess`
+  views. Updated the manual CLI commands and unit tests to depend on the
+  specific context they require so each call site opts into only the manual
+  helper it consumes.

--- a/src/cli/commands/generate-feather-metadata.js
+++ b/src/cli/commands/generate-feather-metadata.js
@@ -68,8 +68,8 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    fetchManualFile,
-    resolveManualRef
+    fileAccess: { fetchManualFile },
+    referenceAccess: { resolveManualRef }
 } = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml feather metadata generator",

--- a/src/cli/commands/generate-gml-identifiers.js
+++ b/src/cli/commands/generate-gml-identifiers.js
@@ -45,8 +45,8 @@ const {
         defaultCacheRoot: DEFAULT_CACHE_ROOT,
         defaultOutputPath: OUTPUT_DEFAULT
     },
-    fetchManualFile,
-    resolveManualRef
+    fileAccess: { fetchManualFile },
+    referenceAccess: { resolveManualRef }
 } = createManualAccessContexts({
     importMetaUrl: import.meta.url,
     userAgent: "prettier-plugin-gml identifier generator",

--- a/src/cli/features/manual/context.js
+++ b/src/cli/features/manual/context.js
@@ -95,10 +95,17 @@ function resolveOutputPath(repoRoot, fileName) {
  */
 
 /**
- * @typedef {object} ManualAccessBundle
+ * Manual access helpers previously returned a catch-all "bundle" that exposed
+ * file fetching and reference resolution off the same object. Commands that
+ * only needed one collaborator still depended on both behaviours. Returning
+ * the focused access contexts keeps the shared environment available while
+ * letting call sites opt into the narrow collaborator they require.
+ */
+/**
+ * @typedef {object} ManualAccessContexts
  * @property {ManualCommandEnvironment} environment
- * @property {ManualCommandFileService["fetchManualFile"]} fetchManualFile
- * @property {ManualCommandRefResolutionService["resolveManualRef"]} resolveManualRef
+ * @property {ManualFileAccess} fileAccess
+ * @property {ManualReferenceAccess} referenceAccess
  */
 
 function buildManualCommandContext({
@@ -238,7 +245,7 @@ export function createManualReferenceAccessContext(options = {}) {
  * underlying GitHub wiring and shared environment metadata.
  *
  * @param {Parameters<typeof buildManualCommandContext>[0]} options
- * @returns {ManualAccessBundle}
+ * @returns {ManualAccessContexts}
  */
 export function createManualAccessContexts(options = {}) {
     const context = buildManualCommandContext(options);
@@ -246,8 +253,8 @@ export function createManualAccessContexts(options = {}) {
     const referenceAccess = mapManualReferenceAccessContext(context);
     return Object.freeze({
         environment: context.environment,
-        fetchManualFile: fileAccess.fetchManualFile,
-        resolveManualRef: referenceAccess.resolveManualRef
+        fileAccess,
+        referenceAccess
     });
 }
 

--- a/src/cli/tests/manual-command-context.test.js
+++ b/src/cli/tests/manual-command-context.test.js
@@ -25,12 +25,15 @@ test("createManualAccessContexts centralizes manual access defaults", () => {
         path.resolve("src/cli/commands/generate-gml-identifiers.js")
     ).href;
 
-    const { environment, fetchManualFile, resolveManualRef } =
-        createManualAccessContexts({
-            importMetaUrl: commandUrl,
-            userAgent: "manual-context-test",
-            outputFileName: "example.json"
-        });
+    const {
+        environment,
+        fileAccess: { fetchManualFile },
+        referenceAccess: { resolveManualRef }
+    } = createManualAccessContexts({
+        importMetaUrl: commandUrl,
+        userAgent: "manual-context-test",
+        outputFileName: "example.json"
+    });
 
     const expectedRepoRoot = path.resolve("src/cli/commands", "..", "..");
     assert.equal(environment.repoRoot, expectedRepoRoot);


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
