### PR TITLE
Refactor doc-comment services to use direct utility imports

### DIFF
--- a/src/core/src/comments/doc-comment/manager.ts
+++ b/src/core/src/comments/doc-comment/manager.ts
@@ -5,11 +5,8 @@ import {
     isDocCommentLine,
     type DocCommentLines
 } from "../comment-utils.js";
-import {
-    isNonEmptyArray,
-    isNonEmptyTrimmedString,
-    toMutableArray
-} from "../../utils/index.js";
+import { isNonEmptyArray, toMutableArray } from "../../utils/array.js";
+import { isNonEmptyTrimmedString } from "../../utils/string.js";
 
 const DOC_COMMENT_MANAGERS = new WeakMap();
 const DOC_COMMENT_TRAVERSAL_SERVICES = new WeakMap();

--- a/src/core/src/comments/doc-comment/service/collection.ts
+++ b/src/core/src/comments/doc-comment/service/collection.ts
@@ -1,9 +1,9 @@
 import {
     asArray,
     isNonEmptyArray,
-    toMutableArray,
-    toTrimmedString
-} from "../../../utils/index.js";
+    toMutableArray
+} from "../../../utils/array.js";
+import { toTrimmedString } from "../../../utils/string.js";
 import { getCommentArray } from "../../comment-utils.js";
 import { getDocCommentPrinterDependencies } from "../printer-dependencies.js";
 import type { DocCommentPrinterDependencies } from "../types.js";

--- a/src/core/src/comments/doc-comment/service/legacy.ts
+++ b/src/core/src/comments/doc-comment/service/legacy.ts
@@ -2,7 +2,7 @@ import {
     capitalize,
     isNonEmptyTrimmedString,
     toTrimmedString
-} from "../../../utils/index.js";
+} from "../../../utils/string.js";
 import type { DocCommentLines } from "../../comment-utils.js";
 import { parseDocCommentMetadata, isDocCommentTagLine } from "./metadata.js";
 

--- a/src/core/src/comments/doc-comment/service/metadata.ts
+++ b/src/core/src/comments/doc-comment/service/metadata.ts
@@ -1,4 +1,4 @@
-import { toTrimmedString } from "../../../utils/index.js";
+import { toTrimmedString } from "../../../utils/string.js";
 
 const STRING_TYPE = "string";
 const NUMBER_TYPE = "number";

--- a/src/core/src/comments/doc-comment/service/params.ts
+++ b/src/core/src/comments/doc-comment/service/params.ts
@@ -1,4 +1,4 @@
-import { getNonEmptyString } from "../../../utils/index.js";
+import { getNonEmptyString } from "../../../utils/string.js";
 
 const STRING_TYPE = "string";
 

--- a/src/core/src/comments/doc-comment/service/synthetic/generation.ts
+++ b/src/core/src/comments/doc-comment/service/synthetic/generation.ts
@@ -2,7 +2,7 @@ import {
     getNodeName,
     isUndefinedSentinel
 } from "../../../../ast/node-helpers.js";
-import { isNonEmptyTrimmedString } from "../../../../utils/index.js";
+import { isNonEmptyTrimmedString } from "../../../../utils/string.js";
 import { parseDocCommentMetadata } from "../metadata.js";
 import { normalizeDocCommentTypeAnnotations } from "../type-normalization.js";
 import {

--- a/src/core/src/comments/doc-comment/service/synthetic/helpers.ts
+++ b/src/core/src/comments/doc-comment/service/synthetic/helpers.ts
@@ -9,7 +9,7 @@ import {
 import {
     getNonEmptyString,
     isNonEmptyTrimmedString
-} from "../../../../utils/index.js";
+} from "../../../../utils/string.js";
 import { normalizeDocMetadataName } from "../params.js";
 
 const STRING_TYPE = "string";

--- a/src/core/src/comments/doc-comment/service/synthetic/merge.ts
+++ b/src/core/src/comments/doc-comment/service/synthetic/merge.ts
@@ -2,13 +2,9 @@ import type {
     DocCommentLines,
     MutableDocCommentLines
 } from "../../../comment-utils.js";
-import {
-    coercePositiveIntegerOption,
-    findLastIndex,
-    toMutableArray,
-    toTrimmedString,
-    isNonEmptyString
-} from "../../../../utils/index.js";
+import { coercePositiveIntegerOption } from "../../../../utils/numeric-options.js";
+import { findLastIndex, toMutableArray } from "../../../../utils/array.js";
+import { isNonEmptyString, toTrimmedString } from "../../../../utils/string.js";
 import { parseDocCommentMetadata } from "../metadata.js";
 import {
     dedupeReturnDocLines,

--- a/src/core/src/comments/doc-comment/service/type-normalization.ts
+++ b/src/core/src/comments/doc-comment/service/type-normalization.ts
@@ -1,9 +1,9 @@
+import { createResolverController } from "../../../utils/resolver-controller.js";
 import {
     capitalize,
-    createResolverController,
     getNonEmptyString,
     getNonEmptyTrimmedString
-} from "../../../utils/index.js";
+} from "../../../utils/string.js";
 import { normalizeOptionalParamToken } from "./params.js";
 
 const STRING_TYPE = "string" as const;

--- a/src/core/src/comments/doc-comment/service/wrap.ts
+++ b/src/core/src/comments/doc-comment/service/wrap.ts
@@ -1,7 +1,5 @@
-import {
-    createEnvConfiguredValueWithFallback,
-    toFiniteNumber
-} from "../../../utils/index.js";
+import { createEnvConfiguredValueWithFallback } from "../../../utils/environment.js";
+import { toFiniteNumber } from "../../../utils/number.js";
 
 const DOC_COMMENT_MAX_WRAP_WIDTH_ENV_VAR =
     "PRETTIER_PLUGIN_GML_DOC_COMMENT_MAX_WRAP_WIDTH";

--- a/src/core/src/comments/doc-comment/synthetic-comments.ts
+++ b/src/core/src/comments/doc-comment/synthetic-comments.ts
@@ -12,7 +12,8 @@ import {
     reorderDescriptionLinesAfterFunction,
     resolveDocCommentWrapWidth
 } from "./service/index.js";
-import { isNonEmptyTrimmedString, toMutableArray } from "../../utils/index.js";
+import { toMutableArray } from "../../utils/array.js";
+import { isNonEmptyTrimmedString } from "../../utils/string.js";
 
 const STRING_TYPE = "string";
 


### PR DESCRIPTION
## Summary
- replace doc-comment service imports from utils index surfaces with direct module paths
- preserve existing doc-comment service APIs while avoiding internal index usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939007be084832faddb546c1db1ea41)