### PR TITLE
refactor(semantic): remove getDefaultIdentifierCaseFsFacade() wrapper, use constant directly

### DIFF
--- a/src/semantic/src/identifier-case/fs-facade.ts
+++ b/src/semantic/src/identifier-case/fs-facade.ts
@@ -47,8 +47,4 @@ const defaultIdentifierCaseFsFacade = Object.freeze({
     }
 });
 
-export function getDefaultIdentifierCaseFsFacade() {
-    return defaultIdentifierCaseFsFacade;
-}
-
 export { defaultIdentifierCaseFsFacade };

--- a/src/semantic/src/identifier-case/local-plan.ts
+++ b/src/semantic/src/identifier-case/local-plan.ts
@@ -12,7 +12,7 @@ import {
     summarizeReferenceFileOccurrences
 } from "./common.js";
 import { ConflictSeverity } from "./conflict-severity.js";
-import { getDefaultIdentifierCaseFsFacade } from "./fs-facade.js";
+import { defaultIdentifierCaseFsFacade } from "./fs-facade.js";
 import { peekIdentifierCaseDryRunContext } from "./identifier-case-context.js";
 import { formatIdentifierCase } from "./identifier-case-utils.js";
 import { setIdentifierCaseOption } from "./option-store.js";
@@ -118,7 +118,7 @@ function applyAssetRenamesIfEligible({ options, projectIndex, assetRenames, asse
     }
 
     const fsFacade =
-        Core.coalesceOption(options, ["__identifierCaseFs", "identifierCaseFs"]) ?? getDefaultIdentifierCaseFsFacade();
+        Core.coalesceOption(options, ["__identifierCaseFs", "identifierCaseFs"]) ?? defaultIdentifierCaseFsFacade;
     const logger = options.logger ?? null;
     const result = applyAssetRenames({
         projectIndex,

--- a/src/semantic/test/identifier-case-fs-facade.test.ts
+++ b/src/semantic/test/identifier-case-fs-facade.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DEFAULT_WRITE_ACCESS_MODE, defaultIdentifierCaseFsFacade } from "../src/identifier-case/fs-facade.js";
+
+void describe("defaultIdentifierCaseFsFacade", () => {
+    void it("is frozen so callers cannot mutate the shared default", () => {
+        assert.ok(Object.isFrozen(defaultIdentifierCaseFsFacade));
+    });
+
+    void it("exposes the expected file-system methods", () => {
+        const expectedMethods = [
+            "readFileSync",
+            "writeFileSync",
+            "renameSync",
+            "accessSync",
+            "statSync",
+            "mkdirSync",
+            "existsSync"
+        ];
+        for (const method of expectedMethods) {
+            assert.equal(
+                typeof (defaultIdentifierCaseFsFacade as Record<string, unknown>)[method],
+                "function",
+                `expected '${method}' to be a function`
+            );
+        }
+    });
+
+    void it("readFileSync rejects non-string paths", () => {
+        assert.throws(
+            () => defaultIdentifierCaseFsFacade.readFileSync(42 as unknown as string),
+            /readFileSync only accepts string paths/
+        );
+    });
+
+    void it("writeFileSync rejects non-string paths", () => {
+        assert.throws(
+            () => defaultIdentifierCaseFsFacade.writeFileSync(42 as unknown as string, "contents"),
+            /writeFileSync only accepts string paths/
+        );
+    });
+
+    void it("DEFAULT_WRITE_ACCESS_MODE is a number or undefined", () => {
+        assert.ok(
+            DEFAULT_WRITE_ACCESS_MODE === undefined || typeof DEFAULT_WRITE_ACCESS_MODE === "number",
+            "DEFAULT_WRITE_ACCESS_MODE must be a number or undefined"
+        );
+    });
+});


### PR DESCRIPTION
Removes `getDefaultIdentifierCaseFsFacade()` from `src/semantic/src/identifier-case/fs-facade.ts` — a three-line pure-getter wrapper that returned `defaultIdentifierCaseFsFacade`, a constant that was already exported directly from the same file. This is the exact `defaultNow()` anti-pattern: a function that re-exports a value under a new name, inflating the public API surface and implying flexibility that does not exist.

## Before / After

**Before — `fs-facade.ts`:**
```ts
export function getDefaultIdentifierCaseFsFacade() {
    return defaultIdentifierCaseFsFacade;   // ← pure getter, no logic
}

export { defaultIdentifierCaseFsFacade };   // ← already exported directly!
```

**Before — `local-plan.ts`:**
```ts
import { getDefaultIdentifierCaseFsFacade } from "./fs-facade.js";
// ...
const fsFacade =
    Core.coalesceOption(options, ["__identifierCaseFs", "identifierCaseFs"])
    ?? getDefaultIdentifierCaseFsFacade();
```

**After — `local-plan.ts`:**
```ts
import { defaultIdentifierCaseFsFacade } from "./fs-facade.js";
// ...
const fsFacade =
    Core.coalesceOption(options, ["__identifierCaseFs", "identifierCaseFs"])
    ?? defaultIdentifierCaseFsFacade;
```

## Why This Is Safe

- Zero behaviour change: the wrapper and the constant it returned are identical objects — the constant is `Object.freeze`d, so the wrapper could never return a different value.
- The barrel (`identifier-case/index.ts`) re-exports everything from `fs-facade.ts` via `export *`; removing a function that was never part of the documented public API has no downstream impact.
- Callers now see the concrete frozen object they are working with, rather than an opaque factory call that implied multiple configurations might be possible.

## Changes Made

- **`fs-facade.ts`**: Deleted the 3-line `getDefaultIdentifierCaseFsFacade()` function.
- **`local-plan.ts`**: Updated the single call site to import `defaultIdentifierCaseFsFacade` directly.
- **`identifier-case-fs-facade.test.ts`** *(new)*: 5 regression assertions covering the constant's frozen immutability, method shape, `readFileSync`/`writeFileSync` non-string path guards, and `DEFAULT_WRITE_ACCESS_MODE` type.

## Testing

- ✅ `pnpm run build:ts` — clean (0 errors)
- ✅ `pnpm run lint:quiet` — clean (0 warnings)
- ✅ All 595 semantic tests pass (including 5 new assertions)
- ✅ CodeQL security scan — 0 alerts