### PR TITLE
Dead Code & Asset Audit: remove unused GML_ARGUMENT_IDENTIFIER_PATTERN and stale debug comment

### DIFF
--- a/src/cli/src/modules/refactor/semantic-bridge.ts
+++ b/src/cli/src/modules/refactor/semantic-bridge.ts
@@ -1586,7 +1586,6 @@ export class GmlSemanticBridge {
         for (const filePath of Object.keys(files)) {
             if (filePath.endsWith(".gml")) {
                 const hits = this.findIdentifierOccurrences(filePath, symbolName);
-                // console.log("HITS for", filePath, ":", hits);
                 for (const hit of hits) {
                     occurrences.push({
                         path: filePath,

--- a/src/core/src/utils/regexp.ts
+++ b/src/core/src/utils/regexp.ts
@@ -12,16 +12,6 @@ const ESCAPE_REGEXP_REPLACEMENT = String.raw`\$&`;
 export const GML_IDENTIFIER_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
- * Pattern matching GML built-in argument identifiers. GameMaker provides
- * implicit `argument0` through `argument15` variables in legacy scripts and
- * constructors. This pattern is used to detect and migrate these identifiers
- * during formatting, Feather fixes, and documentation generation.
- *
- * @type {RegExp}
- */
-export const GML_ARGUMENT_IDENTIFIER_PATTERN = /^argument(\d+)$/;
-
-/**
  * Escape characters that carry special meaning in regular expressions so the
  * resulting string can be injected into a pattern literal or constructor
  * without altering the intended match. Non-string inputs are normalized to an


### PR DESCRIPTION
Conservative audit of the full monorepo (1,969 TypeScript source files across 10 workspaces) to locate confirmed unused or legacy items. The codebase is in good shape overall; two confirmed dead-code items were identified and removed.

## Changes Made

- **Removed `GML_ARGUMENT_IDENTIFIER_PATTERN`** (`src/core/src/utils/regexp.ts`): An exported `RegExp` constant with zero import sites across the entire monorepo. Its TSDoc claimed it was "used to detect and migrate `argument0`–`argument15` identifiers during formatting, Feather fixes, and documentation generation," but every actual consumer (e.g. `create-feather-rule.ts`) defines its own inline `RegExp` instead. Both the constant and its now-inaccurate TSDoc were removed.

- **Removed commented-out `console.log`** (`src/cli/src/modules/refactor/semantic-bridge.ts`): The only commented-out debug statement found in non-test source files (`// console.log("HITS for", filePath, ":", hits);` inside `collectOccurrencesFromGmlFiles`). Removed to keep production code clean.

## Audit Coverage

The following categories were surveyed across all workspaces with no additional findings:
- Empty files or directories — none found
- Deprecated configuration settings — none found
- Empty try/catch or conditional blocks — none found
- Duplicate definitions — none found

## Verification

- ✅ `pnpm run build:ts` passes with no errors
- ✅ `pnpm run lint:quiet` passes with no warnings
- ✅ CodeQL security scan reports 0 alerts
- ✅ No golden `.gml` fixtures modified
- ✅ No compatibility shims added