### PR TITLE
Codex: Defensive Input Hardening

### DIFF
--- a/src/semantic/src/identifier-case/asset-rename-executor.js
+++ b/src/semantic/src/identifier-case/asset-rename-executor.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import {
+    assertPlainObject,
     getOrCreateMapEntry,
     isNonEmptyString,
     trimStringEntries,
@@ -58,10 +59,13 @@ function readJsonFile(fsFacade, absolutePath, cache) {
 
     const raw = fsFacade.readFileSync(absolutePath, "utf8");
     const parsed = parseJsonWithContext(raw, { source: absolutePath });
+    const resourceJson = assertPlainObject(parsed, {
+        errorMessage: `Resource JSON at ${absolutePath} must be a plain object.`
+    });
     if (cache) {
-        cache.set(absolutePath, parsed);
+        cache.set(absolutePath, resourceJson);
     }
-    return parsed;
+    return resourceJson;
 }
 
 function getObjectAtPath(json, propertyPath) {

--- a/src/semantic/test/identifier-case-asset-rename-executor.test.js
+++ b/src/semantic/test/identifier-case-asset-rename-executor.test.js
@@ -127,4 +127,22 @@ describe("asset rename executor JSON helpers", () => {
         assert.match(error.message, /\/tmp\/broken\.yy/);
         assert.ok(error.cause instanceof SyntaxError);
     });
+
+    it("rejects resource payloads that are not plain objects", () => {
+        const fsFacade = {
+            readFileSync() {
+                return "[]";
+            }
+        };
+
+        assert.throws(
+            () => {
+                readJsonFile(fsFacade, "/tmp/list.yy", new Map());
+            },
+            {
+                name: "TypeError",
+                message: "Resource JSON at /tmp/list.yy must be a plain object."
+            }
+        );
+    });
 });


### PR DESCRIPTION
Seed PR for Codex to reinforce defensive programming anywhere external data is accepted without validation or functions rely on `any`/loosely typed parameters. Tighten inputs before they can propagate invalid states.
