### PR TITLE
Codex: Stringly Typed Flags

### DIFF
--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1544,9 +1544,8 @@ export function print(path, options, print) {
         }
         case "DefineStatement": {
             const directive =
-                typeof node.replacementDirective === "string"
-                    ? node.replacementDirective
-                    : "#macro";
+                getNormalizedDefineReplacementDirective(node) ??
+                DefineReplacementDirective.MACRO;
             const suffixDoc =
                 typeof node.replacementSuffix === "string"
                     ? node.replacementSuffix

--- a/src/plugin/src/printer/print.js
+++ b/src/plugin/src/printer/print.js
@@ -1,6 +1,7 @@
 import { builders, utils } from "prettier/doc";
 
 import {
+    DefineReplacementDirective,
     isLastStatement,
     optionalSemicolon,
     isNextLineEmpty,
@@ -2900,7 +2901,8 @@ function printStatements(path, options, print, childrenAttribute) {
 
             const isMacroLikeNode = isMacroLikeStatement(node);
             const isDefineMacroReplacement =
-                getNormalizedDefineReplacementDirective(node) === "#macro";
+                getNormalizedDefineReplacementDirective(node) ===
+                DefineReplacementDirective.MACRO;
             const shouldForceMacroPadding =
                 isMacroLikeNode &&
                 !isDefineMacroReplacement &&

--- a/src/plugin/src/printer/statement-spacing-policy.js
+++ b/src/plugin/src/printer/statement-spacing-policy.js
@@ -1,4 +1,5 @@
 import {
+    DefineReplacementDirective,
     getNormalizedDefineReplacementDirective,
     isFunctionLikeDeclaration
 } from "./util.js";
@@ -15,7 +16,10 @@ function isMacroLikeStatement(node) {
     }
 
     if (nodeType === "DefineStatement") {
-        return getNormalizedDefineReplacementDirective(node) === "#macro";
+        return (
+            getNormalizedDefineReplacementDirective(node) ===
+            DefineReplacementDirective.MACRO
+        );
     }
 
     return false;

--- a/src/plugin/test/printer-util.test.js
+++ b/src/plugin/test/printer-util.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    DefineReplacementDirective,
+    getNormalizedDefineReplacementDirective
+} from "../src/printer/util.js";
+
+describe("printer util define replacement directive normalization", () => {
+    it("normalizes recognized directives case-insensitively", () => {
+        const regionNode = {
+            type: "DefineStatement",
+            replacementDirective: "#REGION"
+        };
+        const macroNode = {
+            type: "DefineStatement",
+            replacementDirective: "  #MACRO  "
+        };
+
+        assert.equal(
+            getNormalizedDefineReplacementDirective(regionNode),
+            DefineReplacementDirective.REGION
+        );
+        assert.equal(
+            getNormalizedDefineReplacementDirective(macroNode),
+            DefineReplacementDirective.MACRO
+        );
+    });
+
+    it("returns null when a define statement lacks a directive", () => {
+        assert.equal(getNormalizedDefineReplacementDirective(null), null);
+        assert.equal(
+            getNormalizedDefineReplacementDirective({
+                type: "DefineStatement"
+            }),
+            null
+        );
+        assert.equal(
+            getNormalizedDefineReplacementDirective({
+                type: "DefineStatement",
+                replacementDirective: "   "
+            }),
+            null
+        );
+    });
+
+    it("throws when the directive string is unsupported", () => {
+        assert.throws(
+            () =>
+                getNormalizedDefineReplacementDirective({
+                    type: "DefineStatement",
+                    replacementDirective: "#unknown"
+                }),
+            (error) =>
+                error instanceof RangeError && /#unknown/.test(error.message)
+        );
+    });
+});


### PR DESCRIPTION
Seed PR for Codex to replace a brittle magic string flag with a safer enum/constant approach and validation.
