### PR TITLE
fix(refactor): occurrence deduplication preserves kind field; naming codemod queries companion .yy paths

### DIFF
--- a/src/refactor/src/codemods/naming-convention/naming-convention-codemod.ts
+++ b/src/refactor/src/codemods/naming-convention/naming-convention-codemod.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../types.js";
 import { detectCircularRenames, detectCrossRenameNameConfusion, detectDuplicateTargetNames } from "../../validation.js";
 import { type WorkspaceEdit, WorkspaceEdit as WorkspaceEditClass } from "../../workspace-edit.js";
-import { createPathSelectionMatcher } from "./path-selection.js";
+import { createPathSelectionMatcher, resolveProjectPath } from "./path-selection.js";
 
 const RESERVED_LOCAL_RENAME_CATEGORIES = new Set([
     "globalVariable",
@@ -213,6 +213,40 @@ function findDependentMacroNames(
 }
 
 /**
+ * Build the expanded list of file paths to pass to `listNamingConventionTargets`.
+ *
+ * For each selected GML file the semantic analyzer is also given:
+ * - The project-absolute form of the GML path, since indexers may store absolute paths.
+ * - The companion `.yy` metadata file path (GameMaker resource descriptor), in both
+ *   relative and absolute forms, because some semantic adapters key their symbol tables
+ *   on the resource path rather than the GML source path.
+ *
+ * Passing all four variants ensures the analyzer can surface targets regardless of how
+ * it has indexed the project.
+ *
+ * @param projectRoot - Absolute project root path used to resolve relative entries.
+ * @param selectedFilePaths - Relative or absolute GML file paths that passed selection.
+ * @returns Deduplicated list of paths to query.
+ */
+function buildNamingTargetQueryPaths(projectRoot: string, selectedFilePaths: Array<string>): Array<string> {
+    const queryPaths = new Set<string>();
+
+    for (const filePath of selectedFilePaths) {
+        queryPaths.add(filePath);
+        queryPaths.add(resolveProjectPath(projectRoot, filePath));
+
+        // Companion .yy resource descriptor (sibling of every GML script file).
+        const yyPath = filePath.replace(/\.gml$/i, ".yy");
+        if (yyPath !== filePath) {
+            queryPaths.add(yyPath);
+            queryPaths.add(resolveProjectPath(projectRoot, yyPath));
+        }
+    }
+
+    return [...queryPaths];
+}
+
+/**
  * Plan naming-policy-driven edits for the selected project paths.
  */
 export async function planNamingConventionCodemod(
@@ -267,8 +301,9 @@ export async function planNamingConventionCodemod(
     const isSelectedTargetPath = createPathSelectionMatcher(parameters.projectRoot, parameters.targetPaths, []);
 
     const selectedFilePaths = (parameters.gmlFilePaths ?? []).filter((filePath) => isSelectedTargetPath(filePath));
+    const queryPaths = buildNamingTargetQueryPaths(parameters.projectRoot, selectedFilePaths);
     const queriedTargets = await semantic.listNamingConventionTargets(
-        selectedFilePaths.length === 0 ? undefined : selectedFilePaths,
+        queryPaths.length === 0 ? undefined : queryPaths,
         requestedCategories
     );
     const selectedTargets = queriedTargets.filter((target) => isSelectedTargetPath(target.path));

--- a/src/refactor/src/refactor-engine.ts
+++ b/src/refactor/src/refactor-engine.ts
@@ -105,17 +105,20 @@ function deduplicateSymbolOccurrences(occurrences: Array<SymbolOccurrence>): Arr
         const deduplicated: Array<SymbolOccurrence> = [];
 
         for (const occurrence of occurrences) {
-            const existingOccurrence = deduplicated.find(
+            const existingIndex = deduplicated.findIndex(
                 (candidate) => candidate.path === occurrence.path && candidate.start === occurrence.start
             );
 
-            if (!existingOccurrence) {
+            if (existingIndex === -1) {
                 deduplicated.push(occurrence);
                 continue;
             }
 
-            if (occurrence.end > existingOccurrence.end) {
-                existingOccurrence.end = occurrence.end;
+            // Replace the entire entry when the incoming occurrence covers a wider span so
+            // that all fields (including `kind`) come from the dominant occurrence rather
+            // than forming a hybrid with stale metadata from the first entry seen.
+            if (occurrence.end > deduplicated[existingIndex].end) {
+                deduplicated[existingIndex] = occurrence;
             }
         }
 


### PR DESCRIPTION
Fixes two pre-existing bugs in the `@gmloop/refactor` workspace identified during a codebase survey.

## Changes Made

### 1. `deduplicateSymbolOccurrences` – stale `kind` field after deduplication (`refactor-engine.ts`)

In the small-array fast path (≤8 occurrences), when a duplicate occurrence at the same `path`/`start` but with a larger `end` was encountered, the code mutated only `end` on the existing entry. This left all other fields (including `kind`) from the first occurrence, producing a hybrid object with stale metadata.

**Fix**: Switched from a `find` + mutation pattern to `findIndex` + full array-index replacement, so the dominant occurrence's complete data (all fields) replaces the earlier entry.

### 2. `planNamingConventionCodemod` – missing companion `.yy` paths in `listNamingConventionTargets` call (`naming-convention-codemod.ts`)

The codemod was passing only the selected relative GML file paths to the semantic analyzer. Semantic adapters may index scripts by their `.yy` resource descriptor path and/or by project-absolute paths, so targets could be silently missed.

**Fix**: Added `buildNamingTargetQueryPaths` helper that expands each selected GML path into four variants — relative GML, absolute GML, relative `.yy`, absolute `.yy` — and passes all of them to `listNamingConventionTargets`.

## Testing

- ✅ `pnpm run build:ts` passes with no errors
- ✅ `pnpm run lint:quiet` passes with no issues
- ✅ Refactor test suite: 556 pass (up from 554); 2 remaining failures are pre-existing `EACCES` fixture-runner environment issues unrelated to these changes
- ✅ CodeQL security scan: 0 alerts