### PR TITLE
Simplify dataset cache lookup in performance command

### DIFF
--- a/src/cli/src/commands/performance.ts
+++ b/src/cli/src/commands/performance.ts
@@ -107,7 +107,7 @@ interface CollectPerformanceSuiteResultsOptions {
 }
 
 function resolveCachedDataset(cache) {
-    if (!cache || typeof cache.get !== "function") {
+    if (!cache?.get) {
         return null;
     }
 
@@ -116,17 +116,16 @@ function resolveCachedDataset(cache) {
         return null;
     }
 
-    const deref = typeof entry?.deref === "function" ? entry.deref : null;
-    if (!deref) {
+    if (typeof entry?.deref !== "function") {
         return entry;
     }
 
-    const dataset = deref.call(entry);
+    const dataset = entry.deref();
     if (dataset) {
         return dataset;
     }
 
-    cache.delete(DATASET_CACHE_KEY);
+    cache.delete?.(DATASET_CACHE_KEY);
     return null;
 }
 


### PR DESCRIPTION
## Summary
- streamline `resolveCachedDataset` to use straightforward guard clauses and optional chaining while retaining existing behavior

## Testing
- npm run test:cli -- src/cli/dist/test/performance-cli-suite-option.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe0772d98832f9bb629ad6a507d30)