### PR TITLE
Relocate resolver controller utility to shared package

### DIFF
--- a/src/plugin/src/comments/line-comment-formatting.js
+++ b/src/plugin/src/comments/line-comment-formatting.js
@@ -13,7 +13,7 @@ import {
 } from "@prettier-plugin-gml/shared/utils/string.js";
 import { hasOwn } from "@prettier-plugin-gml/shared/utils/object.js";
 import { isRegExpLike } from "@prettier-plugin-gml/shared/utils/capability-probes.js";
-import { createResolverController } from "../shared/resolver-controller.js";
+import { createResolverController } from "@prettier-plugin-gml/shared/utils/resolver-controller.js";
 import { normalizeOptionalParamToken } from "./optional-param-normalization.js";
 
 function normalizeEntryPair(entry) {

--- a/src/plugin/src/options/core-option-overrides.js
+++ b/src/plugin/src/options/core-option-overrides.js
@@ -1,5 +1,5 @@
 import { hasOwn } from "../shared/index.js";
-import { createResolverController } from "../shared/resolver-controller.js";
+import { createResolverController } from "@prettier-plugin-gml/shared/utils/resolver-controller.js";
 import {
     TRAILING_COMMA,
     assertTrailingCommaValue

--- a/src/plugin/src/options/line-comment-options.js
+++ b/src/plugin/src/options/line-comment-options.js
@@ -5,7 +5,7 @@ import {
     isObjectLike,
     isRegExpLike
 } from "../shared/index.js";
-import { createResolverController } from "../shared/resolver-controller.js";
+import { createResolverController } from "@prettier-plugin-gml/shared/utils/resolver-controller.js";
 
 const LINE_COMMENT_BANNER_DETECTION_MIN_SLASHES = 5;
 const DEFAULT_LINE_COMMENT_BANNER_LENGTH = 60;

--- a/src/plugin/src/shared/index.js
+++ b/src/plugin/src/shared/index.js
@@ -1,4 +1,4 @@
 // Re-export the curated dependency surface alongside plugin-specific helpers so
 // consumers interact with the minimal shared API required by the formatter.
 export * from "./dependencies.js";
-export { createResolverController } from "./resolver-controller.js";
+export { createResolverController } from "@prettier-plugin-gml/shared/utils/resolver-controller.js";

--- a/src/shared/src/utils/index.js
+++ b/src/shared/src/utils/index.js
@@ -11,5 +11,6 @@ export * from "./line-breaks.js";
 export * from "./number.js";
 export * from "./numeric-options.js";
 export * from "./object.js";
+export * from "./resolver-controller.js";
 export * from "./regexp.js";
 export * from "./string.js";

--- a/src/shared/src/utils/resolver-controller.js
+++ b/src/shared/src/utils/resolver-controller.js
@@ -1,8 +1,10 @@
-import { assertFunction } from "@prettier-plugin-gml/shared/utils/object.js";
+import { assertFunction } from "./object.js";
 
-// Option resolver plumbing now lives alongside the plugin so shared bundles stay
-// focused on cross-environment primitives. The implementation remains unchanged
-// aside from importing its assertions from the shared object helpers.
+// Option resolver plumbing now lives in the shared utility bundle so formatter
+// packages (plugin, CLI integrations, semantic tooling) can reuse the
+// controller without depending on plugin internals. The implementation mirrors
+// the previous module, only the import path changed to stay within the shared
+// surface.
 
 /**
  * @template TOptions

--- a/src/shared/test/resolver-controller.test.js
+++ b/src/shared/test/resolver-controller.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createResolverController } from "../src/shared/resolver-controller.js";
+import { createResolverController } from "../src/utils/resolver-controller.js";
 
 describe("createResolverController", () => {
     it("returns defaults when no resolver is installed", () => {


### PR DESCRIPTION
## Summary
- move the resolver controller helper from the plugin shared folder into the shared utils bundle so it can be consumed without going through plugin internals
- update shared barrels and plugin modules to import the controller from its new home
- relocate the resolver controller unit tests under the shared package

## Testing
- npm run test:shared

------
https://chatgpt.com/codex/tasks/task_e_69084d440c08832f8941741d9afe3551