### PR TITLE
refactor(parser): compose listener dispatch responsibilities

### DIFF
--- a/src/parser/src/runtime/game-maker-language-parser-listener.ts
+++ b/src/parser/src/runtime/game-maker-language-parser-listener.ts
@@ -1,67 +1,24 @@
-import { Core } from "@gml-modules/core";
-
-import type { ListenerDelegate, ListenerOptions, ParserContext } from "../types/index.js";
-import { toDelegate } from "./delegation.js";
+import type { ListenerOptions, ParserContext } from "../types/index.js";
 import { VISIT_METHOD_NAMES } from "./game-maker-language-parser-visitor.js";
 import { getParserListenerBase, type ParserListenerBaseConstructor } from "./generated-bindings.js";
+import { createListenerMethodDispatcher } from "./listener-method-dispatcher.js";
 import { deriveListenerMethodNames } from "./method-reflection.js";
 import { definePrototypeMethods } from "./prototype-builder.js";
-
-const DEFAULT_LISTENER_DELEGATE: ListenerDelegate = ({ fallback = Core.noop }) => fallback();
 
 export const LISTENER_METHOD_NAMES = Object.freeze(deriveListenerMethodNames(VISIT_METHOD_NAMES));
 
 const GeneratedParserListenerBase: ParserListenerBaseConstructor = getParserListenerBase();
 
-function createListenerDelegate(options: ListenerOptions = {}): ListenerDelegate {
-    const { listenerDelegate, listenerHandlers } = options;
-    const baseDelegate = toDelegate(listenerDelegate, DEFAULT_LISTENER_DELEGATE);
-
-    if (!listenerHandlers || typeof listenerHandlers !== "object") {
-        return baseDelegate;
-    }
-
-    const handlerEntries = Object.entries(listenerHandlers)
-        .filter(([, value]) => typeof value === "function")
-        .map(([key, value]) => [key, value] as const);
-
-    if (handlerEntries.length === 0) {
-        return baseDelegate;
-    }
-
-    const handlerMap = Object.fromEntries(handlerEntries);
-
-    return (payload) => {
-        const handler = handlerMap[payload.methodName];
-        if (!handler) {
-            return baseDelegate(payload);
-        }
-
-        const enhancedPayload = {
-            ...payload,
-            fallback: () => baseDelegate(payload)
-        };
-
-        return handler(enhancedPayload.ctx, enhancedPayload);
-    };
-}
-
 export default class GameMakerLanguageParserListener extends GeneratedParserListenerBase {
-    #listenerDelegate: ListenerDelegate;
+    readonly #methodDispatcher: ReturnType<typeof createListenerMethodDispatcher>;
 
     constructor(options: ListenerOptions = {}) {
         super();
-        this.#listenerDelegate = createListenerDelegate(options);
+        this.#methodDispatcher = createListenerMethodDispatcher(options);
     }
 
-    _dispatch(methodName: string, ctx: ParserContext) {
-        const phase = methodName.startsWith("enter") ? "enter" : "exit";
-        return this.#listenerDelegate({
-            methodName,
-            phase,
-            ctx,
-            fallback: Core.noop
-        });
+    dispatchListenerMethod(methodName: string, ctx: ParserContext): unknown {
+        return this.#methodDispatcher.dispatch(methodName, ctx);
     }
 }
 
@@ -70,6 +27,6 @@ definePrototypeMethods(
     LISTENER_METHOD_NAMES,
     (methodName: string) =>
         function (this: GameMakerLanguageParserListener, ctx: ParserContext) {
-            return this._dispatch(methodName, ctx);
+            return this.dispatchListenerMethod(methodName, ctx);
         }
 );

