### PR TITLE
Codex: Separate policy evaluators from mechanisms

### DIFF
--- a/src/plugin/src/printer/statement-spacing-policy.js
+++ b/src/plugin/src/printer/statement-spacing-policy.js
@@ -1,0 +1,116 @@
+import { getNormalizedDefineReplacementDirective } from "./util.js";
+import { getBooleanLiteralValue } from "../shared/index.js";
+
+/**
+ * Encapsulates spacing heuristics so callers can reason about blank-line
+ * insertion without embedding policy logic in the printer's rendering paths.
+ */
+class StatementSpacingPolicy {
+    isMacroLikeStatement(node) {
+        const nodeType = node?.type;
+        if (!nodeType) {
+            return false;
+        }
+
+        if (nodeType === "MacroDeclaration") {
+            return true;
+        }
+
+        if (nodeType === "DefineStatement") {
+            return getNormalizedDefineReplacementDirective(node) === "#macro";
+        }
+
+        return false;
+    }
+
+    shouldSuppressEmptyLineBetween(previousNode, nextNode) {
+        if (!previousNode || !nextNode) {
+            return false;
+        }
+
+        if (
+            this.isMacroLikeStatement(previousNode) &&
+            this.isMacroLikeStatement(nextNode)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    shouldForceTrailingBlankLineForNestedFunction(
+        node,
+        blockNode,
+        containerNode
+    ) {
+        if (!isFunctionLikeDeclaration(node)) {
+            return false;
+        }
+
+        if (!blockNode || blockNode.type !== "BlockStatement") {
+            return false;
+        }
+
+        return isFunctionLikeDeclaration(containerNode);
+    }
+
+    shouldForceBlankLineBetweenReturnPaths(currentNode, nextNode) {
+        if (!currentNode || currentNode.type !== "IfStatement") {
+            return false;
+        }
+
+        if (!nextNode || nextNode.type !== "ReturnStatement") {
+            return false;
+        }
+
+        if (currentNode.alternate) {
+            return false;
+        }
+
+        const consequent = currentNode.consequent;
+        if (!consequent || consequent.type !== "BlockStatement") {
+            return false;
+        }
+
+        const body = Array.isArray(consequent.body) ? consequent.body : [];
+        let lastReturn = null;
+
+        for (let index = body.length - 1; index >= 0; index -= 1) {
+            const statement = body[index];
+            if (!statement) {
+                continue;
+            }
+
+            if (statement.type === "ReturnStatement") {
+                lastReturn = statement;
+                break;
+            }
+
+            return false;
+        }
+
+        if (!lastReturn) {
+            return false;
+        }
+
+        const consequentBoolean = getBooleanLiteralValue(lastReturn.argument);
+        const fallbackBoolean = getBooleanLiteralValue(nextNode.argument);
+
+        if (consequentBoolean === null || fallbackBoolean === null) {
+            return false;
+        }
+
+        return consequentBoolean !== fallbackBoolean;
+    }
+}
+
+function isFunctionLikeDeclaration(node) {
+    const nodeType = node?.type;
+    return (
+        nodeType === "FunctionDeclaration" ||
+        nodeType === "ConstructorDeclaration" ||
+        nodeType === "FunctionExpression"
+    );
+}
+
+export { StatementSpacingPolicy };

--- a/src/plugin/test/statement-spacing-policy.test.js
+++ b/src/plugin/test/statement-spacing-policy.test.js
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { StatementSpacingPolicy } from "../src/printer/statement-spacing-policy.js";
+
+describe("StatementSpacingPolicy", () => {
+    it("detects macro-like statements", () => {
+        const policy = new StatementSpacingPolicy();
+        const macroDeclaration = { type: "MacroDeclaration" };
+        const defineMacro = {
+            type: "DefineStatement",
+            replacementDirective: "#macro"
+        };
+        const unrelated = { type: "ReturnStatement" };
+
+        assert.equal(policy.isMacroLikeStatement(macroDeclaration), true);
+        assert.equal(policy.isMacroLikeStatement(defineMacro), true);
+        assert.equal(policy.isMacroLikeStatement(unrelated), false);
+        assert.equal(
+            policy.shouldSuppressEmptyLineBetween(macroDeclaration, null),
+            false
+        );
+        assert.equal(
+            policy.shouldSuppressEmptyLineBetween(
+                macroDeclaration,
+                defineMacro
+            ),
+            true
+        );
+        assert.equal(
+            policy.shouldSuppressEmptyLineBetween(macroDeclaration, unrelated),
+            false
+        );
+    });
+
+    it("requires nested functions to keep trailing padding", () => {
+        const policy = new StatementSpacingPolicy();
+        const nestedFunction = { type: "FunctionDeclaration" };
+        const block = { type: "BlockStatement" };
+        const container = { type: "FunctionExpression" };
+        const unrelatedContainer = { type: "StructDeclaration" };
+
+        assert.equal(
+            policy.shouldForceTrailingBlankLineForNestedFunction(
+                nestedFunction,
+                block,
+                container
+            ),
+            true
+        );
+        assert.equal(
+            policy.shouldForceTrailingBlankLineForNestedFunction(
+                nestedFunction,
+                block,
+                unrelatedContainer
+            ),
+            false
+        );
+    });
+
+    it("enforces padding between divergent return paths", () => {
+        const policy = new StatementSpacingPolicy();
+        const guardedReturn = {
+            type: "IfStatement",
+            alternate: null,
+            consequent: {
+                type: "BlockStatement",
+                body: [
+                    {
+                        type: "ReturnStatement",
+                        argument: { type: "Literal", value: "true" }
+                    }
+                ]
+            }
+        };
+        const fallbackReturn = {
+            type: "ReturnStatement",
+            argument: { type: "Literal", value: "false" }
+        };
+        const matchingFallback = {
+            type: "ReturnStatement",
+            argument: { type: "Literal", value: "true" }
+        };
+
+        assert.equal(
+            policy.shouldForceBlankLineBetweenReturnPaths(
+                guardedReturn,
+                fallbackReturn
+            ),
+            true
+        );
+        assert.equal(
+            policy.shouldForceBlankLineBetweenReturnPaths(
+                guardedReturn,
+                matchingFallback
+            ),
+            false
+        );
+    });
+});


### PR DESCRIPTION
## Summary
* Identify formatter modules where policy heuristics are intertwined with operational logic.
* Extract policy evaluators or strategy objects so that formatting actions can delegate to them.

## Testing
* npm test
