### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/semantic/src/project-index/coordinator.js
+++ b/src/semantic/src/project-index/coordinator.js
@@ -5,6 +5,7 @@ import {
     throwIfAborted,
     toTrimmedString
 } from "../dependencies.js";
+import { ProjectIndexCacheStatus } from "./cache.js";
 
 function assertCoordinatorFunction(value, name) {
     const normalizedName = toTrimmedString(name) || "dependency";
@@ -78,7 +79,7 @@ async function executeEnsureReadyOperation({
     );
     throwIfAborted(signal, disposedMessage);
 
-    if (loadResult.status === "hit") {
+    if (loadResult.status === ProjectIndexCacheStatus.HIT) {
         throwIfAborted(signal, disposedMessage);
         return {
             source: "cache",

--- a/src/semantic/src/project-index/index.js
+++ b/src/semantic/src/project-index/index.js
@@ -99,6 +99,8 @@ export {
     setDefaultProjectIndexCacheMaxSize,
     applyProjectIndexCacheEnvOverride,
     ProjectIndexCacheMissReason,
+    ProjectIndexCacheStatus,
+    assertProjectIndexCacheStatus,
     loadProjectIndexCache,
     saveProjectIndexCache,
     deriveCacheKey


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
