### PR TITLE
Update regression detection workflow path

### DIFF
--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -145,7 +145,7 @@ jobs:
           export BASE_RESULTS_DIR="$(pwd)/junit-base"
           export MERGE_RESULTS_DIR="$(pwd)/junit-merge"
           # Falls back to head when merge isn't available (handled by your script)
-          node src/cli/commands/detect-test-regressions.mjs 2>&1 | tee "$log_file"
+          node src/cli/src/commands/detect-test-regressions.mjs 2>&1 | tee "$log_file"
           code=${PIPESTATUS[0]}
           if [ $code -eq 0 ]; then
             echo "all_green=true" >> "$GITHUB_OUTPUT"
@@ -180,7 +180,7 @@ jobs:
             const notes = [];
             const testResults = {};
 
-            const modulePath = path.resolve(process.cwd(), 'src/cli/commands/detect-test-regressions.mjs');
+            const modulePath = path.resolve(process.cwd(), 'src/cli/src/commands/detect-test-regressions.mjs');
             const regressionModule = await import(pathToFileURL(modulePath).href);
             const { readTestResults, detectRegressions } = regressionModule;
 


### PR DESCRIPTION
## Summary
- point the automerge regression detection step at the CLI command's new location within src/cli/src
- update the GitHub Script helper to import the regression helpers from the same path so the action can load the module

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68feb63530b4832fa276f8c94a486345