### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/cli/test/core-errors.test.js
+++ b/src/cli/test/core-errors.test.js
@@ -86,4 +86,15 @@ describe("cli error details", () => {
         assert.equal(details.code, undefined);
         assert.equal(details.stack, undefined);
     });
+
+    it("derives the error name from the @@toStringTag when missing", () => {
+        const tagError = {
+            message: "boom",
+            [Symbol.toStringTag]: "DOMException"
+        };
+
+        const details = createCliErrorDetails(tagError);
+
+        assert.equal(details.name, "DOMException");
+    });
 });


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
