### PR TITLE
refactor(cli): move assertSupportedNodeVersion from shared/ to cli-core/

### DIFF
--- a/src/cli/src/cli-core/index.ts
+++ b/src/cli/src/cli-core/index.ts
@@ -12,4 +12,5 @@ export * from "./errors.js";
 export * from "./extension-normalizer.js";
 export * from "./format-command-options.js";
 export * from "./main-module-runner.js";
+export * from "./node-version.js";
 export * from "./version.js";

--- a/src/cli/src/cli-core/node-version.ts
+++ b/src/cli/src/cli-core/node-version.ts
@@ -1,3 +1,14 @@
+/**
+ * Node.js runtime version validation for the CLI.
+ *
+ * Asserting the Node.js version is a startup prerequisite for commands that
+ * depend on features unavailable in older runtimes. Placing this check in
+ * `cli-core/` keeps it alongside the other CLI infrastructure concerns (error
+ * types, version resolution, env overrides) rather than in the `shared/`
+ * utilities which are intended for cross-command helpers with no direct CLI
+ * framework dependency.
+ */
+
 const VERSION_REQUIREMENTS = new Map<number, { minor: number; label: string }>([
     [18, { minor: 18, label: "18.18.0" }],
     [20, { minor: 9, label: "20.9.0" }]
@@ -38,7 +49,6 @@ function normalizeVersionString(rawVersion: string): string {
  *
  * The runtime only interacts with an explicit version string, which keeps
  * callers from depending on the nested `process.versions` object.
- *
  */
 function readNodeVersionParts(environment: NodeEnvironment = process): {
     majorPart: string;
@@ -51,6 +61,17 @@ function readNodeVersionParts(environment: NodeEnvironment = process): {
     return { majorPart, minorPart };
 }
 
+/**
+ * Asserts that the currently running Node.js version meets the CLI's minimum
+ * version requirements. Throws if the detected version is unsupported.
+ *
+ * This check must be called early in commands that depend on Node.js features
+ * unavailable in older runtimes. Calling it at command entry-point keeps the
+ * error message actionable before any other CLI work begins.
+ *
+ * @throws {TypeError} When the Node.js version cannot be parsed from `process.version`.
+ * @throws {Error} When the detected major or minor version falls below the minimum requirement.
+ */
 export function assertSupportedNodeVersion(): void {
     const { majorPart, minorPart } = readNodeVersionParts();
     const major = parseVersionPart(majorPart);

--- a/src/cli/src/commands/generate-feather-metadata.ts
+++ b/src/cli/src/commands/generate-feather-metadata.ts
@@ -5,6 +5,7 @@ import type { Element } from "linkedom/types/interface/element.js";
 import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 import type { CommanderCommandLike } from "../cli-core/commander-types.js";
 import { isMainModule, runAsMainModule } from "../cli-core/main-module-runner.js";
+import { assertSupportedNodeVersion } from "../cli-core/node-version.js";
 import {
     getDirectElementChildren,
     parseManualDocument,
@@ -13,7 +14,6 @@ import {
 import { getManualRootMetadataPath, readManualText, resolveManualSourceCommitHash } from "../modules/manual/source.js";
 import { type ManualWorkflowOptions, prepareManualWorkflow } from "../modules/manual/workflow.js";
 import { writeJsonArtifact } from "../shared/fs-artifacts.js";
-import { assertSupportedNodeVersion } from "../shared/node-version.js";
 import { resolveFromRepoRoot } from "../shared/workspace-paths.js";
 
 const {

--- a/src/cli/src/commands/generate-gml-identifiers.ts
+++ b/src/cli/src/commands/generate-gml-identifiers.ts
@@ -11,6 +11,7 @@ import { wrapInvalidArgumentResolver } from "../cli-core/command-parsing.js";
 import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 import type { CommanderCommandLike } from "../cli-core/commander-types.js";
 import { isMainModule, runAsMainModule } from "../cli-core/main-module-runner.js";
+import { assertSupportedNodeVersion } from "../cli-core/node-version.js";
 import {
     getDirectElementChildren,
     parseManualDocument,
@@ -21,7 +22,6 @@ import { getManualRootMetadataPath, readManualText, resolveManualSourceCommitHas
 import { type ManualWorkflowOptions, prepareManualWorkflow } from "../modules/manual/workflow.js";
 import { getDefaultVmEvalTimeoutMs, resolveVmEvalTimeout } from "../runtime-options/vm-eval-timeout.js";
 import { writeJsonArtifact } from "../shared/fs-artifacts.js";
-import { assertSupportedNodeVersion } from "../shared/node-version.js";
 import { resolveFromRepoRoot } from "../shared/workspace-paths.js";
 
 const {

--- a/src/cli/test/core-node-version.test.ts
+++ b/src/cli/test/core-node-version.test.ts
@@ -17,4 +17,44 @@ void describe("assertSupportedNodeVersion", () => {
         // is sufficient here.
         assert.doesNotThrow(() => assertSupportedNodeVersion());
     });
+
+    void it("throws when the Node.js major version is too old", () => {
+        const original = process.version;
+        Object.defineProperty(process, "version", { value: "v16.0.0", configurable: true });
+        try {
+            assert.throws(
+                () => assertSupportedNodeVersion(),
+                (err: unknown) => err instanceof Error && /required/.test(err.message)
+            );
+        } finally {
+            Object.defineProperty(process, "version", { value: original, configurable: true });
+        }
+    });
+
+    void it("throws when the Node.js minor version is below the minimum for that major", () => {
+        const original = process.version;
+        // Node 18.17.x is below the 18.18.0 minimum.
+        Object.defineProperty(process, "version", { value: "v18.17.0", configurable: true });
+        try {
+            assert.throws(
+                () => assertSupportedNodeVersion(),
+                (err: unknown) => err instanceof Error && /18\.18\.0/.test(err.message)
+            );
+        } finally {
+            Object.defineProperty(process, "version", { value: original, configurable: true });
+        }
+    });
+
+    void it("throws a TypeError when the version string cannot be parsed", () => {
+        const original = process.version;
+        Object.defineProperty(process, "version", { value: "not-a-version", configurable: true });
+        try {
+            assert.throws(
+                () => assertSupportedNodeVersion(),
+                (err: unknown) => err instanceof TypeError && /Unable to determine/.test(err.message)
+            );
+        } finally {
+            Object.defineProperty(process, "version", { value: original, configurable: true });
+        }
+    });
 });

--- a/src/cli/test/core-node-version.test.ts
+++ b/src/cli/test/core-node-version.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Tests for the Node.js runtime version guard in the CLI core.
+ *
+ * {@link assertSupportedNodeVersion} is a startup prerequisite for commands that
+ * require a minimum Node.js version. These tests verify that it throws the correct
+ * errors for unsupported versions and passes silently for supported ones.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { assertSupportedNodeVersion } from "../src/cli-core/node-version.js";
+
+void describe("assertSupportedNodeVersion", () => {
+    void it("does not throw when running under the current Node.js version", () => {
+        // The test environment itself must satisfy the version requirement for
+        // the rest of the CLI test suite to work, so a simple non-throw check
+        // is sufficient here.
+        assert.doesNotThrow(() => assertSupportedNodeVersion());
+    });
+});

--- a/src/core/resource-directory.json
+++ b/src/core/resource-directory.json
@@ -1,3 +1,3 @@
 {
-  "resourceDirectory": "/home/runner/work/GMLoop/GMLoop/resources"
+  "resourceDirectory": "/Users/henrykirk/GMLoop/resources"
 }

--- a/src/core/resource-directory.json
+++ b/src/core/resource-directory.json
@@ -1,3 +1,3 @@
 {
-  "resourceDirectory": "/Users/henrykirk/GMLoop/resources"
+  "resourceDirectory": "/home/runner/work/GMLoop/GMLoop/resources"
 }


### PR DESCRIPTION
Moves `assertSupportedNodeVersion` from `cli/src/shared/node-version.ts` to `cli/src/cli-core/node-version.ts` as a focused organization improvement.

## Why the original placement was suboptimal

- `assertSupportedNodeVersion()` is a CLI startup/infrastructure guard, not a cross-command shared utility
- It was never exported through `cli/src/shared/index.ts`, so it was inaccessible via the shared barrel and accessed only via direct relative imports from two commands
- The `shared/` directory is intended for utilities shared broadly across commands; a startup version check is a CLI infrastructure concern

## Why `cli-core/` is the correct home

- `cli-core/` already owns the other CLI infrastructure pieces: `version.ts` (resolves plugin version), `errors.ts` (CLI error types), `env-overrides.ts` (runtime-option overrides)
- `assertSupportedNodeVersion()` complements `resolveCliVersion()` in `version.ts` — one validates *what* version is running, the other reports *which* plugin version is in use
- Placing it here makes it discoverable via the `cli-core/index.ts` barrel alongside the rest of startup infrastructure

## Changes Made

- **`cli/src/cli-core/node-version.ts`** — new location for the moved file, with added module-level TSDoc explaining the placement rationale and improved function TSDoc
- **`cli/src/shared/node-version.ts`** — deleted
- **`cli/src/cli-core/index.ts`** — `export * from "./node-version.js"` added to the barrel
- **`cli/src/commands/generate-gml-identifiers.ts`** — import path updated
- **`cli/src/commands/generate-feather-metadata.ts`** — import path updated
- **`cli/test/core-node-version.test.ts`** — new test covering the happy path, unsupported major version, unsupported minor version, and unparseable version string; follows the `core-*.test.ts` naming convention used by all other `cli-core/` tests

## Testing

- ✅ TypeScript build passes
- ✅ New tests pass; existing `cli-core` tests unaffected
- ✅ CodeQL found 0 alerts