### PR TITLE
Add parser grammar base accessor for runtime wrappers

### DIFF
--- a/src/parser/src/runtime/game-maker-language-parser-listener.ts
+++ b/src/parser/src/runtime/game-maker-language-parser-listener.ts
@@ -4,13 +4,16 @@ import type {
     ListenerOptions,
     ParserContext
 } from "../types/index.js";
-import GameMakerLanguageParserListenerBase from "../../generated/GameMakerLanguageParserListener.js";
+import { getGameMakerLanguageParserBases } from "./parser-grammar-bases.js";
 import { VISIT_METHOD_NAMES } from "./game-maker-language-parser-visitor.js";
 import {
     definePrototypeMethods,
     deriveListenerMethodNames,
     toDelegate
 } from "./parse-tree-helpers.js";
+
+const { listener: GameMakerLanguageParserListenerBase } =
+    getGameMakerLanguageParserBases();
 
 const DEFAULT_LISTENER_DELEGATE: ListenerDelegate = ({
     fallback = Core.noop

--- a/src/parser/src/runtime/game-maker-language-parser-visitor.ts
+++ b/src/parser/src/runtime/game-maker-language-parser-visitor.ts
@@ -1,9 +1,9 @@
-import GameMakerLanguageParserVisitorBase from "../../generated/GameMakerLanguageParserVisitor.js";
 import type {
     ParserContext,
     VisitorOptions,
     VisitorPayload
 } from "../types/index.js";
+import { getGameMakerLanguageParserBases } from "./parser-grammar-bases.js";
 import {
     collectPrototypeMethodNames,
     collectVisitMethodNames,
@@ -11,6 +11,9 @@ import {
     definePrototypeMethods,
     ensureHasInstancePatched
 } from "./parse-tree-helpers.js";
+
+const { visitor: GameMakerLanguageParserVisitorBase } =
+    getGameMakerLanguageParserBases();
 
 const DEFAULT_VISIT_CHILDREN_DELEGATE = ({ fallback }: VisitorPayload) =>
     fallback();

--- a/src/parser/src/runtime/parser-grammar-bases.ts
+++ b/src/parser/src/runtime/parser-grammar-bases.ts
@@ -1,0 +1,25 @@
+import GameMakerLanguageParserListenerBase from "../../generated/GameMakerLanguageParserListener.js";
+import GameMakerLanguageParserVisitorBase from "../../generated/GameMakerLanguageParserVisitor.js";
+
+type ParserListenerConstructor = new () => unknown;
+type ParserVisitorConstructor = new () => unknown;
+
+export type GameMakerLanguageParserBases = Readonly<{
+    listener: ParserListenerConstructor;
+    visitor: ParserVisitorConstructor;
+}>;
+
+const gameMakerLanguageParserBases: GameMakerLanguageParserBases =
+    Object.freeze({
+        listener:
+            GameMakerLanguageParserListenerBase as ParserListenerConstructor,
+        visitor: GameMakerLanguageParserVisitorBase as ParserVisitorConstructor
+    });
+
+/**
+ * Provides stable access to the generated GameMaker language parser bases so runtime
+ * wrappers do not couple directly to the generated module paths.
+ */
+export function getGameMakerLanguageParserBases(): GameMakerLanguageParserBases {
+    return gameMakerLanguageParserBases;
+}


### PR DESCRIPTION
## Summary
- introduce a runtime accessor for GameMaker parser base classes to decouple wrapper imports from generated paths
- update listener and visitor wrappers to consume the new accessor instead of importing generated artifacts directly

## Testing
- npm exec -- eslint src/parser/src/runtime/game-maker-language-parser-visitor.ts src/parser/src/runtime/game-maker-language-parser-listener.ts src/parser/src/runtime/parser-grammar-bases.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944299f8c64832f85131d58a3ce4664)