--- a/src/parser/src/runtime/listener-method-dispatcher.ts
+++ b/src/parser/src/runtime/listener-method-dispatcher.ts
@@ -1,0 +1,85 @@
+import { Core } from "@gml-modules/core";
+
+import type { ListenerDelegate, ListenerOptions, ParserContext } from "../types/index.js";
+import { toDelegate } from "./delegation.js";
+
+const DEFAULT_LISTENER_DELEGATE: ListenerDelegate = ({ fallback = Core.noop }) => fallback();
+
+interface ListenerPhaseResolver {
+    resolve(methodName: string): "enter" | "exit";
+}
+
+interface ListenerMethodDispatcher {
+    dispatch(methodName: string, ctx: ParserContext): unknown;
+}
+
+class PrefixListenerPhaseResolver implements ListenerPhaseResolver {
+    resolve(methodName: string): "enter" | "exit" {
+        return methodName.startsWith("enter") ? "enter" : "exit";
+    }
+}
+
+class DelegateBackedListenerMethodDispatcher implements ListenerMethodDispatcher {
+    readonly #listenerDelegate: ListenerDelegate;
+    readonly #phaseResolver: ListenerPhaseResolver;
+
+    constructor(listenerDelegate: ListenerDelegate, phaseResolver: ListenerPhaseResolver) {
+        this.#listenerDelegate = listenerDelegate;
+        this.#phaseResolver = phaseResolver;
+    }
+
+    dispatch(methodName: string, ctx: ParserContext): unknown {
+        const phase = this.#phaseResolver.resolve(methodName);
+
+        return this.#listenerDelegate({
+            methodName,
+            phase,
+            ctx,
+            fallback: Core.noop
+        });
+    }
+}
+
+function createListenerDelegate(options: ListenerOptions): ListenerDelegate {
+    const { listenerDelegate, listenerHandlers } = options;
+    const baseDelegate = toDelegate(listenerDelegate, DEFAULT_LISTENER_DELEGATE);
+
+    if (!listenerHandlers || typeof listenerHandlers !== "object") {
+        return baseDelegate;
+    }
+
+    const handlerEntries = Object.entries(listenerHandlers)
+        .filter(([, value]) => typeof value === "function")
+        .map(([key, value]) => [key, value] as const);
+
+    if (handlerEntries.length === 0) {
+        return baseDelegate;
+    }
+
+    const handlerMap = Object.fromEntries(handlerEntries);
+
+    return (payload) => {
+        const handler = handlerMap[payload.methodName];
+        if (!handler) {
+            return baseDelegate(payload);
+        }
+
+        const enhancedPayload = {
+            ...payload,
+            fallback: () => baseDelegate(payload)
+        };
+
+        return handler(enhancedPayload.ctx, enhancedPayload);
+    };
+}
+
+/**
+ * Creates a listener method dispatcher that translates generated parser listener callbacks
+ * into delegate payloads with consistent phase metadata and fallback behavior.
+ */
+export function createListenerMethodDispatcher(options: ListenerOptions = {}): ListenerMethodDispatcher {
+    return new DelegateBackedListenerMethodDispatcher(
+        createListenerDelegate(options),
+        new PrefixListenerPhaseResolver()
+    );
+}

--- a/src/parser/test/listener-method-dispatcher.test.ts
+++ b/src/parser/test/listener-method-dispatcher.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createListenerMethodDispatcher } from "../src/runtime/listener-method-dispatcher.js";
+
+void test("dispatcher uses default no-op fallback", () => {
+    const dispatcher = createListenerMethodDispatcher();
+
+    assert.equal(dispatcher.dispatch("enterProgram", null), undefined);
+});
+
+void test("dispatcher resolves enter and exit phases", () => {
+    const calls: string[] = [];
+    const dispatcher = createListenerMethodDispatcher({
+        listenerDelegate: (payload) => {
+            calls.push(`${payload.methodName}:${payload.phase}`);
+        }
+    });
+
+    dispatcher.dispatch("enterProgram", null);
+    dispatcher.dispatch("exitProgram", null);
+
+    assert.deepEqual(calls, ["enterProgram:enter", "exitProgram:exit"]);
+});
+
+void test("dispatcher routes methods with handlers through handler and fallback", () => {
+    let delegateCalls = 0;
+    const dispatcher = createListenerMethodDispatcher({
+        listenerDelegate: () => {
+            delegateCalls += 1;
+        },
+        listenerHandlers: {
+            exitProgram: (_ctx, payload) => {
+                assert.equal(payload.phase, "exit");
+                payload.fallback();
+            }
+        }
+    });
+
+    dispatcher.dispatch("exitProgram", null);
+
+    assert.equal(delegateCalls, 1);
+});


### PR DESCRIPTION
### Motivation
- Reduce inheritance-heavy logic in the parser runtime by moving listener dispatch orchestration out of the `GameMakerLanguageParserListener` subclass and into a composable collaborator to improve testability and clarity.
- Make the listener's behavior easier to reason about and unit-test by delegating phase resolution and handler fallback routing to a focused dispatcher instead of embedding conditional branching inside the subclass.

### Description
- Extracted a new runtime collaborator `createListenerMethodDispatcher` in `src/parser/src/runtime/listener-method-dispatcher.ts` that implements phase resolution (`enter`/`exit`), delegate routing, and per-method handler fallback chaining.
- Updated `GameMakerLanguageParserListener` to use the composed dispatcher (replacing the inline delegate creation) and exposed a `dispatchListenerMethod` instance method that preserves the original observable behavior; the prototype-constructed visit methods now call this dispatcher.
- Added focused unit tests in `src/parser/test/listener-method-dispatcher.test.ts` that assert default no-op fallback behavior, correct phase resolution, and handler-fallback chaining.
- Ran automatic formatting and import sorting on the changed files and kept all public APIs and runtime behavior unchanged.

### Testing
- Ran ESLint autofix and then `eslint` on the changed files (passed for the modified files).
- Ran `prettier --check` on the modified files (all files matched Prettier style).
- Ran the TypeScript build via `pnpm run build:ts`, which failed due to pre-existing, unrelated type errors in `src/parser/src/ast/gml-ast-builder.ts` and not due to this refactor, so the new tests were not executed as part of a successful full build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a738659fd0832f9e174e29e5cacd78)