### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/plugin/src/comments/line-comment-formatting.js
+++ b/src/plugin/src/comments/line-comment-formatting.js
@@ -177,13 +177,44 @@ function mergeSpecifierPrefixes(target, candidates) {
     }
 }
 
+function tryGetEntriesIterator(candidate) {
+    if (
+        !candidate ||
+        Array.isArray(candidate) ||
+        (typeof candidate !== "object" && typeof candidate !== "function")
+    ) {
+        return null;
+    }
+
+    const { entries } = candidate;
+    if (typeof entries !== "function") {
+        return null;
+    }
+
+    try {
+        const iterator = entries.call(candidate);
+        if (iterator && typeof iterator[Symbol.iterator] === "function") {
+            return iterator;
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
 function* getEntryIterable(value) {
     if (!value) {
         return;
     }
 
-    if (value instanceof Map) {
-        yield* value.entries();
+    const entriesIterator = tryGetEntriesIterator(value);
+    if (entriesIterator) {
+        for (const entry of entriesIterator) {
+            if (Array.isArray(entry) && entry.length >= 2) {
+                yield [entry[0], entry[1]];
+            }
+        }
         return;
     }
 

--- a/src/plugin/src/comments/line-comment-formatting.js
+++ b/src/plugin/src/comments/line-comment-formatting.js
@@ -14,6 +14,32 @@ import {
 import { isRegExpLike } from "@prettier-plugin-gml/shared/utils/capability-probes.js";
 import { createResolverController } from "@prettier-plugin-gml/shared/utils/resolver-controller.js";
 
+const objectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+
+function hasOwn(object, property) {
+    return objectPrototypeHasOwnProperty.call(object, property);
+}
+
+function normalizeEntryPair(entry) {
+    if (Array.isArray(entry)) {
+        return entry.length >= 2 ? [entry[0], entry[1]] : null;
+    }
+
+    if (!entry || typeof entry !== "object") {
+        return null;
+    }
+
+    if (hasOwn(entry, 0) && hasOwn(entry, 1)) {
+        return [entry[0], entry[1]];
+    }
+
+    if (hasOwn(entry, "key") && hasOwn(entry, "value")) {
+        return [entry.key, entry.value];
+    }
+
+    return null;
+}
+
 const JSDOC_REPLACEMENTS = {
     "@func": "@function",
     "@method": "@function",
@@ -211,8 +237,9 @@ function* getEntryIterable(value) {
     const entriesIterator = tryGetEntriesIterator(value);
     if (entriesIterator) {
         for (const entry of entriesIterator) {
-            if (Array.isArray(entry) && entry.length >= 2) {
-                yield [entry[0], entry[1]];
+            const pair = normalizeEntryPair(entry);
+            if (pair) {
+                yield pair;
             }
         }
         return;
@@ -220,8 +247,9 @@ function* getEntryIterable(value) {
 
     if (Array.isArray(value)) {
         for (const entry of value) {
-            if (Array.isArray(entry) && entry.length >= 2) {
-                yield [entry[0], entry[1]];
+            const pair = normalizeEntryPair(entry);
+            if (pair) {
+                yield pair;
             }
         }
         return;

--- a/src/plugin/test/doc-comment-type-normalization.test.js
+++ b/src/plugin/test/doc-comment-type-normalization.test.js
@@ -140,3 +140,36 @@ test("doc comment normalization accepts entry-capable collaborators", () => {
         restoreDefaultDocCommentTypeNormalizationResolver();
     }
 });
+
+test("doc comment normalization ignores invalid entry shapes", () => {
+    const synonymsEntries = {
+        entries() {
+            return (function* () {
+                yield "not-a-pair";
+                yield { key: "Keyed", value: "value-normalized" };
+                yield { 0: "Indexed", 1: "indexed-normalized" };
+                yield { key: "MissingValue" };
+            })();
+        }
+    };
+
+    try {
+        setDocCommentTypeNormalizationResolver(() => ({
+            synonyms: synonymsEntries
+        }));
+
+        const normalization = resolveDocCommentTypeNormalization();
+        assert.equal(
+            normalization.lookupTypeIdentifier("Keyed"),
+            "value-normalized"
+        );
+        assert.equal(
+            normalization.lookupTypeIdentifier("Indexed"),
+            "indexed-normalized"
+        );
+        assert.equal(normalization.lookupTypeIdentifier("MissingValue"), null);
+        assert.equal(normalization.lookupTypeIdentifier("not-a-pair"), null);
+    } finally {
+        restoreDefaultDocCommentTypeNormalizationResolver();
+    }
+});


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
