### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -225,3 +225,18 @@ no code changes were required.
   the identifier-case service registry and unit tests to register the focused
   collaborators independently so each call site pulls in only the snapshot role
   it exercises.
+
+## Follow-up audit (2026-02-26)
+
+- Surveyed the shared metrics utilities and spotted the
+  `MetricsReportingTools` facade in
+  `src/shared/src/reporting/metrics.js`. The contract bundled summary
+  snapshotting, auto logging, and metadata updates into one surface, forcing
+  trackers that only needed to record metadata (or log summaries) to depend on
+  the entire reporting API.
+- Split the facade into focused collaborators: `MetricsSummaryReporter` for
+  snapshot/finalize, `MetricsSummaryLogger` for `logSummary`, and
+  `MetricsMetadataWriter` for metadata updates. Updated the tracker
+  implementation, semantic metrics helpers, and their unit tests to rely on the
+  specialised interfaces so call sites opt into only the reporting behaviour
+  they exercise.

--- a/src/semantic/src/identifier-case/local-plan.js
+++ b/src/semantic/src/identifier-case/local-plan.js
@@ -770,7 +770,7 @@ export async function prepareIdentifierCasePlan(options) {
     };
 
     for (const [key, value] of Object.entries(styleMetadataEntries)) {
-        metrics.reporting.setMetadata(key, value);
+        metrics.metadata.setMetadata(key, value);
     }
 
     const preservedIdentifiers = normalizedOptions.preservedIdentifiers;
