### PR TITLE
Codex: Add Extensibility Hook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,10 @@ sheet, then return here when you need deeper context.
   — Adjust the boilerplate stripping and commented-code heuristics without
   forking the formatter. Normalization guards keep overrides safe even when
   hosts provide partial data.
+- [Core option overrides hook](core-option-overrides-hook.md) — Swap or remove
+  the hard-coded Prettier clamps (such as `trailingComma: "none"`) when a host
+  needs different defaults, all while keeping the formatter opinionated by
+  default.
 - [Project index source extension hook](project-index-source-extensions-hook.md)
   — Extend the recognised GML suffix list so the identifier-case bootstrap and
   formatter refactors include generated or experimental file extensions.

--- a/docs/core-option-overrides-hook.md
+++ b/docs/core-option-overrides-hook.md
@@ -1,0 +1,38 @@
+# Core option overrides hook
+
+## Pre-change analysis
+- **Current behavior:** The plugin entry point in `src/plugin/src/gml.js` freezes a `CORE_OPTION_OVERRIDES` map that forces a handful of Prettier core options (for example `trailingComma: "none"` and `arrowParens: "always"`). Hosts that want to keep most defaults but relax or remove one of these clamps must fork the module because the overrides are not configurable.
+- **Proposed seam:** Introduce a resolver hook that produces the override map on demand. The hook keeps the existing defaults, validates incoming values against the supported Prettier choices, and allows hosts to either swap a value or drop an override entirely by returning `null`/`undefined` for that key.
+- **Default preservation:** Without a registered resolver we continue returning the frozen default override object, so `gml.js` merges the exact same map and all published behaviour stays opinionated by default.
+
+## Overview
+Advanced embedders such as custom CLI wrappers or editor integrations can now call
+`setCoreOptionOverridesResolver` to adjust the hard-coded overrides without exposing
+extra user configuration. The resolver receives the Prettier option bag (currently unused)
+and should return a partial override object: omit a property or return `null` to let user
+configs apply, or provide an alternate value like `"es5"` for `trailingComma`. Guardrails
+ensure only recognised Prettier values are accepted, falling back to the default map otherwise.
+
+Restore the defaults at any time with `restoreDefaultCoreOptionOverridesResolver`. The helper
+returns the canonical override map so wrappers can snapshot it when toggling behaviour.
+
+## Usage example
+```js
+import {
+    DEFAULT_CORE_OPTION_OVERRIDES,
+    setCoreOptionOverridesResolver
+} from "prettier-plugin-gamemaker/src/options/core-option-overrides.js";
+
+// Allow project-level trailingComma settings to take effect while keeping
+// other opinionated defaults unchanged.
+setCoreOptionOverridesResolver(() => ({
+    trailingComma: null,
+    arrowParens: DEFAULT_CORE_OPTION_OVERRIDES.arrowParens
+}));
+```
+
+## Future evolution
+The resolver currently guards the existing override keys. If the plugin adopts new
+opinionated clamps we can extend the validator table without breaking existing hooks.
+Likewise, future call sites may forward richer context (for example, workspace metadata)
+through the resolver parameters while keeping the default implementation side-effect free.

--- a/src/plugin/src/gml.js
+++ b/src/plugin/src/gml.js
@@ -6,6 +6,7 @@
  */
 
 import { resolveGmlPluginComponents } from "./plugin-components.js";
+import { resolveCoreOptionOverrides } from "./options/core-option-overrides.js";
 
 function selectPluginComponents() {
     return resolveGmlPluginComponents();
@@ -98,25 +99,6 @@ export const languages = [
     }
 ];
 
