### PR TITLE
Follow-up: normalize decorated two-slash banners

### DIFF
--- a/src/plugin/src/comments/comment-printer.js
+++ b/src/plugin/src/comments/comment-printer.js
@@ -183,10 +183,6 @@ function printComment(commentPath, options) {
 
             const slashRun = bannerMatch[1];
             const slashCount = slashRun.length;
-            if (slashCount < LINE_COMMENT_BANNER_DETECTION_MIN_SLASHES) {
-                return formatLineComment(comment, lineCommentOptions);
-            }
-
             const bannerStart =
                 typeof bannerMatch.index === "number"
                     ? bannerMatch.index
@@ -194,11 +190,23 @@ function printComment(commentPath, options) {
             const safeBannerStart = Math.max(bannerStart, 0);
             const remainder = rawText.slice(safeBannerStart + slashCount);
             const remainderTrimmed = remainder.trimStart();
+
             if (remainderTrimmed.startsWith("@")) {
                 return formatLineComment(comment, lineCommentOptions);
             }
 
+            const trimmedRemainder = remainderTrimmed.trim();
             const normalizedText = normalizeBannerCommentText(remainderTrimmed);
+            const shouldTreatAsBanner =
+                slashCount >= LINE_COMMENT_BANNER_DETECTION_MIN_SLASHES ||
+                trimmedRemainder.length === 0 ||
+                normalizedText === null ||
+                normalizedText !== trimmedRemainder;
+
+            if (!shouldTreatAsBanner) {
+                return formatLineComment(comment, lineCommentOptions);
+            }
+
             if (normalizedText === null) {
                 return "";
             }

--- a/src/plugin/test/line-comment-banner-length-option.test.js
+++ b/src/plugin/test/line-comment-banner-length-option.test.js
@@ -33,4 +33,13 @@ describe("line comment banner handling", () => {
 
         assert.strictEqual(printed, "// Standard comment");
     });
+
+    it("normalizes decorated banners even with two leading slashes", () => {
+        const comment = createBannerComment(
+            "//-------------------Move camera-----------------------//"
+        );
+        const printed = printComment({ getValue: () => comment }, {});
+
+        assert.strictEqual(printed, "// Move camera");
+    });
 });


### PR DESCRIPTION
## Summary
- treat decorative banner comments with only two leading slashes as banners so their text is preserved while trimming decoration
- drop empty banner comments and normalize decorated output to match fixture expectations
- add a regression unit test that covers two-slash decorated banners

## Testing
- node --test src/plugin/test/line-comment-banner-length-option.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691509ddf6a0832fbeec22373738b15a)