@@ -784,7 +784,7 @@ export async function prepareIdentifierCasePlan(options) {
 
     const finalizeMetrics = (extraMetadata = {}) => {
         stopTotal();
-        const report = metrics.reporting.finalize({ metadata: extraMetadata });
+        const report = metrics.summary.finalize({ metadata: extraMetadata });
         setIdentifierCaseOption(
             options,
             "__identifierCaseMetricsReport",

--- a/src/semantic/src/project-index/index.js
+++ b/src/semantic/src/project-index/index.js
@@ -1955,8 +1955,8 @@ async function discoverProjectFilesForIndex({
     );
     ensureNotAborted();
 
-    metrics.reporting.setMetadata("yyFileCount", projectFiles.yyFiles.length);
-    metrics.reporting.setMetadata("gmlFileCount", projectFiles.gmlFiles.length);
+    metrics.metadata.setMetadata("yyFileCount", projectFiles.yyFiles.length);
+    metrics.metadata.setMetadata("gmlFileCount", projectFiles.gmlFiles.length);
 
     return projectFiles;
 }
@@ -1994,7 +1994,7 @@ function configureGmlProcessing({ options, metrics }) {
     const gmlConcurrency = clampConcurrency(
         concurrencySettings.gml ?? concurrencySettings.gmlParsing
     );
-    metrics.reporting.setMetadata("gmlParseConcurrency", gmlConcurrency);
+    metrics.metadata.setMetadata("gmlParseConcurrency", gmlConcurrency);
 
     const parseProjectSource = resolveProjectIndexParser(options);
 

--- a/src/semantic/src/project-index/metrics.js
+++ b/src/semantic/src/project-index/metrics.js
@@ -5,7 +5,9 @@ const REQUIRED_METRIC_GROUPS = Object.freeze({
     timers: ["startTimer", "timeAsync", "timeSync"],
     counters: ["increment"],
     caches: ["recordHit", "recordMiss", "recordStale", "recordMetric"],
-    reporting: ["snapshot", "finalize", "setMetadata", "logSummary"]
+    summary: ["snapshot", "finalize"],
+    logger: ["logSummary"],
+    metadata: ["setMetadata"]
 });
 
 function hasMetricGroup(candidate, groupName, methodNames) {
@@ -68,11 +70,15 @@ const NOOP_METRIC_GROUPS = Object.freeze({
         recordStale: noop,
         recordMetric: noop
     }),
-    reporting: Object.freeze({
+    summary: Object.freeze({
         snapshot: createMetricsSnapshot,
-        finalize: createMetricsSnapshot,
-        setMetadata: noop,
+        finalize: createMetricsSnapshot
+    }),
+    logger: Object.freeze({
         logSummary: noop
+    }),
+    metadata: Object.freeze({
+        setMetadata: noop
     })
 });
 
@@ -106,5 +112,5 @@ export function finalizeProjectIndexMetrics(metrics) {
         return null;
     }
 
-    return metrics.reporting.finalize();
+    return metrics.summary.finalize();
 }

--- a/src/semantic/test/project-index-metrics.test.js
+++ b/src/semantic/test/project-index-metrics.test.js
@@ -75,7 +75,7 @@ class TestMetricsTracker {
             recordStale() {},
             recordMetric() {}
         };
-        this.reporting = {
+        this.summary = {
             snapshot: (extra = {}) => ({
                 category: this.category,
                 totalTimeMs: 0,
@@ -96,9 +96,13 @@ class TestMetricsTracker {
                     metadata: { provided: true },
                     ...extra
                 };
-            },
-            setMetadata() {},
+            }
+        };
+        this.logger = {
             logSummary() {}
+        };
+        this.metadata = {
+            setMetadata() {}
         };
     }
     category = "custom-metrics";
@@ -161,7 +165,7 @@ test("createMetricsTracker trims and deduplicates configured cache keys", () => 
 
     tracker.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.snapshot().caches.demo, {
+    assert.deepEqual(tracker.summary.snapshot().caches.demo, {
         hits: 0,
         Misses: 0,
         custom: 0,
@@ -174,7 +178,7 @@ test("createMetricsTracker falls back to default cache keys when normalization i
 
     tracker.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.snapshot().caches.demo, {
+    assert.deepEqual(tracker.summary.snapshot().caches.demo, {
         hits: 0,
         misses: 0,
         stale: 0,
@@ -187,7 +191,7 @@ test("createMetricsTracker falls back to default cache keys when option is inval
 
     tracker.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.snapshot().caches.demo, {
+    assert.deepEqual(tracker.summary.snapshot().caches.demo, {
         hits: 0,
         misses: 0,
         stale: 0,

--- a/src/shared/src/reporting/metrics.js
+++ b/src/shared/src/reporting/metrics.js
@@ -64,10 +64,27 @@ const SUMMARY_SECTIONS = Object.freeze([
  */
 
 /**
- * @typedef {object} MetricsReportingTools
+ * Earlier iterations exposed a single `MetricsReportingTools` surface that
+ * coupled snapshotting, finalization, summary logging, and metadata writes.
+ * That wide contract forced callers that only needed one reporting behaviour
+ * to depend on the entire bundle. The specialised contracts below keep those
+ * responsibilities separate so consumers can import only the collaborator they
+ * require.
+ */
+
+/**
+ * @typedef {object} MetricsSummaryReporter
  * @property {(extra?: object) => MetricsSnapshot} snapshot
  * @property {(extra?: object) => MetricsSnapshot} finalize
+ */
+
+/**
+ * @typedef {object} MetricsSummaryLogger
  * @property {(message?: string, extra?: object) => void} logSummary
+ */
+
+/**
+ * @typedef {object} MetricsMetadataWriter
  * @property {(key: string, value: unknown) => void} setMetadata
  */
 
@@ -77,7 +94,9 @@ const SUMMARY_SECTIONS = Object.freeze([
  * @property {MetricsTimingTools} timers
  * @property {MetricsCounterTools} counters
  * @property {MetricsCacheTools} caches
- * @property {MetricsReportingTools} reporting
+ * @property {MetricsSummaryReporter} summary
+ * @property {MetricsSummaryLogger} logger
+ * @property {MetricsMetadataWriter} metadata
  */
 
 function toCandidateCacheKeys(keys) {
@@ -359,10 +378,16 @@ export function createMetricsTracker({
         }
     });
 
-    const reportingTools = Object.freeze({
+    const summaryTools = Object.freeze({
         snapshot,
-        finalize,
-        logSummary,
+        finalize
+    });
+
+    const loggerTools = Object.freeze({
+        logSummary
+    });
+
+    const metadataTools = Object.freeze({
         setMetadata
     });
 
@@ -371,6 +396,8 @@ export function createMetricsTracker({
         timers: timingTools,
         counters: counterTools,
         caches: cacheTools,
-        reporting: reportingTools
+        summary: summaryTools,
+        logger: loggerTools,
+        metadata: metadataTools
     };
 }

--- a/src/shared/test/metrics-utils.test.js
+++ b/src/shared/test/metrics-utils.test.js
@@ -5,7 +5,7 @@ import { createMetricsTracker } from "../src/reporting/index.js";
 
 function getCacheKeys(tracker, cacheName = "example") {
     tracker.caches.recordHit(cacheName);
-    return Object.keys(tracker.reporting.snapshot().caches[cacheName]);
+    return Object.keys(tracker.summary.snapshot().caches[cacheName]);
 }
 
 test("createMetricsTracker uses default cache keys when none provided", () => {

--- a/src/shared/test/reporting-metrics.test.js
+++ b/src/shared/test/reporting-metrics.test.js
@@ -13,9 +13,9 @@ test("snapshot exposes accumulated metrics as plain objects", () => {
     tracker.caches.recordMiss("project-index");
     tracker.caches.recordStale("project-index");
     tracker.caches.recordHit("project-index");
-    tracker.reporting.setMetadata("mode", "test");
+    tracker.metadata.setMetadata("mode", "test");
 
-    const report = tracker.reporting.snapshot({
+    const report = tracker.summary.snapshot({
         counters: { extra: 2 },
         caches: { extraCache: { hits: 5 } },
         metadata: { note: "ok" }
@@ -38,7 +38,7 @@ test("cache summaries include untouched counters", () => {
     const tracker = createMetricsTracker();
     tracker.caches.recordHit("default");
 
-    const report = tracker.reporting.snapshot();
+    const report = tracker.summary.snapshot();
     assert.deepEqual(report.caches.default, {
         hits: 1,
         misses: 0,
@@ -59,8 +59,8 @@ test("finalize logs once when auto logging is enabled", () => {
     });
 
     tracker.counters.increment("items", 3);
-    const report = tracker.reporting.finalize({ counters: { extra: 1 } });
-    const second = tracker.reporting.finalize({ counters: { extra: 999 } });
+    const report = tracker.summary.finalize({ counters: { extra: 1 } });
+    const second = tracker.summary.finalize({ counters: { extra: 999 } });
 
     assert.deepEqual(report.counters, { items: 3, extra: 1 });
     assert.equal(events.length, 1);
@@ -80,7 +80,7 @@ test("cache keys are configurable and support custom metrics", () => {
     tracker.caches.recordMetric("store", "evictions", 2);
     tracker.caches.recordMetric("store", "misses", 3);
 
-    const report = tracker.reporting.snapshot();
+    const report = tracker.summary.snapshot();
     assert.deepEqual(report.caches.store, {
         hits: 1,
         evictions: 2,
@@ -94,7 +94,7 @@ test("cache key normalization accepts delimited strings", () => {
     tracker.caches.recordHit("store");
     tracker.caches.recordMetric("store", "misses", 2);
 
-    const report = tracker.reporting.snapshot();
+    const report = tracker.summary.snapshot();
     assert.deepEqual(report.caches.store, {
         hits: 1,
         misses: 2
@@ -109,7 +109,7 @@ test("cache key normalization trims duplicates from iterable input", () => {
     tracker.caches.recordHit("store");
     tracker.caches.recordMetric("store", "misses", 2);
 
-    const report = tracker.reporting.snapshot();
+    const report = tracker.summary.snapshot();
     assert.deepEqual(report.caches.store, {
         hits: 1,
         misses: 2
@@ -120,7 +120,7 @@ test("cache key normalization falls back to defaults when empty", () => {
     const tracker = createMetricsTracker({ cacheKeys: [null, undefined] });
     tracker.caches.recordHit("store");
 
-    const report = tracker.reporting.snapshot();
+    const report = tracker.summary.snapshot();
     assert.deepEqual(report.caches.store, {
         hits: 1,
         misses: 0,
@@ -133,11 +133,11 @@ test("snapshot returns fresh copies of accumulated metrics", () => {
     tracker.counters.increment("runs");
     tracker.caches.recordHit("cache");
 
-    const first = tracker.reporting.snapshot();
+    const first = tracker.summary.snapshot();
     first.counters.runs = 99;
     first.caches.cache.hits = 42;
 
-    const second = tracker.reporting.snapshot();
+    const second = tracker.summary.snapshot();
     assert.deepEqual(second.counters, { runs: 1 });
     assert.deepEqual(second.caches.cache, { hits: 1, misses: 0, stale: 0 });
 });


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
