### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/plugin/src/ast-transforms/condense-logical-expressions.js
+++ b/src/plugin/src/ast-transforms/condense-logical-expressions.js
@@ -1,7 +1,7 @@
 import {
     hasComment as sharedHasComment,
     normalizeHasCommentHelpers,
-    resolveDocCommentLookupService,
+    resolveDocCommentPresenceService,
     resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "../comments/index.js";
@@ -52,7 +52,7 @@ export function condenseLogicalExpressions(ast, helpers) {
         return ast;
     }
 
-    const docCommentLookup = resolveDocCommentLookupService(ast);
+    const docCommentPresence = resolveDocCommentPresenceService(ast);
     const docCommentDescriptions = resolveDocCommentDescriptionService(ast);
     const docCommentUpdateService = resolveDocCommentUpdateService(ast);
     const normalizedHelpers = normalizeHasCommentHelpers(helpers);
@@ -60,7 +60,7 @@ export function condenseLogicalExpressions(ast, helpers) {
         ast,
         helpers: normalizedHelpers,
         docUpdates: new Map(),
-        docCommentLookup,
+        docCommentPresence,
         docCommentDescriptions,
         docCommentUpdateService,
         expressionSignatures: new Map()
@@ -192,7 +192,7 @@ function removeDuplicateCondensedFunctions(context) {
         return null;
     }
 
-    const docCommentLookup = context.docCommentLookup;
+    const docCommentPresence = context.docCommentPresence;
     const signatureToFunctions = new Map();
     for (const [fn, signature] of context.expressionSignatures.entries()) {
         if (!signature) {
@@ -232,7 +232,7 @@ function removeDuplicateCondensedFunctions(context) {
             const update = context.docUpdates.get(fn);
             const hasDocComment =
                 update?.hasDocComment ||
-                (docCommentLookup?.hasDocComment(fn) ?? false);
+                (docCommentPresence?.hasDocComment(fn) ?? false);
             if (hasDocComment && !keeper) {
                 keeper = fn;
             }
@@ -247,7 +247,7 @@ function removeDuplicateCondensedFunctions(context) {
                 const update = context.docUpdates.get(fn);
                 const hasDocComment =
                     update?.hasDocComment ||
-                    (docCommentLookup?.hasDocComment(fn) ?? false);
+                    (docCommentPresence?.hasDocComment(fn) ?? false);
                 if (!hasDocComment) {
                     toRemove.add(fn);
                 }

--- a/src/plugin/src/comments/doc-comment-manager.js
+++ b/src/plugin/src/comments/doc-comment-manager.js
@@ -12,7 +12,9 @@ import {
  * mutation operations. That wide surface forced transforms that only needed
  * read-only inspection to depend on update capabilities as well. Introducing
  * narrow inspection and update views lets collaborators wire only the
- * behaviours they actually require.
+ * behaviours they actually require. The legacy lookup surface also conflated
+ * retrieving full comment collections with simple presence checks, so this
+ * module exposes discrete collection and presence services.
  */
 
 const DOC_COMMENT_TARGET_TYPES = new Set([
@@ -27,7 +29,8 @@ const DOC_COMMENT_TARGET_TYPES = new Set([
 
 const DOC_COMMENT_MANAGERS = new WeakMap();
 const DOC_COMMENT_TRAVERSAL_SERVICES = new WeakMap();
-const DOC_COMMENT_LOOKUP_SERVICES = new WeakMap();
+const DOC_COMMENT_COLLECTION_SERVICES = new WeakMap();
+const DOC_COMMENT_PRESENCE_SERVICES = new WeakMap();
 const DOC_COMMENT_DESCRIPTION_SERVICES = new WeakMap();
 const DOC_COMMENT_UPDATE_SERVICES = new WeakMap();
 
@@ -79,8 +82,12 @@ export function prepareDocCommentEnvironment(ast) {
  */
 
 /**
- * @typedef {object} DocCommentLookupService
+ * @typedef {object} DocCommentCollectionService
  * @property {(functionNode: object) => Array<object>} getComments
+ */
+
+/**
+ * @typedef {object} DocCommentPresenceService
  * @property {(functionNode: object) => boolean} hasDocComment
  */
 
@@ -108,12 +115,21 @@ export function resolveDocCommentTraversalService(ast) {
     );
 }
 
-export function resolveDocCommentLookupService(ast) {
+export function resolveDocCommentCollectionService(ast) {
     return resolveDocCommentService(
         ast,
-        DOC_COMMENT_LOOKUP_SERVICES,
+        DOC_COMMENT_COLLECTION_SERVICES,
         (manager) => ({
-            getComments: manager.getComments.bind(manager),
+            getComments: manager.getComments.bind(manager)
+        })
+    );
+}
+
+export function resolveDocCommentPresenceService(ast) {
+    return resolveDocCommentService(
+        ast,
+        DOC_COMMENT_PRESENCE_SERVICES,
+        (manager) => ({
             hasDocComment: manager.hasDocComment.bind(manager)
         })
     );

--- a/src/plugin/src/comments/index.js
+++ b/src/plugin/src/comments/index.js
@@ -34,7 +34,8 @@ export {
 export {
     prepareDocCommentEnvironment,
     resolveDocCommentTraversalService,
-    resolveDocCommentLookupService,
+    resolveDocCommentCollectionService,
+    resolveDocCommentPresenceService,
     resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "./doc-comment-manager.js";

--- a/src/plugin/test/doc-comment-manager.test.js
+++ b/src/plugin/test/doc-comment-manager.test.js
@@ -3,7 +3,8 @@ import test from "node:test";
 
 import {
     resolveDocCommentTraversalService,
-    resolveDocCommentLookupService,
+    resolveDocCommentCollectionService,
+    resolveDocCommentPresenceService,
     resolveDocCommentDescriptionService,
     resolveDocCommentUpdateService
 } from "../src/comments/doc-comment-manager.js";
@@ -12,26 +13,26 @@ test("doc comment services expose segregated contracts", () => {
     const ast = { type: "Program", body: [] };
 
     const traversal = resolveDocCommentTraversalService(ast);
-    const lookup = resolveDocCommentLookupService(ast);
+    const collection = resolveDocCommentCollectionService(ast);
+    const presence = resolveDocCommentPresenceService(ast);
     const descriptions = resolveDocCommentDescriptionService(ast);
     const updates = resolveDocCommentUpdateService(ast);
 
     assert.ok(Object.isFrozen(traversal));
-    assert.ok(Object.isFrozen(lookup));
+    assert.ok(Object.isFrozen(collection));
+    assert.ok(Object.isFrozen(presence));
     assert.ok(Object.isFrozen(descriptions));
     assert.ok(Object.isFrozen(updates));
 
     assert.deepStrictEqual(Object.keys(traversal), ["forEach"]);
-    assert.deepStrictEqual(Object.keys(lookup), [
-        "getComments",
-        "hasDocComment"
-    ]);
+    assert.deepStrictEqual(Object.keys(collection), ["getComments"]);
+    assert.deepStrictEqual(Object.keys(presence), ["hasDocComment"]);
     assert.deepStrictEqual(Object.keys(descriptions), ["extractDescription"]);
     assert.deepStrictEqual(Object.keys(updates), ["applyUpdates"]);
 
     assert.strictEqual(typeof traversal.forEach, "function");
-    assert.strictEqual(typeof lookup.getComments, "function");
-    assert.strictEqual(typeof lookup.hasDocComment, "function");
+    assert.strictEqual(typeof collection.getComments, "function");
+    assert.strictEqual(typeof presence.hasDocComment, "function");
     assert.strictEqual(typeof descriptions.extractDescription, "function");
     assert.strictEqual(typeof updates.applyUpdates, "function");
 });
@@ -41,20 +42,24 @@ test("doc comment services reuse cached views and tolerate missing AST", () => {
 
     const firstTraversal = resolveDocCommentTraversalService(ast);
     const secondTraversal = resolveDocCommentTraversalService(ast);
-    const firstLookup = resolveDocCommentLookupService(ast);
-    const secondLookup = resolveDocCommentLookupService(ast);
+    const firstCollection = resolveDocCommentCollectionService(ast);
+    const secondCollection = resolveDocCommentCollectionService(ast);
+    const firstPresence = resolveDocCommentPresenceService(ast);
+    const secondPresence = resolveDocCommentPresenceService(ast);
     const firstDescriptions = resolveDocCommentDescriptionService(ast);
     const secondDescriptions = resolveDocCommentDescriptionService(ast);
     const firstUpdates = resolveDocCommentUpdateService(ast);
     const secondUpdates = resolveDocCommentUpdateService(ast);
 
     assert.strictEqual(firstTraversal, secondTraversal);
-    assert.strictEqual(firstLookup, secondLookup);
+    assert.strictEqual(firstCollection, secondCollection);
+    assert.strictEqual(firstPresence, secondPresence);
     assert.strictEqual(firstDescriptions, secondDescriptions);
     assert.strictEqual(firstUpdates, secondUpdates);
 
     const noopTraversal = resolveDocCommentTraversalService(null);
-    const noopLookup = resolveDocCommentLookupService(null);
+    const noopCollection = resolveDocCommentCollectionService(null);
+    const noopPresence = resolveDocCommentPresenceService();
     const noopDescriptions = resolveDocCommentDescriptionService();
     const noopUpdates = resolveDocCommentUpdateService();
 
@@ -64,8 +69,8 @@ test("doc comment services reuse cached views and tolerate missing AST", () => {
     });
     assert.strictEqual(visited, false);
 
-    assert.deepStrictEqual(noopLookup.getComments({}), []);
-    assert.strictEqual(noopLookup.hasDocComment({}), false);
+    assert.deepStrictEqual(noopCollection.getComments({}), []);
+    assert.strictEqual(noopPresence.hasDocComment({}), false);
     assert.strictEqual(noopDescriptions.extractDescription({}), null);
     assert.doesNotThrow(() => noopUpdates.applyUpdates(new Map()));
 });


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
