### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/docs/interface-segregation-investigation.md
+++ b/docs/interface-segregation-investigation.md
@@ -270,3 +270,16 @@ no code changes were required.
   `ManualGitHubRequestExecutor` function type. Updated the manual utilities,
   context factory, and unit tests to accept the plain executor function so each
   collaborator depends only on the HTTP behaviour it actually invokes.
+
+## Follow-up audit (2026-12-11)
+
+- Revisited the shared metrics helpers and found the
+  `MetricsSummaryReporter` contract in `src/shared/src/reporting/metrics.js`
+  still bundled summary lifecycle helpers with cache inspection. Callers that
+  only needed to snapshot or finalize metrics were forced to depend on the
+  cache reporters.
+- Split the surface into `MetricsSummaryLifecycle` for snapshot/finalize and
+  `MetricsCacheReporter` for cache summaries. Updated the tracker factory,
+  project-index metrics guards, and associated unit tests to rely on the
+  specialised interfaces so consumers opt into only the reporting collaborator
+  they require.

--- a/src/semantic/src/project-index/metrics.js
+++ b/src/semantic/src/project-index/metrics.js
@@ -10,6 +10,7 @@ const REQUIRED_RECORDING_GROUPS = Object.freeze({
 
 const REQUIRED_REPORTING_GROUPS = Object.freeze({
     summary: ["snapshot", "finalize"],
+    caches: ["cachesSnapshot", "cacheSnapshot"],
     logger: ["logSummary"]
 });
 
@@ -103,6 +104,10 @@ const NOOP_METRIC_REPORTING_GROUPS = Object.freeze({
     summary: Object.freeze({
         snapshot: createMetricsSnapshot,
         finalize: createMetricsSnapshot
+    }),
+    caches: Object.freeze({
+        cachesSnapshot: () => ({}),
+        cacheSnapshot: () => {}
     }),
     logger: Object.freeze({
         logSummary: noop

--- a/src/semantic/test/project-index-metrics.test.js
+++ b/src/semantic/test/project-index-metrics.test.js
@@ -108,6 +108,10 @@ class TestMetricsTracker {
                     };
                 }
             }),
+            caches: Object.freeze({
+                cachesSnapshot: () => ({}),
+                cacheSnapshot: () => ({})
+            }),
             logger: Object.freeze({
                 logSummary() {}
             })
@@ -173,7 +177,7 @@ test("createMetricsTracker trims and deduplicates configured cache keys", () => 
 
     tracker.recording.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.summary.cacheSnapshot("demo"), {
+    assert.deepEqual(tracker.reporting.caches.cacheSnapshot("demo"), {
         hits: 0,
         Misses: 0,
         custom: 0,
@@ -186,7 +190,7 @@ test("createMetricsTracker falls back to default cache keys when normalization i
 
     tracker.recording.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.summary.cacheSnapshot("demo"), {
+    assert.deepEqual(tracker.reporting.caches.cacheSnapshot("demo"), {
         hits: 0,
         misses: 0,
         stale: 0,
@@ -199,7 +203,7 @@ test("createMetricsTracker falls back to default cache keys when option is inval
 
     tracker.recording.caches.recordMetric("demo", "custom", 0);
 
-    assert.deepEqual(tracker.reporting.summary.cacheSnapshot("demo"), {
+    assert.deepEqual(tracker.reporting.caches.cacheSnapshot("demo"), {
         hits: 0,
         misses: 0,
         stale: 0,

--- a/src/shared/src/reporting/metrics.js
+++ b/src/shared/src/reporting/metrics.js
@@ -64,18 +64,21 @@ const SUMMARY_SECTIONS = Object.freeze([
  */
 
 /**
- * Earlier iterations exposed a single `MetricsReportingTools` surface that
- * coupled snapshotting, finalization, summary logging, and metadata writes.
- * That wide contract forced callers that only needed one reporting behaviour
- * to depend on the entire bundle. The specialised contracts below keep those
- * responsibilities separate so consumers can import only the collaborator they
- * require.
+ * Earlier iterations exposed a single `MetricsSummaryReporter` surface that
+ * coupled summary lifecycle helpers with cache inspection. That wide contract
+ * forced callers that only needed the high-level snapshot tools to depend on
+ * the cache reporters (and vice versa). Splitting the collaborators lets
+ * dependents import only the behaviour they exercise.
  */
 
 /**
- * @typedef {object} MetricsSummaryReporter
+ * @typedef {object} MetricsSummaryLifecycle
  * @property {(extra?: object) => MetricsSnapshot} snapshot
  * @property {(extra?: object) => MetricsSnapshot} finalize
+ */
+
+/**
+ * @typedef {object} MetricsCacheReporter
  * @property {(extra?: object) => Record<string, Record<string, number>>} cachesSnapshot
  * @property {(
  *   cacheName: string,
@@ -104,7 +107,8 @@ const SUMMARY_SECTIONS = Object.freeze([
 
 /**
  * @typedef {object} MetricsReportingSuite
- * @property {MetricsSummaryReporter} summary
+ * @property {MetricsSummaryLifecycle} summary
+ * @property {MetricsCacheReporter} caches
  * @property {MetricsSummaryLogger} logger
  */
 
@@ -403,9 +407,12 @@ export function createMetricsTracker({
         return caches[normalized];
     }
 
-    const summaryTools = Object.freeze({
+    const summaryLifecycle = Object.freeze({
         snapshot,
-        finalize,
+        finalize
+    });
+
+    const cacheReporter = Object.freeze({
         cachesSnapshot,
         cacheSnapshot
     });
@@ -427,7 +434,8 @@ export function createMetricsTracker({
     });
 
     const reporting = Object.freeze({
-        summary: summaryTools,
+        summary: summaryLifecycle,
+        caches: cacheReporter,
         logger: loggerTools
     });
 

--- a/src/shared/test/metrics-utils.test.js
+++ b/src/shared/test/metrics-utils.test.js
@@ -6,7 +6,7 @@ import { createMetricsTracker } from "../src/reporting/index.js";
 function getCacheKeys(contracts, cacheName = "example") {
     const { recording, reporting } = contracts;
     recording.caches.recordHit(cacheName);
-    return Object.keys(reporting.summary.cacheSnapshot(cacheName) ?? {});
+    return Object.keys(reporting.caches.cacheSnapshot(cacheName) ?? {});
 }
 
 test("createMetricsTracker uses default cache keys when none provided", () => {

--- a/src/shared/test/reporting-metrics.test.js
+++ b/src/shared/test/reporting-metrics.test.js
@@ -42,7 +42,7 @@ test("cache summaries include untouched counters", () => {
     const { recording, reporting } = tracker;
     recording.caches.recordHit("default");
 
-    const stats = reporting.summary.cacheSnapshot("default");
+    const stats = reporting.caches.cacheSnapshot("default");
     assert.deepEqual(stats, {
         hits: 1,
         misses: 0,
@@ -55,7 +55,7 @@ test("cacheSnapshot falls back to full cache summary when name omitted", () => {
     const { recording, reporting } = tracker;
     recording.caches.recordHit("named");
 
-    const caches = reporting.summary.cacheSnapshot();
+    const caches = reporting.caches.cacheSnapshot();
     assert.deepEqual(caches.named, {
         hits: 1,
         misses: 0,


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
