### PR TITLE
Add relative script ids for watch patches

### DIFF
--- a/src/cli/test/watch-symbol-id.test.ts
+++ b/src/cli/test/watch-symbol-id.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { createScriptSymbolId } from "../src/commands/watch.js";
+
+void describe("createScriptSymbolId", () => {
+    void it("builds a stable id using the relative path", () => {
+        const watchRoot = path.join("/project", "game");
+        const filePath = path.join(
+            watchRoot,
+            "scripts",
+            "movement",
+            "player_move.gml"
+        );
+
+        const symbolId = createScriptSymbolId(watchRoot, filePath);
+
+        assert.equal(symbolId, "gml/script/scripts/movement/player_move");
+    });
+
+    void it("keeps scripts with duplicate basenames distinct", () => {
+        const watchRoot = "/project/game";
+        const firstPath = path.join(watchRoot, "ui", "menu", "init.gml");
+        const secondPath = path.join(watchRoot, "scripts", "init.gml");
+
+        const firstId = createScriptSymbolId(watchRoot, firstPath);
+        const secondId = createScriptSymbolId(watchRoot, secondPath);
+
+        assert.equal(firstId, "gml/script/ui/menu/init");
+        assert.equal(secondId, "gml/script/scripts/init");
+        assert.notEqual(firstId, secondId);
+    });
+});


### PR DESCRIPTION
## Summary
- build script symbol identifiers from relative paths to avoid collisions across nested folders
- thread watch root into file change handling and cover the helper with dedicated tests

## Testing
- npm run build:ts
- node --test src/cli/dist/test/watch-symbol-id.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e04e8bf8832f9fe4be1bf735d33e)