### PR TITLE
Fix doc metadata normalization typing

### DIFF
--- a/src/core/src/comments/doc-comment/service/synthetic-generation.ts
+++ b/src/core/src/comments/doc-comment/service/synthetic-generation.ts
@@ -29,7 +29,7 @@ const NUMBER_TYPE = "number";
 
 function normalizeDocMetadataNameToString(value: unknown): string | null {
     const normalized = normalizeDocMetadataName(value);
-    return typeof normalized === STRING_TYPE ? normalized : null;
+    return typeof normalized === "string" ? normalized : null;
 }
 
 function hasReturnStatement(node: any): boolean {

--- a/src/core/test/doc-metadata-normalization.test.ts
+++ b/src/core/test/doc-metadata-normalization.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    getCanonicalParamNameFromText,
+    normalizeDocMetadataName
+} from "../src/comments/doc-comment/service/params.js";
+
+void test("normalizeDocMetadataName preserves valid optional tokens", () => {
+    assert.equal(normalizeDocMetadataName("[value]"), "[value]");
+});
+
+void test("normalizeDocMetadataName strips synthetic sentinels", () => {
+    assert.equal(normalizeDocMetadataName("__value__"), "value");
+    assert.equal(normalizeDocMetadataName("$$value$$"), "value");
+});
+
+void test("getCanonicalParamNameFromText unwraps optional tokens and defaults", () => {
+    assert.equal(
+        getCanonicalParamNameFromText("[value]")?.includes("["),
+        false
+    );
+    assert.equal(getCanonicalParamNameFromText("[value=10]"), "value");
+});


### PR DESCRIPTION
## Summary
- fix doc comment metadata normalization type guard
- add tests covering doc metadata normalization and canonical parameter names

## Testing
- npm run build:ts
- node --test src/core/dist/test/**/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694460b551a8832f866c4cf50431555a)