### PR TITLE
Fix banner comment normalization width handling

### DIFF
--- a/src/plugin/test/line-comment-banner-length-option.test.js
+++ b/src/plugin/test/line-comment-banner-length-option.test.js
@@ -64,7 +64,29 @@ describe("line comment banner length option", () => {
             { lineCommentBannerLength: 12 }
         );
 
-        assert.strictEqual(printed, "//////////// Heading");
+        assert.strictEqual(printed, "//////// Heading");
+    });
+
+    it("balances banner padding around the content when width allows", () => {
+        const comment = createBannerComment("//////// Banner comment");
+        const printed = printComment(
+            { getValue: () => comment },
+            { lineCommentBannerLength: 40 }
+        );
+
+        assert.strictEqual(printed, "//////////// Banner comment ////////////");
+    });
+
+    it("assigns remainder padding to the trailing slash run", () => {
+        const comment = createBannerComment(
+            "//////// Move camera //////////////"
+        );
+        const printed = printComment(
+            { getValue: () => comment },
+            { lineCommentBannerLength: 40 }
+        );
+
+        assert.strictEqual(printed, "///////////// Move camera //////////////");
     });
 
     it("preserves the source width when the option is disabled", () => {


### PR DESCRIPTION
## Summary
- rework banner comment normalization to distribute padding around the content using the configured width while preserving existing behavior when the width is too small
- add focused banner padding tests to cover even and odd width distributions

## Testing
- node --test src/plugin/test/line-comment-banner-length-option.test.js

------
https://chatgpt.com/codex/tasks/task_e_6908a37b2abc832f8bc08504d77935da