### PR TITLE
Codex: LSP Polymorphism Guardrails

### DIFF
--- a/src/cli/src/core/command-usage.js
+++ b/src/cli/src/core/command-usage.js
@@ -1,3 +1,5 @@
+import { getCommanderUsage } from "./commander-contract.js";
+
 /**
  * Resolve the usage/help text for a Commander command while gracefully
  * tolerating `null`ish values and callers without a `helpInformation` method.
@@ -10,9 +12,9 @@
  * @returns {string | null | undefined} Normalized usage string when available.
  */
 export function resolveCommandUsage(command, { fallback } = {}) {
-    if (command && typeof command.helpInformation === "function") {
-        const usage = command.helpInformation();
-        return typeof usage === "string" ? usage : String(usage);
+    const usage = getCommanderUsage(command);
+    if (usage != null) {
+        return usage;
     }
 
     if (typeof fallback === "function") {

--- a/src/cli/src/core/commander-contract.js
+++ b/src/cli/src/core/commander-contract.js
@@ -1,0 +1,131 @@
+import {
+    assertFunctionProperties,
+    describeValueWithArticle,
+    isObjectOrFunction
+} from "../dependencies.js";
+
+function hasFunction(value, property) {
+    return typeof value?.[property] === "function";
+}
+
+function normalizeUsageResult(output) {
+    if (output == null) {
+        return null;
+    }
+
+    return typeof output === "string" ? output : String(output);
+}
+
+function createUsageReader(target) {
+    if (!isObjectOrFunction(target)) {
+        return null;
+    }
+
+    if (hasFunction(target, "helpInformation")) {
+        return () => target.helpInformation();
+    }
+
+    if (hasFunction(target, "usage")) {
+        return () => target.usage();
+    }
+
+    if (hasFunction(target, "getUsage")) {
+        return () => target.getUsage();
+    }
+
+    return null;
+}
+
+function createProgramParseDelegate(program) {
+    if (hasFunction(program, "parseAsync")) {
+        return (argv, options) => program.parseAsync(argv, options);
+    }
+
+    if (hasFunction(program, "parse")) {
+        return (argv, options) => Promise.resolve(program.parse(argv, options));
+    }
+
+    return null;
+}
+
+function describeProgramForError(program) {
+    return describeValueWithArticle(program, {
+        objectLabel: "a commander-compatible program"
+    });
+}
+
+export function createCommanderProgramContract(program) {
+    const normalizedProgram = assertFunctionProperties(program, [
+        "addCommand",
+        "hook"
+    ], {
+        name: "Commander program"
+    });
+
+    const parse = createProgramParseDelegate(normalizedProgram);
+    if (!parse) {
+        throw new TypeError(
+            `Commander program must provide parseAsync() or parse(); received ${describeProgramForError(program)}.`
+        );
+    }
+
+    const usageReader = createUsageReader(normalizedProgram);
+
+    return {
+        raw: normalizedProgram,
+        parse,
+        addCommand: (command, options) =>
+            normalizedProgram.addCommand(command, options),
+        hook: (event, listener) => normalizedProgram.hook(event, listener),
+        getUsage() {
+            return normalizeUsageResult(usageReader?.());
+        }
+    };
+}
+
+export function createCommanderCommandContract(
+    command,
+    { name = "Commander command", requireAction = true } = {}
+) {
+    const methods = requireAction ? ["action"] : [];
+    const normalizedCommand = assertFunctionProperties(command, methods, {
+        name
+    });
+
+    const usageReader = createUsageReader(normalizedCommand);
+    const hasAction = hasFunction(normalizedCommand, "action");
+
+    return {
+        raw: normalizedCommand,
+        action(handler) {
+            if (!hasAction) {
+                throw new TypeError(`${name} does not expose action()`);
+            }
+
+            return normalizedCommand.action(handler);
+        },
+        getUsage() {
+            return normalizeUsageResult(usageReader?.());
+        }
+    };
+}
+
+export function tryCreateCommanderCommandContract(command, options) {
+    try {
+        return createCommanderCommandContract(command, options);
+    } catch {
+        return null;
+    }
+}
+
+export function isCommanderCommandLike(value) {
+    if (!isObjectOrFunction(value)) {
+        return false;
+    }
+
+    return createUsageReader(value) !== null;
+}
+
+export function getCommanderUsage(command) {
+    return normalizeUsageResult(createUsageReader(command)?.());
+}

--- a/src/cli/src/dependencies.js
+++ b/src/cli/src/dependencies.js
@@ -3,6 +3,7 @@ export {
     asArray,
     assertArray,
     assertFunction,
+    assertFunctionProperties,
     assertNonEmptyString,
     assertPlainObject,
     coerceNonNegativeInteger,

--- a/src/cli/test/core-command-manager.test.js
+++ b/src/cli/test/core-command-manager.test.js
@@ -7,6 +7,63 @@ import { createCliCommandManager } from "../src/core/command-manager.js";
 import { CliUsageError } from "../src/core/errors.js";
 import { applyStandardCommandOptions } from "../src/core/command-standard-options.js";
 
+function createStubProgram() {
+    const hooks = new Map();
+    const registeredCommands = [];
+    return {
+        parseCalls: [],
+        addCommand(command, options = {}) {
+            registeredCommands.push({ command, options });
+            if (options.isDefault) {
+                this.defaultCommand = command;
+            }
+            return this;
+        },
+        hook(name, handler) {
+            hooks.set(name, handler);
+            return this;
+        },
+        parse(argv, options) {
+            this.parseCalls.push({ argv, options });
+            const nonDefault = registeredCommands.find(
+                (entry) => entry.options?.isDefault !== true
+            );
+            const targetCommand =
+                nonDefault?.command ?? this.defaultCommand ?? null;
+            const action = targetCommand?._actionHandler;
+            if (!action) {
+                return undefined;
+            }
+
+            hooks.get("preSubcommand")?.(this, targetCommand);
+            return Promise.resolve()
+                .then(() => action(argv.slice(1), targetCommand))
+                .finally(() => {
+                    hooks.get("postAction")?.();
+                });
+        },
+        helpInformation() {
+            return "stub program usage";
+        }
+    };
+}
+
+function createStubCommand(name) {
+    return {
+        _actionHandler: null,
+        action(handler) {
+            this._actionHandler = handler;
+            return this;
+        },
+        helpInformation() {
+            return `${name} usage`;
+        },
+        name() {
+            return name;
+        }
+    };
+}
+
 test("default command usage is reported for option parsing errors", async () => {
     const program = applyStandardCommandOptions(new Command());
     const unhandledErrors = [];
@@ -77,4 +134,27 @@ test("subcommand usage is reported when Commander omits command reference", asyn
     assert.ok(error.message.includes("performance"));
     assert.ok(error.usage?.includes("performance"));
     assert.ok(error.usage?.includes("--stdout"));
+});
+
+test("command manager adapts programs that only expose parse()", async () => {
+    const program = createStubProgram();
+    const { registry, runner } = createCliCommandManager({ program });
+
+    const executed = [];
+    const command = createStubCommand("adapter");
+
+    registry.registerCommand({
+        command,
+        run: () => {
+            executed.push("run");
+            return 0;
+        }
+    });
+
+    await runner.run(["adapter", "--flag"]);
+
+    assert.deepStrictEqual(program.parseCalls, [
+        { argv: ["adapter", "--flag"], options: { from: "user" } }
+    ]);
+    assert.deepStrictEqual(executed, ["run"]);
 });

--- a/src/cli/test/core-command-usage.test.js
+++ b/src/cli/test/core-command-usage.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveCommandUsage } from "../src/core/command-usage.js";
+
+test("resolveCommandUsage reads usage() when helpInformation is absent", () => {
+    const command = {
+        usage() {
+            return "usage placeholder";
+        }
+    };
+
+    assert.equal(resolveCommandUsage(command), "usage placeholder");
+});
+
+test("resolveCommandUsage falls back when no usage metadata is present", () => {
+    assert.equal(
+        resolveCommandUsage({}, { fallback: "manual fallback" }),
+        "manual fallback"
+    );
+
+    assert.equal(
+        resolveCommandUsage(null, { fallback: () => "lazy fallback" }),
+        "lazy fallback"
+    );
+});


### PR DESCRIPTION
Seed PR for Codex to remove brittle collaborator type checks and reinforce
Liskov Substitution Principle expectations.

### Acceptable substitution checks
- Probe for required capabilities by verifying the presence of a method or
  property before use (e.g., `typeof transport.send === "function"`).
- Feature-detect optional behaviour (flags, version markers) instead of
  comparing constructor names or prototypes.
- Guard result shape by routing collaborators through a shared adapter or
  contract test that normalizes outputs.
