### PR TITLE
Style Consistency Pass: Remove workspace namespace destructuring in lint workspace

### DIFF
--- a/src/lint/src/rules/gml/rule-base-helpers.ts
+++ b/src/lint/src/rules/gml/rule-base-helpers.ts
@@ -1,17 +1,16 @@
-import type { GameMakerAstNode } from "@gmloop/core";
-import * as CoreWorkspace from "@gmloop/core";
+import { Core, type GameMakerAstNode } from "@gmloop/core";
 import type { Rule } from "eslint";
 
 import type { GmlRuleDefinition } from "./rule-definition.js";
 
-const { clamp, isObjectLike } = CoreWorkspace.Core;
+const { clamp, isObjectLike } = Core;
 
-const getNodeStartIndex: (node: unknown) => number | null = CoreWorkspace.Core.getNodeStartIndex;
-const getNodeEndIndex: (node: unknown) => number | null = CoreWorkspace.Core.getNodeEndIndex;
+const getNodeStartIndex: (node: unknown) => number | null = Core.getNodeStartIndex;
+const getNodeEndIndex: (node: unknown) => number | null = Core.getNodeEndIndex;
 const getCallExpressionIdentifierName: (callExpression: GameMakerAstNode | null | undefined) => string | null =
-    CoreWorkspace.Core.getCallExpressionIdentifierName;
+    Core.getCallExpressionIdentifierName;
 const getCallExpressionArguments: (callExpression: GameMakerAstNode | null | undefined) => readonly GameMakerAstNode[] =
-    CoreWorkspace.Core.getCallExpressionArguments;
+    Core.getCallExpressionArguments;
 
 export { getCallExpressionArguments, getCallExpressionIdentifierName, getNodeEndIndex, getNodeStartIndex };
 
@@ -94,7 +93,7 @@ export interface SourceTextEdit {
 }
 
 export function cloneAstNodeWithoutTraversalLinks<T>(node: T): T {
-    return CoreWorkspace.Core.cloneAstNode(node) as T;
+    return Core.cloneAstNode(node) as T;
 }
 
 type RuleMetaOverrides = Readonly<{

--- a/src/lint/src/rules/gml/rules/no-legacy-api-rule.ts
+++ b/src/lint/src/rules/gml/rules/no-legacy-api-rule.ts
@@ -1,4 +1,4 @@
-import * as CoreWorkspace from "@gmloop/core";
+import { Core } from "@gmloop/core";
 import type { Rule } from "eslint";
 
 import { getDeprecatedIdentifierCatalogEntry } from "../../../services/deprecated-identifiers/index.js";
@@ -10,8 +10,6 @@ import {
     walkAstNodesWithParent
 } from "../rule-base-helpers.js";
 import type { GmlRuleDefinition } from "../rule-definition.js";
-
-const { Core } = CoreWorkspace;
 
 type AstNodeWithType = Readonly<{ type: string }>;
 type DeprecatedCatalogEntry = NonNullable<ReturnType<typeof getDeprecatedIdentifierCatalogEntry>>;

--- a/src/lint/src/services/deprecated-identifiers/deprecated-identifier-catalog.ts
+++ b/src/lint/src/services/deprecated-identifiers/deprecated-identifier-catalog.ts
@@ -1,6 +1,10 @@
-import * as CoreWorkspace from "@gmloop/core";
-
-const { Core } = CoreWorkspace;
+import {
+    Core,
+    type DeprecatedIdentifierDiagnosticOwner,
+    type DeprecatedIdentifierLegacyUsage,
+    type DeprecatedIdentifierMetadataEntry,
+    type DeprecatedIdentifierReplacementKind
+} from "@gmloop/core";
 
 /**
  * Normalized deprecated identifier metadata used by lint rules.
@@ -10,10 +14,10 @@ export type DeprecatedIdentifierCatalogEntry = Readonly<{
     normalizedName: string;
     type: string;
     replacement: string | null;
-    replacementKind: CoreWorkspace.DeprecatedIdentifierReplacementKind;
+    replacementKind: DeprecatedIdentifierReplacementKind;
     legacyCategory: string | null;
-    legacyUsage: CoreWorkspace.DeprecatedIdentifierLegacyUsage;
-    diagnosticOwner: CoreWorkspace.DeprecatedIdentifierDiagnosticOwner | null;
+    legacyUsage: DeprecatedIdentifierLegacyUsage;
+    diagnosticOwner: DeprecatedIdentifierDiagnosticOwner | null;
 }>;
 
 /**
@@ -25,7 +29,7 @@ export type DeprecatedIdentifierCatalog = Readonly<{
 
 let cachedDeprecatedIdentifierCatalog: DeprecatedIdentifierCatalog | null = null;
 
-function createCatalogEntry(entry: CoreWorkspace.DeprecatedIdentifierMetadataEntry): DeprecatedIdentifierCatalogEntry {
+function createCatalogEntry(entry: DeprecatedIdentifierMetadataEntry): DeprecatedIdentifierCatalogEntry {
     return Object.freeze({
         name: entry.name,
         normalizedName: entry.name.toLowerCase(),


### PR DESCRIPTION
Surveyed the codebase for mechanical style drift and found three files in `src/lint/src/` where `@gmloop/core` was imported with a `CoreWorkspace` alias and then immediately destructured (`const { Core } = CoreWorkspace`), violating the AGENTS.md rule: *"do not destructure [the workspace namespace] into individual symbols; external consumers must always call functions or access exports via the namespace object"*.

## Changes Made

- **`src/lint/src/services/deprecated-identifiers/deprecated-identifier-catalog.ts`**: Replaced `import * as CoreWorkspace` + `const { Core } = CoreWorkspace` with a single `import { Core, type DeprecatedIdentifier… }` statement; renamed all `CoreWorkspace.TypeName` references to direct named types.
- **`src/lint/src/rules/gml/rules/no-legacy-api-rule.ts`**: Replaced `import * as CoreWorkspace` + `const { Core } = CoreWorkspace` with `import { Core } from "@gmloop/core"`. All `Core.method()` call sites are unchanged.
- **`src/lint/src/rules/gml/rule-base-helpers.ts`**: Merged two separate `@gmloop/core` imports (`import type { GameMakerAstNode }` and `import * as CoreWorkspace`) into one `import { Core, type GameMakerAstNode }`; replaced all `CoreWorkspace.Core.*` references with `Core.*`.

These three files now match the established convention used throughout the rest of the lint workspace (e.g. `no-assignment-in-condition-rule.ts`, `optimize-logical-flow-rule.ts`).

## Testing

- ✅ TypeScript compilation passes (`tsc --noEmit`, exit 0)
- ✅ CodeQL: 0 alerts

No logic changes — purely mechanical import/alias normalisation.