-// Hard overrides for GML regardless of incoming config. These knobs either map
-// to syntax that GameMaker never emits (for example JSX attributes) or would
-// let callers re-enable formatting modes the printers deliberately avoid. The
-// fixtures showcased in README.md#formatter-at-a-glance and the
-// docs/examples/* snapshots all assume "no trailing commas" plus
-// "always-parenthesised arrow parameters", so letting user configs flip those
-// bits would desynchronize the documented contract from the code we ship. We
-// therefore clamp the values here to advertise a single canonical style and to
-// prevent project-level `.prettierrc` files from surfacing ineffective or
-// misleading toggles.
-const CORE_OPTION_OVERRIDES = {
-    trailingComma: "none",
-    arrowParens: "always",
-    singleAttributePerLine: false,
-    jsxSingleQuote: false,
-    proseWrap: "preserve",
-    htmlWhitespaceSensitivity: "css"
-};
-
 const BASE_PRETTIER_DEFAULTS = {
     tabWidth: 4,
     semi: true,
@@ -143,12 +125,14 @@ function computeOptionDefaults() {
 }
 
 function createDefaultOptionsSnapshot() {
+    const coreOptionOverrides = resolveCoreOptionOverrides();
+
     return {
         // Merge order:
         // GML Prettier defaults -> option defaults -> fixed overrides
         ...BASE_PRETTIER_DEFAULTS,
         ...computeOptionDefaults(),
-        ...CORE_OPTION_OVERRIDES
+        ...coreOptionOverrides
     };
 }
 

--- a/src/plugin/src/identifier-case/asset-renames.js
+++ b/src/plugin/src/identifier-case/asset-renames.js
@@ -198,14 +198,15 @@ function detectAssetRenameConflicts({ projectIndex, renames, metrics = null }) {
             }
 
             const existingEntries = bucket.filter((entry) => !entry.isRename);
-            const existingCollisionSummary = existingEntries.length > 0
-                ? existingEntries
-                      .map(
-                          (entry) =>
-                              `'${entry.originalName}' (${entry.resourcePath})`
-                      )
-                      .join(", ")
-                : "";
+            const existingCollisionSummary =
+                existingEntries.length > 0
+                    ? existingEntries
+                          .map(
+                              (entry) =>
+                                  `'${entry.originalName}' (${entry.resourcePath})`
+                          )
+                          .join(", ")
+                    : "";
             const renameNames = renameEntries.map(
                 (entry) => `'${entry.originalName}'`
             );
@@ -227,9 +228,10 @@ function detectAssetRenameConflicts({ projectIndex, renames, metrics = null }) {
 
                 const otherRenames = [];
                 let otherNames = "";
-                for (
-                    const [otherIndex, otherEntry] of renameEntries.entries()
-                ) {
+                for (const [
+                    otherIndex,
+                    otherEntry
+                ] of renameEntries.entries()) {
                     if (otherIndex === index) {
                         continue;
                     }

--- a/src/plugin/src/options/core-option-overrides.js
+++ b/src/plugin/src/options/core-option-overrides.js
@@ -1,0 +1,133 @@
+// Hard overrides for GML regardless of incoming config. These knobs either map
+// to syntax that GameMaker never emits (for example JSX attributes) or would let
+// callers re-enable formatting modes the printers deliberately avoid. The
+// fixtures showcased in README.md#formatter-at-a-glance and the docs/examples/*
+// snapshots assume "no trailing commas" plus "always-parenthesised arrow
+// parameters", so letting user configs flip those bits would desynchronise the
+// documented contract from the code we ship. We therefore expose the default map
+// here while giving advanced hosts a narrow hook for swapping or removing
+// specific entries.
+
+const DEFAULT_CORE_OPTION_OVERRIDES = Object.freeze({
+    trailingComma: "none",
+    arrowParens: "always",
+    singleAttributePerLine: false,
+    jsxSingleQuote: false,
+    proseWrap: "preserve",
+    htmlWhitespaceSensitivity: "css"
+});
+
+const TRAILING_COMMA_VALUES = new Set(["none", "es5", "all"]);
+const ARROW_PARENS_VALUES = new Set(["always", "avoid"]);
+const PROSE_WRAP_VALUES = new Set(["always", "never", "preserve"]);
+const HTML_WHITESPACE_SENSITIVITY_VALUES = new Set(["css", "strict", "ignore"]);
+
+let coreOptionOverridesResolver = null;
+
+function normalizeBoolean(value) {
+    return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeChoice(value, allowedValues) {
+    if (typeof value !== "string") {
+        return;
+    }
+
+    return allowedValues.has(value) ? value : undefined;
+}
+
+const CORE_OVERRIDE_NORMALIZERS = {
+    trailingComma: (value) => normalizeChoice(value, TRAILING_COMMA_VALUES),
+    arrowParens: (value) => normalizeChoice(value, ARROW_PARENS_VALUES),
+    singleAttributePerLine: (value) => normalizeBoolean(value),
+    jsxSingleQuote: (value) => normalizeBoolean(value),
+    proseWrap: (value) => normalizeChoice(value, PROSE_WRAP_VALUES),
+    htmlWhitespaceSensitivity: (value) =>
+        normalizeChoice(value, HTML_WHITESPACE_SENSITIVITY_VALUES)
+};
+
+const CORE_OVERRIDE_KEYS = Object.keys(CORE_OVERRIDE_NORMALIZERS);
+
+function normalizeCoreOptionOverrides(overrides) {
+    if (overrides === DEFAULT_CORE_OPTION_OVERRIDES) {
+        return DEFAULT_CORE_OPTION_OVERRIDES;
+    }
+
+    if (!overrides || typeof overrides !== "object") {
+        return DEFAULT_CORE_OPTION_OVERRIDES;
+    }
+
+    const normalized = {};
+    let changed = false;
+
+    for (const key of CORE_OVERRIDE_KEYS) {
+        const defaultValue = DEFAULT_CORE_OPTION_OVERRIDES[key];
+
+        if (!Object.hasOwn(overrides, key)) {
+            normalized[key] = defaultValue;
+            continue;
+        }
+
+        const candidate = overrides[key];
+
+        if (candidate == null) {
+            changed = true;
+            continue;
+        }
+
+        const normalizer = CORE_OVERRIDE_NORMALIZERS[key];
+        const value = normalizer(candidate);
+
+        if (value === undefined) {
+            normalized[key] = defaultValue;
+            continue;
+        }
+
+        normalized[key] = value;
+        if (value !== defaultValue) {
+            changed = true;
+        }
+    }
+
+    if (
+        !changed &&
+        Object.keys(normalized).length === CORE_OVERRIDE_KEYS.length
+    ) {
+        return DEFAULT_CORE_OPTION_OVERRIDES;
+    }
+
+    return Object.freeze(normalized);
+}
+
+function resolveCoreOptionOverrides(options = {}) {
+    if (!coreOptionOverridesResolver) {
+        return DEFAULT_CORE_OPTION_OVERRIDES;
+    }
+
+    return normalizeCoreOptionOverrides(
+        coreOptionOverridesResolver(options) ?? DEFAULT_CORE_OPTION_OVERRIDES
+    );
+}
+
+function setCoreOptionOverridesResolver(resolver) {
+    if (typeof resolver !== "function") {
+        throw new TypeError(
+            "Core option override resolvers must be functions that return override objects"
+        );
+    }
+
+    coreOptionOverridesResolver = resolver;
+    return resolveCoreOptionOverrides();
+}
+
+function restoreDefaultCoreOptionOverridesResolver() {
+    coreOptionOverridesResolver = null;
+    return DEFAULT_CORE_OPTION_OVERRIDES;
+}
+
+export {
+    DEFAULT_CORE_OPTION_OVERRIDES,
+    resolveCoreOptionOverrides,
+    restoreDefaultCoreOptionOverridesResolver,
+    setCoreOptionOverridesResolver
+};

--- a/src/plugin/tests/core-option-overrides-resolver.test.js
+++ b/src/plugin/tests/core-option-overrides-resolver.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    DEFAULT_CORE_OPTION_OVERRIDES,
+    resolveCoreOptionOverrides,
+    restoreDefaultCoreOptionOverridesResolver,
+    setCoreOptionOverridesResolver
+} from "../src/options/core-option-overrides.js";
+
+describe("resolveCoreOptionOverrides", () => {
+    it("returns the default override map when no resolver is registered", () => {
+        const overrides = resolveCoreOptionOverrides();
+
+        assert.strictEqual(overrides, DEFAULT_CORE_OPTION_OVERRIDES);
+        assert.deepEqual(Object.keys(overrides).sort(), [
+            "arrowParens",
+            "htmlWhitespaceSensitivity",
+            "jsxSingleQuote",
+            "proseWrap",
+            "singleAttributePerLine",
+            "trailingComma"
+        ]);
+    });
+
+    it("allows hosts to replace opinionated values via the resolver hook", () => {
+        try {
+            setCoreOptionOverridesResolver(() => ({
+                trailingComma: "es5",
+                htmlWhitespaceSensitivity: "ignore"
+            }));
+
+            const overrides = resolveCoreOptionOverrides();
+
+            assert.equal(overrides.trailingComma, "es5");
+            assert.equal(overrides.htmlWhitespaceSensitivity, "ignore");
+            assert.equal(overrides.arrowParens, "always");
+            assert.equal(overrides.jsxSingleQuote, false);
+        } finally {
+            restoreDefaultCoreOptionOverridesResolver();
+        }
+    });
+
+    it("treats null or undefined entries as opt-outs so user configs can apply", () => {
+        try {
+            setCoreOptionOverridesResolver(() => ({
+                trailingComma: null,
+                arrowParens: undefined
+            }));
+
+            const overrides = resolveCoreOptionOverrides();
+
+            assert.ok(!Object.hasOwn(overrides, "trailingComma"));
+            assert.ok(!Object.hasOwn(overrides, "arrowParens"));
+            assert.equal(overrides.singleAttributePerLine, false);
+        } finally {
+            restoreDefaultCoreOptionOverridesResolver();
+        }
+    });
+
+    it("falls back to the default map when the resolver returns invalid data", () => {
+        try {
+            setCoreOptionOverridesResolver(() => ({
+                trailingComma: 42,
+                proseWrap: "ALWAYS"
+            }));
+
+            const overrides = resolveCoreOptionOverrides();
+
+            assert.strictEqual(overrides, DEFAULT_CORE_OPTION_OVERRIDES);
+        } finally {
+            restoreDefaultCoreOptionOverridesResolver();
+        }
+    });
+});


### PR DESCRIPTION
Seed PR for Codex to implement a targeted extensibility improvement while
keeping the defaults opinionated.

## Requirements
- Document the rigid decision point that makes extension difficult today.
- Explain the minimal seam or hook you will add before touching code.
- Avoid exposing new end-user configuration unless it is indispensable;
  prefer sensible defaults and internal extension points.
- When a new hook or option is warranted, clearly state who should use
  it, the default value, and the guardrails that keep the behavior
  predictable for everyone else.
- Update any impacted docs or inline comments, and keep behavior
  unchanged by default.
