### PR TITLE
Codex: Loop Mutability Hazards

### DIFF
--- a/src/plugin/src/ast-transforms/consolidate-struct-assignments.js
+++ b/src/plugin/src/ast-transforms/consolidate-struct-assignments.js
@@ -679,21 +679,25 @@ class CommentTracker {
         }
 
         const results = [];
-        let index = this.firstGreaterThan(left);
+        const indicesToRemove = [];
+        const startIndex = this.firstGreaterThan(left);
 
-        while (index < this.entries.length) {
+        for (let index = startIndex; index < this.entries.length; index++) {
             const entry = this.entries[index];
             if (entry.index >= upperBound) {
                 break;
             }
 
             if (predicate && !predicate(entry.comment)) {
-                index += 1;
                 continue;
             }
 
             results.push(entry.comment);
-            this.entries.splice(index, 1);
+            indicesToRemove.push(index);
+        }
+
+        for (let i = indicesToRemove.length - 1; i >= 0; i--) {
+            this.entries.splice(indicesToRemove[i], 1);
         }
 
         return results;

--- a/src/plugin/test/consolidate-struct-assignments.test.js
+++ b/src/plugin/test/consolidate-struct-assignments.test.js
@@ -98,6 +98,30 @@ describe("CommentTracker", () => {
             [20]
         );
     });
+
+    it("correctly takes multiple consecutive matching comments without skipping", async () => {
+        const { CommentTracker } = await loadCommentTracker();
+
+        const comments = [
+            { start: { index: 10 }, type: "match" },
+            { start: { index: 20 }, type: "match" },
+            { start: { index: 30 }, type: "skip" },
+            { start: { index: 40 }, type: "match" },
+            { start: { index: 50 }, type: "match" }
+        ];
+
+        const tracker = new CommentTracker(comments);
+        const predicate = (comment) => comment.type === "match";
+        const taken = tracker.takeBetween(5, 100, predicate);
+
+        assert.equal(taken.length, 4);
+        assert.deepEqual(
+            taken.map((c) => c.start.index),
+            [10, 20, 40, 50]
+        );
+        assert.equal(tracker.entries.length, 1);
+        assert.equal(tracker.entries[0].comment.start.index, 30);
+    });
 });
 
 describe("consolidateStructAssignments", () => {


### PR DESCRIPTION
Seed PR for Codex to refactor a loop that mutates the collection it is iterating, preventing subtle data corruption or skipped entries.
