### PR TITLE
test(core): align core unit tests with Core namespace imports

### DIFF
--- a/src/core/test/ast/get-single-body-statement.test.ts
+++ b/src/core/test/ast/get-single-body-statement.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { getSingleBodyStatement } from "../../src/ast/node-helpers.js";
+import { Core } from "../../index.js";
 
 void describe("getSingleBodyStatement", () => {
     void it("returns null for non-block nodes", () => {
-        assert.equal(getSingleBodyStatement(null), null);
-        assert.equal(getSingleBodyStatement(undefined), null);
-        assert.equal(getSingleBodyStatement({ type: "Identifier" }), null);
-        assert.equal(getSingleBodyStatement({ type: "ExpressionStatement" }), null);
+        assert.equal(Core.getSingleBodyStatement(null), null);
+        assert.equal(Core.getSingleBodyStatement(undefined), null);
+        assert.equal(Core.getSingleBodyStatement({ type: "Identifier" }), null);
+        assert.equal(Core.getSingleBodyStatement({ type: "ExpressionStatement" }), null);
     });
 
     void it("returns null when block has no statements", () => {
@@ -16,7 +16,7 @@ void describe("getSingleBodyStatement", () => {
             type: "BlockStatement",
             body: []
         };
-        assert.equal(getSingleBodyStatement(emptyBlock), null);
+        assert.equal(Core.getSingleBodyStatement(emptyBlock), null);
     });
 
     void it("returns null when block has multiple statements", () => {
@@ -24,7 +24,7 @@ void describe("getSingleBodyStatement", () => {
             type: "BlockStatement",
             body: [{ type: "ExpressionStatement" }, { type: "ReturnStatement" }]
         };
-        assert.equal(getSingleBodyStatement(multipleStatements), null);
+        assert.equal(Core.getSingleBodyStatement(multipleStatements), null);
     });
 
     void it("returns the single statement when present", () => {
@@ -32,7 +32,7 @@ void describe("getSingleBodyStatement", () => {
             type: "BlockStatement",
             body: [{ type: "ReturnStatement", argument: null }]
         };
-        const result = getSingleBodyStatement(singleStatement);
+        const result = Core.getSingleBodyStatement(singleStatement);
         assert.notEqual(result, null);
         assert.equal(result?.type, "ReturnStatement");
     });
@@ -43,7 +43,7 @@ void describe("getSingleBodyStatement", () => {
             body: [{ type: "ReturnStatement" }],
             comments: [{ type: "CommentLine", value: "test" }]
         };
-        assert.equal(getSingleBodyStatement(blockWithComment), null);
+        assert.equal(Core.getSingleBodyStatement(blockWithComment), null);
     });
 
     void it("allows blocks with comments when skipBlockCommentCheck is true", () => {
@@ -52,7 +52,7 @@ void describe("getSingleBodyStatement", () => {
             body: [{ type: "ReturnStatement", argument: null }],
             comments: [{ type: "CommentLine", value: "test" }]
         };
-        const result = getSingleBodyStatement(blockWithComment, {
+        const result = Core.getSingleBodyStatement(blockWithComment, {
             skipBlockCommentCheck: true
         });
         assert.notEqual(result, null);
@@ -70,7 +70,7 @@ void describe("getSingleBodyStatement", () => {
                 }
             ]
         };
-        assert.equal(getSingleBodyStatement(blockWithCommentedStatement), null);
+        assert.equal(Core.getSingleBodyStatement(blockWithCommentedStatement), null);
     });
 
     void it("allows statements with comments when skipStatementCommentCheck is true", () => {
@@ -84,7 +84,7 @@ void describe("getSingleBodyStatement", () => {
                 }
             ]
         };
-        const result = getSingleBodyStatement(blockWithCommentedStatement, {
+        const result = Core.getSingleBodyStatement(blockWithCommentedStatement, {
             skipStatementCommentCheck: true
         });
         assert.notEqual(result, null);
@@ -103,7 +103,7 @@ void describe("getSingleBodyStatement", () => {
             ],
             comments: [{ type: "CommentLine", value: "block" }]
         };
-        const result = getSingleBodyStatement(fullyCommented, {
+        const result = Core.getSingleBodyStatement(fullyCommented, {
             skipBlockCommentCheck: true,
             skipStatementCommentCheck: true
         });
@@ -116,7 +116,7 @@ void describe("getSingleBodyStatement", () => {
             type: "BlockStatement",
             body: null
         };
-        assert.equal(getSingleBodyStatement(invalidBlock), null);
+        assert.equal(Core.getSingleBodyStatement(invalidBlock), null);
     });
 
     void it("returns null when single statement is null or undefined", () => {
@@ -124,6 +124,6 @@ void describe("getSingleBodyStatement", () => {
             type: "BlockStatement",
             body: [null]
         };
-        assert.equal(getSingleBodyStatement(blockWithNullStatement), null);
+        assert.equal(Core.getSingleBodyStatement(blockWithNullStatement), null);
     });
 });

--- a/src/core/test/ast/node-classification.test.ts
+++ b/src/core/test/ast/node-classification.test.ts
@@ -1,12 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import {
-    DefineReplacementDirective,
-    getNormalizedDefineReplacementDirective,
-    isFunctionLikeDeclaration,
-    isMacroLikeStatement
-} from "../../src/ast/node-classification.js";
+import { Core } from "../../index.js";
 
 void describe("AST node classification helpers", () => {
     void it("normalizes define directives case-insensitively", () => {
@@ -19,20 +14,20 @@ void describe("AST node classification helpers", () => {
             replacementDirective: "  #MACRO  "
         };
 
-        assert.equal(getNormalizedDefineReplacementDirective(regionNode), DefineReplacementDirective.REGION);
-        assert.equal(getNormalizedDefineReplacementDirective(macroNode), DefineReplacementDirective.MACRO);
+        assert.equal(Core.getNormalizedDefineReplacementDirective(regionNode), Core.DefineReplacementDirective.REGION);
+        assert.equal(Core.getNormalizedDefineReplacementDirective(macroNode), Core.DefineReplacementDirective.MACRO);
     });
 
     void it("returns null when define statements lack directives", () => {
-        assert.equal(getNormalizedDefineReplacementDirective(null), null);
+        assert.equal(Core.getNormalizedDefineReplacementDirective(null), null);
         assert.equal(
-            getNormalizedDefineReplacementDirective({
+            Core.getNormalizedDefineReplacementDirective({
                 type: "DefineStatement"
             }),
             null
         );
         assert.equal(
-            getNormalizedDefineReplacementDirective({
+            Core.getNormalizedDefineReplacementDirective({
                 type: "DefineStatement",
                 replacementDirective: "   "
             }),
@@ -43,7 +38,7 @@ void describe("AST node classification helpers", () => {
     void it("throws when encountering an unsupported directive", () => {
         assert.throws(
             () =>
-                getNormalizedDefineReplacementDirective({
+                Core.getNormalizedDefineReplacementDirective({
                     type: "DefineStatement",
                     replacementDirective: "#unknown"
                 }),
@@ -59,15 +54,15 @@ void describe("AST node classification helpers", () => {
         };
         const unrelated = { type: "ReturnStatement" };
 
-        assert.equal(isMacroLikeStatement(macroDeclaration), true);
-        assert.equal(isMacroLikeStatement(defineMacro), true);
-        assert.equal(isMacroLikeStatement(unrelated), false);
+        assert.equal(Core.isMacroLikeStatement(macroDeclaration), true);
+        assert.equal(Core.isMacroLikeStatement(defineMacro), true);
+        assert.equal(Core.isMacroLikeStatement(unrelated), false);
     });
 
     void it("recognizes function-like declarations", () => {
-        assert.equal(isFunctionLikeDeclaration({ type: "FunctionDeclaration" }), true);
-        assert.equal(isFunctionLikeDeclaration({ type: "ConstructorDeclaration" }), true);
-        assert.equal(isFunctionLikeDeclaration({ type: "FunctionExpression" }), true);
-        assert.equal(isFunctionLikeDeclaration({ type: "StructDeclaration" }), false);
+        assert.equal(Core.isFunctionLikeDeclaration({ type: "FunctionDeclaration" }), true);
+        assert.equal(Core.isFunctionLikeDeclaration({ type: "ConstructorDeclaration" }), true);
+        assert.equal(Core.isFunctionLikeDeclaration({ type: "FunctionExpression" }), true);
+        assert.equal(Core.isFunctionLikeDeclaration({ type: "StructDeclaration" }), false);
     });
 });

--- a/src/core/test/utils/js-string.test.ts
+++ b/src/core/test/utils/js-string.test.ts
@@ -1,160 +1,155 @@
 import { strictEqual } from "node:assert";
 import { test } from "node:test";
 
-import {
-    escapeTemplateText,
-    isIdentifierLike,
-    normalizeStructKeyText,
-    stringifyStructKey
-} from "../../src/utils/js-string.js";
+import { Core } from "../../index.js";
 
 // Tests for isIdentifierLike
 void test("isIdentifierLike accepts valid JavaScript identifiers", () => {
-    strictEqual(isIdentifierLike("foo"), true);
-    strictEqual(isIdentifierLike("bar123"), true);
-    strictEqual(isIdentifierLike("_private"), true);
-    strictEqual(isIdentifierLike("$jquery"), true);
-    strictEqual(isIdentifierLike("CamelCase"), true);
-    strictEqual(isIdentifierLike("snake_case"), true);
-    strictEqual(isIdentifierLike("CONSTANT"), true);
+    strictEqual(Core.isIdentifierLike("foo"), true);
+    strictEqual(Core.isIdentifierLike("bar123"), true);
+    strictEqual(Core.isIdentifierLike("_private"), true);
+    strictEqual(Core.isIdentifierLike("$jquery"), true);
+    strictEqual(Core.isIdentifierLike("CamelCase"), true);
+    strictEqual(Core.isIdentifierLike("snake_case"), true);
+    strictEqual(Core.isIdentifierLike("CONSTANT"), true);
 });
 
 void test("isIdentifierLike rejects invalid identifiers starting with digits", () => {
-    strictEqual(isIdentifierLike("123abc"), false);
-    strictEqual(isIdentifierLike("0foo"), false);
+    strictEqual(Core.isIdentifierLike("123abc"), false);
+    strictEqual(Core.isIdentifierLike("0foo"), false);
 });
 
 void test("isIdentifierLike rejects identifiers with special characters", () => {
-    strictEqual(isIdentifierLike("my-var"), false);
-    strictEqual(isIdentifierLike("hello.world"), false);
-    strictEqual(isIdentifierLike("foo bar"), false);
-    strictEqual(isIdentifierLike("foo@bar"), false);
-    strictEqual(isIdentifierLike("a+b"), false);
+    strictEqual(Core.isIdentifierLike("my-var"), false);
+    strictEqual(Core.isIdentifierLike("hello.world"), false);
+    strictEqual(Core.isIdentifierLike("foo bar"), false);
+    strictEqual(Core.isIdentifierLike("foo@bar"), false);
+    strictEqual(Core.isIdentifierLike("a+b"), false);
 });
 
 void test("isIdentifierLike rejects empty string", () => {
-    strictEqual(isIdentifierLike(""), false);
+    strictEqual(Core.isIdentifierLike(""), false);
 });
 
 void test("isIdentifierLike accepts single character identifiers", () => {
-    strictEqual(isIdentifierLike("x"), true);
-    strictEqual(isIdentifierLike("_"), true);
-    strictEqual(isIdentifierLike("$"), true);
+    strictEqual(Core.isIdentifierLike("x"), true);
+    strictEqual(Core.isIdentifierLike("_"), true);
+    strictEqual(Core.isIdentifierLike("$"), true);
 });
 
 // Tests for escapeTemplateText
 void test("escapeTemplateText leaves plain text unchanged", () => {
-    strictEqual(escapeTemplateText("hello world"), "hello world");
-    strictEqual(escapeTemplateText("simple text"), "simple text");
-    strictEqual(escapeTemplateText(""), "");
+    strictEqual(Core.escapeTemplateText("hello world"), "hello world");
+    strictEqual(Core.escapeTemplateText("simple text"), "simple text");
+    strictEqual(Core.escapeTemplateText(""), "");
 });
 
 void test("escapeTemplateText escapes backticks", () => {
-    strictEqual(escapeTemplateText("hello `world`"), "hello \\`world\\`");
-    strictEqual(escapeTemplateText("`quoted`"), "\\`quoted\\`");
-    strictEqual(escapeTemplateText("multiple ` backticks ` here"), "multiple \\` backticks \\` here");
+    strictEqual(Core.escapeTemplateText("hello `world`"), "hello \\`world\\`");
+    strictEqual(Core.escapeTemplateText("`quoted`"), "\\`quoted\\`");
+    strictEqual(Core.escapeTemplateText("multiple ` backticks ` here"), "multiple \\` backticks \\` here");
 });
 
 void test("escapeTemplateText escapes template interpolation syntax", () => {
-    strictEqual(escapeTemplateText("cost: ${price}"), "cost: \\${price}");
-    strictEqual(escapeTemplateText("${foo} and ${bar}"), "\\${foo} and \\${bar}");
-    strictEqual(escapeTemplateText("value is ${x}"), "value is \\${x}");
+    strictEqual(Core.escapeTemplateText("cost: ${price}"), "cost: \\${price}");
+    strictEqual(Core.escapeTemplateText("${foo} and ${bar}"), "\\${foo} and \\${bar}");
+    strictEqual(Core.escapeTemplateText("value is ${x}"), "value is \\${x}");
 });
 
 void test("escapeTemplateText escapes both backticks and interpolation", () => {
-    strictEqual(escapeTemplateText("`template ${expr}`"), "\\`template \\${expr}\\`");
-    strictEqual(escapeTemplateText("${a} `mixed` ${b}"), "\\${a} \\`mixed\\` \\${b}");
+    strictEqual(Core.escapeTemplateText("`template ${expr}`"), "\\`template \\${expr}\\`");
+    strictEqual(Core.escapeTemplateText("${a} `mixed` ${b}"), "\\${a} \\`mixed\\` \\${b}");
 });
 
 // Tests for normalizeStructKeyText
 void test("normalizeStructKeyText removes double quotes from quoted strings", () => {
-    strictEqual(normalizeStructKeyText('"hello"'), "hello");
-    strictEqual(normalizeStructKeyText('"world"'), "world");
-    strictEqual(normalizeStructKeyText('""'), "");
+    strictEqual(Core.normalizeStructKeyText('"hello"'), "hello");
+    strictEqual(Core.normalizeStructKeyText('"world"'), "world");
+    strictEqual(Core.normalizeStructKeyText('""'), "");
 });
 
 void test("normalizeStructKeyText removes single quotes from quoted strings", () => {
-    strictEqual(normalizeStructKeyText("'hello'"), "hello");
-    strictEqual(normalizeStructKeyText("'world'"), "world");
-    strictEqual(normalizeStructKeyText("''"), "");
+    strictEqual(Core.normalizeStructKeyText("'hello'"), "hello");
+    strictEqual(Core.normalizeStructKeyText("'world'"), "world");
+    strictEqual(Core.normalizeStructKeyText("''"), "");
 });
 
 void test("normalizeStructKeyText handles JSON escape sequences in double quotes", () => {
-    strictEqual(normalizeStructKeyText(String.raw`"hello\nworld"`), "hello\nworld");
-    strictEqual(normalizeStructKeyText(String.raw`"tab\there"`), "tab\there");
-    strictEqual(normalizeStructKeyText(String.raw`"quote: \"test\""`), 'quote: "test"');
+    strictEqual(Core.normalizeStructKeyText(String.raw`"hello\nworld"`), "hello\nworld");
+    strictEqual(Core.normalizeStructKeyText(String.raw`"tab\there"`), "tab\there");
+    strictEqual(Core.normalizeStructKeyText(String.raw`"quote: \"test\""`), 'quote: "test"');
 });
 
 void test("normalizeStructKeyText returns unquoted strings unchanged", () => {
-    strictEqual(normalizeStructKeyText("unquoted"), "unquoted");
-    strictEqual(normalizeStructKeyText("my_identifier"), "my_identifier");
-    strictEqual(normalizeStructKeyText("123"), "123");
+    strictEqual(Core.normalizeStructKeyText("unquoted"), "unquoted");
+    strictEqual(Core.normalizeStructKeyText("my_identifier"), "my_identifier");
+    strictEqual(Core.normalizeStructKeyText("123"), "123");
 });
 
 void test("normalizeStructKeyText returns mismatched quotes unchanged", () => {
-    strictEqual(normalizeStructKeyText("\"mixed'"), "\"mixed'");
-    strictEqual(normalizeStructKeyText("'\"wrong"), "'\"wrong");
+    strictEqual(Core.normalizeStructKeyText("\"mixed'"), "\"mixed'");
+    strictEqual(Core.normalizeStructKeyText("'\"wrong"), "'\"wrong");
 });
 
 void test("normalizeStructKeyText handles single characters", () => {
-    strictEqual(normalizeStructKeyText('"a"'), "a");
-    strictEqual(normalizeStructKeyText("'x'"), "x");
-    strictEqual(normalizeStructKeyText("a"), "a");
+    strictEqual(Core.normalizeStructKeyText('"a"'), "a");
+    strictEqual(Core.normalizeStructKeyText("'x'"), "x");
+    strictEqual(Core.normalizeStructKeyText("a"), "a");
 });
 
 void test("normalizeStructKeyText handles strings shorter than 2 characters", () => {
-    strictEqual(normalizeStructKeyText('"'), '"');
-    strictEqual(normalizeStructKeyText("'"), "'");
-    strictEqual(normalizeStructKeyText(""), "");
+    strictEqual(Core.normalizeStructKeyText('"'), '"');
+    strictEqual(Core.normalizeStructKeyText("'"), "'");
+    strictEqual(Core.normalizeStructKeyText(""), "");
 });
 
 void test("normalizeStructKeyText handles malformed JSON gracefully", () => {
     // Invalid escape sequence - should fall back to slicing
-    strictEqual(normalizeStructKeyText(String.raw`"\x invalid"`), String.raw`\x invalid`);
+    strictEqual(Core.normalizeStructKeyText(String.raw`"\x invalid"`), String.raw`\x invalid`);
 });
 
 // Tests for stringifyStructKey
 void test("stringifyStructKey preserves valid identifier keys", () => {
-    strictEqual(stringifyStructKey("name"), "name");
-    strictEqual(stringifyStructKey("_private"), "_private");
-    strictEqual(stringifyStructKey("$special"), "$special");
-    strictEqual(stringifyStructKey("camelCase"), "camelCase");
+    strictEqual(Core.stringifyStructKey("name"), "name");
+    strictEqual(Core.stringifyStructKey("_private"), "_private");
+    strictEqual(Core.stringifyStructKey("$special"), "$special");
+    strictEqual(Core.stringifyStructKey("camelCase"), "camelCase");
 });
 
 void test("stringifyStructKey preserves numeric string keys", () => {
-    strictEqual(stringifyStructKey("0"), "0");
-    strictEqual(stringifyStructKey("123"), "123");
-    strictEqual(stringifyStructKey("999"), "999");
+    strictEqual(Core.stringifyStructKey("0"), "0");
+    strictEqual(Core.stringifyStructKey("123"), "123");
+    strictEqual(Core.stringifyStructKey("999"), "999");
 });
 
 void test("stringifyStructKey quotes keys with special characters", () => {
-    strictEqual(stringifyStructKey("my-key"), '"my-key"');
-    strictEqual(stringifyStructKey("hello world"), '"hello world"');
-    strictEqual(stringifyStructKey("foo.bar"), '"foo.bar"');
+    strictEqual(Core.stringifyStructKey("my-key"), '"my-key"');
+    strictEqual(Core.stringifyStructKey("hello world"), '"hello world"');
+    strictEqual(Core.stringifyStructKey("foo.bar"), '"foo.bar"');
 });
 
 void test("stringifyStructKey quotes keys starting with digits", () => {
-    strictEqual(stringifyStructKey("123abc"), '"123abc"');
-    strictEqual(stringifyStructKey("0foo"), '"0foo"');
+    strictEqual(Core.stringifyStructKey("123abc"), '"123abc"');
+    strictEqual(Core.stringifyStructKey("0foo"), '"0foo"');
 });
 
 void test("stringifyStructKey normalizes quoted input before processing", () => {
-    strictEqual(stringifyStructKey('"name"'), "name");
-    strictEqual(stringifyStructKey("'identifier'"), "identifier");
-    strictEqual(stringifyStructKey('"123"'), "123");
+    strictEqual(Core.stringifyStructKey('"name"'), "name");
+    strictEqual(Core.stringifyStructKey("'identifier'"), "identifier");
+    strictEqual(Core.stringifyStructKey('"123"'), "123");
 });
 
 void test("stringifyStructKey quotes normalized keys with special chars", () => {
-    strictEqual(stringifyStructKey('"my-key"'), '"my-key"');
-    strictEqual(stringifyStructKey("'hello world'"), '"hello world"');
+    strictEqual(Core.stringifyStructKey('"my-key"'), '"my-key"');
+    strictEqual(Core.stringifyStructKey("'hello world'"), '"hello world"');
 });
 
 void test("stringifyStructKey handles empty strings", () => {
-    strictEqual(stringifyStructKey('""'), '""');
-    strictEqual(stringifyStructKey("''"), '""');
+    strictEqual(Core.stringifyStructKey('""'), '""');
+    strictEqual(Core.stringifyStructKey("''"), '""');
 });
 
 void test("stringifyStructKey handles keys with escape sequences", () => {
     // After normalization, newline becomes actual newline which needs quoting
-    strictEqual(stringifyStructKey(String.raw`"line1\nline2"`), String.raw`"line1\nline2"`);
+    strictEqual(Core.stringifyStructKey(String.raw`"line1\nline2"`), String.raw`"line1\nline2"`);
 });


### PR DESCRIPTION
### Motivation
- Reduce coupling to internal module paths in core tests by consuming the public `Core` namespace so tests depend on the package surface rather than deep relative imports.

### Description
- Updated `src/core/test/ast/get-single-body-statement.test.ts`, `src/core/test/ast/node-classification.test.ts`, and `src/core/test/utils/js-string.test.ts` to `import { Core } from "../../index.js"` and reference helpers via the `Core` namespace (e.g. `Core.getSingleBodyStatement`, `Core.DefineReplacementDirective`, `Core.isIdentifierLike`).

### Testing
- Ran pre-commit checks which formatted staged files with `prettier` and linted with `eslint`, and those checks passed after fixing an initial undefined reference; no full test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a1eef94c832f902f5ec28ce7488f)