### PR TITLE
Codex: Add Extensibility Hook

### DIFF
--- a/src/semantic/README.md
+++ b/src/semantic/README.md
@@ -37,3 +37,23 @@ analysis. The bootstrap generates `.prettier-plugin-gml/project-index-cache.json
 the first time a rename-enabled scope executes; pin `gmlIdentifierCaseProjectRoot`
 in CI builds to avoid repeated discovery work.
 
+## Resource Metadata Extension Hook
+
+**Pre-change analysis.** The project index previously treated only `.yy`
+resource documents as metadata, so integrations experimenting with alternate
+GameMaker exports (for example, bespoke build pipelines that emit `.meta`
+descriptors) had to fork the scanner whenever they wanted those files to be
+indexed. The formatter’s defaults remain correct for the vast majority of
+users, so the new seam keeps the behavior opinionated while allowing internal
+callers to extend it on demand.
+
+Use `setProjectResourceMetadataExtensions()` from the semantic project-index
+package to register additional metadata suffixes. The helper normalizes and
+deduplicates the list, seeds it with the default `.yy` entry, and is intended
+for host integrations, tests, or future live tooling—not end-user
+configuration. `resetProjectResourceMetadataExtensions()` restores the
+defaults, and `getProjectResourceMetadataExtensions()` exposes the frozen list
+for diagnostics. Production consumers should treat the defaults as canonical
+until downstream formats stabilize; the hook exists to unblock experimentation
+without diluting the formatter’s standard behavior.
+

--- a/src/semantic/src/project-index/constants.js
+++ b/src/semantic/src/project-index/constants.js
@@ -1,7 +1,139 @@
+import { getNonEmptyTrimmedString } from "../dependencies.js";
+
 export const PROJECT_MANIFEST_EXTENSION = ".yyp";
 
 const PROJECT_MANIFEST_EXTENSION_LOWER =
     PROJECT_MANIFEST_EXTENSION.toLowerCase();
+
+/**
+ * Canonical suffixes treated as GameMaker resource metadata. The formatter
+ * keeps this list opinionated by default and only expands it when callers
+ * explicitly opt in via the extension hook.
+ */
+const DEFAULT_RESOURCE_METADATA_EXTENSIONS = Object.freeze([".yy"]);
+
+let projectResourceMetadataExtensions = DEFAULT_RESOURCE_METADATA_EXTENSIONS;
+
+function normalizeResourceMetadataExtension(candidate) {
+    const trimmed = getNonEmptyTrimmedString(candidate);
+    if (!trimmed) {
+        return null;
+    }
+
+    const prefixed = trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+    if (prefixed === ".") {
+        return null;
+    }
+
+    return prefixed.toLowerCase();
+}
+
+function entriesMatchDefault(normalized) {
+    return (
+        normalized.length === DEFAULT_RESOURCE_METADATA_EXTENSIONS.length &&
+        normalized.every(
+            (value, index) =>
+                value === DEFAULT_RESOURCE_METADATA_EXTENSIONS[index]
+        )
+    );
+}
+
+function isIterable(candidate) {
+    return (
+        candidate != null &&
+        typeof candidate !== "string" &&
+        typeof candidate[Symbol.iterator] === "function"
+    );
+}
+
+function normalizeResourceMetadataExtensions(candidate) {
+    let values;
+
+    if (typeof candidate === "string") {
+        values = [candidate];
+    } else if (isIterable(candidate)) {
+        values = Array.from(candidate);
+    } else {
+        values = [];
+    }
+
+    const normalized = [...DEFAULT_RESOURCE_METADATA_EXTENSIONS];
+    const seen = new Set(normalized);
+
+    for (const entry of values) {
+        const extension = normalizeResourceMetadataExtension(entry);
+        if (!extension || seen.has(extension)) {
+            continue;
+        }
+
+        normalized.push(extension);
+        seen.add(extension);
+    }
+
+    if (normalized.length === DEFAULT_RESOURCE_METADATA_EXTENSIONS.length) {
+        return DEFAULT_RESOURCE_METADATA_EXTENSIONS;
+    }
+
+    return Object.freeze(normalized);
+}
+
+/**
+ * Return the normalized metadata extension when a candidate path matches one of
+ * the registered suffixes. The result keeps comparisons case-insensitive while
+ * allowing callers to trim the original value predictably.
+ */
+export function matchProjectResourceMetadataExtension(candidate) {
+    if (typeof candidate !== "string" || candidate.length === 0) {
+        return null;
+    }
+
+    const lowerCandidate = candidate.toLowerCase();
+    for (const extension of projectResourceMetadataExtensions) {
+        if (lowerCandidate.endsWith(extension)) {
+            return extension;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Return the frozen list of recognized resource metadata extensions. The array
+ * always exposes the canonical `.yy` suffix first so diagnostics remain
+ * predictable.
+ */
+export function getProjectResourceMetadataExtensions() {
+    return projectResourceMetadataExtensions;
+}
+
+/**
+ * Override the recognized resource metadata suffixes used while categorizing
+ * project files. Intended for internal integrations, tests, or experimental
+ * tooling—end users should rely on the opinionated defaults exposed by the
+ * formatter. The override list is normalized, deduplicated, and seeded with the
+ * stock `.yy` entry.
+ */
+export function setProjectResourceMetadataExtensions(extensions) {
+    projectResourceMetadataExtensions =
+        normalizeResourceMetadataExtensions(extensions);
+    return projectResourceMetadataExtensions;
+}
+
+/**
+ * Restore the resource metadata extension list to its default contents. Useful
+ * for tests that temporarily override the recognized suffixes.
+ */
+export function resetProjectResourceMetadataExtensions() {
+    projectResourceMetadataExtensions = DEFAULT_RESOURCE_METADATA_EXTENSIONS;
+    return projectResourceMetadataExtensions;
+}
+
+/**
+ * Determine whether a path ends with a recognized resource metadata suffix.
+ */
+export function isProjectResourceMetadataPath(candidate) {
+    return matchProjectResourceMetadataExtension(candidate) !== null;
+}
 
 export function isProjectManifestPath(candidate) {
     if (typeof candidate !== "string") {
@@ -14,3 +146,5 @@ export function isProjectManifestPath(candidate) {
 
     return candidate.toLowerCase().endsWith(PROJECT_MANIFEST_EXTENSION_LOWER);
 }
+
+export { DEFAULT_RESOURCE_METADATA_EXTENSIONS as PROJECT_RESOURCE_METADATA_DEFAULTS };

--- a/src/semantic/src/project-index/index.js
+++ b/src/semantic/src/project-index/index.js
@@ -86,7 +86,13 @@ export {
 
 export {
     PROJECT_MANIFEST_EXTENSION,
-    isProjectManifestPath
+    isProjectManifestPath,
+    PROJECT_RESOURCE_METADATA_DEFAULTS,
+    getProjectResourceMetadataExtensions,
+    resetProjectResourceMetadataExtensions,
+    setProjectResourceMetadataExtensions,
+    isProjectResourceMetadataPath,
+    matchProjectResourceMetadataExtension
 } from "./constants.js";
 export {
     PROJECT_INDEX_CACHE_SCHEMA_VERSION,

--- a/src/semantic/src/project-index/project-file-categories.js
+++ b/src/semantic/src/project-index/project-file-categories.js
@@ -1,5 +1,8 @@
 import { assertArray, getNonEmptyTrimmedString } from "../dependencies.js";
-import { isProjectManifestPath } from "./constants.js";
+import {
+    isProjectManifestPath,
+    isProjectResourceMetadataPath
+} from "./constants.js";
 
 const DEFAULT_PROJECT_SOURCE_EXTENSIONS = Object.freeze([".gml"]);
 let projectSourceExtensions = DEFAULT_PROJECT_SOURCE_EXTENSIONS;
@@ -119,10 +122,13 @@ export function normalizeProjectFileCategory(value) {
  *          path does not fall into a known bucket.
  */
 export function resolveProjectFileCategory(relativePosix) {
-    const lowerPath = relativePosix.toLowerCase();
-    if (lowerPath.endsWith(".yy") || isProjectManifestPath(relativePosix)) {
+    if (
+        isProjectResourceMetadataPath(relativePosix) ||
+        isProjectManifestPath(relativePosix)
+    ) {
         return ProjectFileCategory.RESOURCE_METADATA;
     }
+    const lowerPath = relativePosix.toLowerCase();
     const sourceExtensions = getProjectIndexSourceExtensions();
     if (sourceExtensions.some((extension) => lowerPath.endsWith(extension))) {
         return ProjectFileCategory.SOURCE;

--- a/src/semantic/src/project-index/resource-analysis.js
+++ b/src/semantic/src/project-index/resource-analysis.js
@@ -14,7 +14,8 @@ import {
 } from "../dependencies.js";
 import {
     PROJECT_MANIFEST_EXTENSION,
-    isProjectManifestPath
+    isProjectManifestPath,
+    matchProjectResourceMetadataExtension
 } from "./constants.js";
 import { normalizeProjectResourcePath } from "./path-normalization.js";
 
@@ -72,9 +73,11 @@ function ensureResourceRecord(resourcesMap, resourcePath, resourceData = {}) {
 
 function deriveDefaultResourceName(resourcePath) {
     const baseName = path.posix.basename(resourcePath);
-    const lowerPath = resourcePath.toLowerCase();
-    if (lowerPath.endsWith(".yy")) {
-        return path.posix.basename(resourcePath, ".yy");
+    const matchedExtension =
+        matchProjectResourceMetadataExtension(resourcePath);
+    if (matchedExtension) {
+        const trimmed = resourcePath.slice(0, -matchedExtension.length);
+        return path.posix.basename(trimmed);
     }
 
     if (isProjectManifestPath(resourcePath)) {

--- a/src/semantic/test/project-index-file-category.test.js
+++ b/src/semantic/test/project-index-file-category.test.js
@@ -7,11 +7,16 @@ import {
     resolveProjectFileCategory,
     getProjectIndexSourceExtensions,
     resetProjectIndexSourceExtensions,
-    setProjectIndexSourceExtensions
+    setProjectIndexSourceExtensions,
+    getProjectResourceMetadataExtensions,
+    resetProjectResourceMetadataExtensions,
+    setProjectResourceMetadataExtensions,
+    matchProjectResourceMetadataExtension
 } from "../src/project-index/index.js";
 
 test.afterEach(() => {
     resetProjectIndexSourceExtensions();
+    resetProjectResourceMetadataExtensions();
 });
 
 test("normalizeProjectFileCategory accepts known categories", () => {
@@ -96,5 +101,35 @@ test("setProjectIndexSourceExtensions rejects invalid input", () => {
     assert.throws(
         () => setProjectIndexSourceExtensions([42]),
         /must be strings/
+    );
+});
+
+test("resource metadata extensions expose the default list", () => {
+    const defaults = getProjectResourceMetadataExtensions();
+    assert.deepEqual(defaults, [".yy"]);
+    assert.throws(() => {
+        defaults.push(".yyz");
+    }, TypeError);
+});
+
+test("resource metadata extension overrides extend detection", () => {
+    setProjectResourceMetadataExtensions([".meta"]);
+    assert.deepEqual(getProjectResourceMetadataExtensions(), [".yy", ".meta"]);
+    assert.equal(
+        resolveProjectFileCategory("objects/player/player.meta"),
+        ProjectFileCategory.RESOURCE_METADATA
+    );
+    assert.equal(
+        resolveProjectFileCategory("objects/player/player.yy"),
+        ProjectFileCategory.RESOURCE_METADATA
+    );
+});
+
+test("resource metadata extension overrides normalise input", () => {
+    setProjectResourceMetadataExtensions([" .YYZ", "", null, ".yyz"]);
+    assert.deepEqual(getProjectResourceMetadataExtensions(), [".yy", ".yyz"]);
+    assert.equal(
+        matchProjectResourceMetadataExtension("objects/player/player.YYZ"),
+        ".yyz"
     );
 });


### PR DESCRIPTION
Seed PR for Codex to implement a targeted extensibility improvement while
keeping the defaults opinionated.

## Requirements
- Document the rigid decision point that makes extension difficult today.
- Explain the minimal seam or hook you will add before touching code.
- Avoid exposing new end-user configuration unless it is indispensable;
  prefer sensible defaults and internal extension points.
- When a new hook or option is warranted, clearly state who should use
  it, the default value, and the guardrails that keep the behavior
  predictable for everyone else.
- Update any impacted docs or inline comments, and keep behavior
  unchanged by default.
