### PR TITLE
refactor(format): simplify _printImplCore sequential dispatcher

### DIFF
--- a/src/format/src/printer/print.ts
+++ b/src/format/src/printer/print.ts
@@ -108,42 +108,26 @@ function _printImpl(path, options, print) {
     return _printImplCore(node, path, options, print);
 }
 
+// Ordered list of category-level printers tried in sequence. Each function
+// returns `undefined` (via implicit switch fall-through) when it does not own
+// the given node type, allowing the loop to advance to the next candidate.
+// Note: some printers legitimately return `null` for a valid-but-empty result
+// (e.g. a bare ExpressionStatement that emits nothing), so the "no match"
+// sentinel is strictly `undefined` – using `??` here would be incorrect.
+const NODE_TYPE_PRINTERS = [
+    tryPrintControlStructureNode,
+    tryPrintFunctionNode,
+    tryPrintFunctionSupportNode,
+    tryPrintVariableNode,
+    tryPrintExpressionNode,
+    tryPrintDeclarationNode,
+    tryPrintLiteralNode
+];
+
 function _printImplCore(node, path, options, print) {
-    let doc;
-
-    doc = tryPrintControlStructureNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintFunctionNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintFunctionSupportNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintVariableNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintExpressionNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintDeclarationNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
-    }
-
-    doc = tryPrintLiteralNode(node, path, options, print);
-    if (doc !== undefined) {
-        return doc;
+    for (const tryPrint of NODE_TYPE_PRINTERS) {
+        const doc = tryPrint(node, path, options, print);
+        if (doc !== undefined) return doc;
     }
 }
 


### PR DESCRIPTION
Replaces the over-engineered `_printImplCore` function in `src/format/src/printer/print.ts` with a concise, idiomatic implementation.

## Problem

`_printImplCore` repeated the same pattern seven times in a row:

```ts
doc = tryPrintX(node, path, options, print);
if (doc !== undefined) {
    return doc;
}
```

This 38-line function had no logic variation between blocks — it was pure copy-pasted boilerplate that obscured the simple sequential-dispatch intent and made adding new node-type categories unnecessarily tedious.

## Changes Made

- **`src/format/src/printer/print.ts`**: Extracted the ordered list of category-level printers into a module-level `NODE_TYPE_PRINTERS` array and replaced the seven identical try-assign-check blocks with a single `for` loop (38 lines → 22 lines).

A clarifying comment explains the key nuance: `??` cannot be used here because some printers legitimately return `null` for a valid-but-empty result (e.g. a bare `ExpressionStatement` that emits no output), so the "no match" sentinel must remain strictly `undefined`.

## Behaviour

Identical to before — dispatch order and short-circuit semantics are preserved exactly. The refactor is purely structural.