### PR TITLE
Codex: Interface Segregation Sweep

### DIFF
--- a/src/cli/src/plugin-runtime/service-providers/default.js
+++ b/src/cli/src/plugin-runtime/service-providers/default.js
@@ -7,7 +7,12 @@ import { resolveCliPluginServiceDependencies } from "./cli-plugin-service-depend
  * collaborators that only needed to warm caches or only needed to clear them
  * to depend on both behaviours. The typedefs below capture the narrower
  * preparation and cache responsibilities so consumers can opt into the precise
- * collaborator they require.
+ * collaborator they require. The shared factory previously returned both the
+ * raw implementation functions and the service facades together, which still
+ * coerced consumers that only needed the functions to depend on the facade
+ * objects (and vice versa). The split contracts separate the implementations
+ * from the facades so callers can import the exact collaborator family they
+ * require.
  */
 
 /**
@@ -29,13 +34,27 @@ import { resolveCliPluginServiceDependencies } from "./cli-plugin-service-depend
  * @property {() => void} clearIdentifierCaseCaches
  */
 
+/**
+ * @typedef {object} CliPluginServiceImplementations
+ * @property {CliProjectIndexBuilder} projectIndexBuilder
+ * @property {CliIdentifierCasePlanPreparationService["prepareIdentifierCasePlan"]} identifierCasePlanPreparer
+ * @property {CliIdentifierCasePlanCacheService["clearIdentifierCaseCaches"]} identifierCaseCacheClearer
+ */
+
+/**
+ * @typedef {object} CliPluginServiceFacades
+ * @property {CliProjectIndexService} projectIndexService
+ * @property {CliIdentifierCasePlanPreparationService} identifierCasePlanPreparationService
+ * @property {CliIdentifierCasePlanCacheService} identifierCasePlanCacheService
+ */
+
 function assertDescriptorValue(value, description) {
     assertFunction(value, description, {
         errorMessage: `CLI plugin service descriptors must include a ${description} function.`
     });
 }
 
-export function createDefaultCliPluginServices(descriptorOverrides) {
+function resolveCliPluginServiceImplementations(descriptorOverrides) {
     if (
         descriptorOverrides != null &&
         typeof descriptorOverrides !== "object"
@@ -72,6 +91,18 @@ export function createDefaultCliPluginServices(descriptorOverrides) {
         "clearIdentifierCaseCaches"
     );
 
+    return {
+        projectIndexBuilder,
+        identifierCasePlanPreparer,
+        identifierCaseCacheClearer
+    };
+}
+
+function createCliPluginServiceFacadesFromImplementations({
+    projectIndexBuilder,
+    identifierCasePlanPreparer,
+    identifierCaseCacheClearer
+}) {
     const projectIndexService = Object.freeze({
         buildProjectIndex: projectIndexBuilder
     });
@@ -88,33 +119,42 @@ export function createDefaultCliPluginServices(descriptorOverrides) {
         })
     );
 
-    /**
-     * Earlier iterations exposed a `CliIdentifierCaseServices` bundle that
-     * coupled the preparation and cache collaborators behind one "services"
-     * contract. That umbrella forced consumers that only needed one helper to
-     * depend on both. We now return only the focused services so call sites can
-     * opt into the precise collaborator they require.
-     */
-
     return {
-        projectIndexBuilder,
-        identifierCasePlanPreparer,
-        identifierCaseCacheClearer,
         projectIndexService,
         identifierCasePlanPreparationService,
         identifierCasePlanCacheService
     };
 }
 
+export function createDefaultCliPluginServiceImplementations(
+    descriptorOverrides
+) {
+    return resolveCliPluginServiceImplementations(descriptorOverrides);
+}
+
+export function createDefaultCliPluginServiceFacades(descriptorOverrides) {
+    const implementations =
+        resolveCliPluginServiceImplementations(descriptorOverrides);
+    return createCliPluginServiceFacadesFromImplementations(implementations);
+}
+
+const defaultImplementations = resolveCliPluginServiceImplementations();
+const defaultFacades = createCliPluginServiceFacadesFromImplementations(
+    defaultImplementations
+);
+
 const {
     projectIndexBuilder: defaultProjectIndexBuilder,
     identifierCasePlanPreparer: defaultIdentifierCasePlanPreparer,
-    identifierCaseCacheClearer: defaultIdentifierCaseCacheClearer,
+    identifierCaseCacheClearer: defaultIdentifierCaseCacheClearer
+} = defaultImplementations;
+
+const {
     projectIndexService: defaultCliProjectIndexService,
     identifierCasePlanPreparationService:
         defaultCliIdentifierCasePlanPreparationService,
     identifierCasePlanCacheService: defaultCliIdentifierCaseCacheService
-} = createDefaultCliPluginServices();
+} = defaultFacades;
 
 export {
     defaultProjectIndexBuilder,

--- a/src/cli/src/plugin-runtime/services.js
+++ b/src/cli/src/plugin-runtime/services.js
@@ -1,5 +1,5 @@
 import {
-    createDefaultCliPluginServices,
+    createDefaultCliPluginServiceImplementations,
     defaultCliProjectIndexService,
     defaultCliIdentifierCasePlanPreparationService,
     defaultCliIdentifierCaseCacheService
@@ -55,7 +55,7 @@ export function registerCliIdentifierCaseCacheClearer(clearer) {
 }
 
 export function resetRegisteredCliPluginServices() {
-    const services = createDefaultCliPluginServices();
+    const services = createDefaultCliPluginServiceImplementations();
 
     projectIndexBuilder = services.projectIndexBuilder;
     identifierCasePlanPreparer = services.identifierCasePlanPreparer;


### PR DESCRIPTION
Seed PR for Codex to inspect oversized interface or type contracts whose
names hint at overly broad responsibilities (for example, `*Service` or
`*Manager`).
