### PR TITLE
fix(core): remove unnecessary `as any` casts and fix test assertions for `_preserveDescriptionBreaks`

### DIFF
--- a/src/core/src/comments/doc-comment/description-utils.ts
+++ b/src/core/src/comments/doc-comment/description-utils.ts
@@ -237,7 +237,7 @@ export function applyDescriptionContinuations(
     }
 
     if (continuations.length > 0) {
-        (docCommentDocs as any)._preserveDescriptionBreaks = true;
+        docCommentDocs._preserveDescriptionBreaks = true;
     }
 
     return docCommentDocs;
@@ -280,6 +280,6 @@ export function ensureDescriptionContinuations(docCommentDocs: MutableDocComment
     }
 
     if (foundContinuation) {
-        (docCommentDocs as any)._preserveDescriptionBreaks = true;
+        docCommentDocs._preserveDescriptionBreaks = true;
     }
 }

--- a/src/core/test/comments/description-utils.test.ts
+++ b/src/core/test/comments/description-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { Core } from "../../src/index.js";
+import { Core, type MutableDocCommentLines } from "../../src/index.js";
 
 void test("collectDescriptionContinuationText normalizes multiline description payloads with consumed-line metadata", () => {
     const docLines = [
@@ -22,23 +22,34 @@ void test("collectDescriptionContinuationText normalizes multiline description p
 });
 
 void test("description continuation helpers reuse the same description anchor lookup", () => {
-    const docLines = ["/// @description Build the packet", "/// first line", "/// @param value"];
+    const docLines: MutableDocCommentLines = [
+        "/// @description Build the packet",
+        "/// first line",
+        "/// @param value"
+    ];
 
     assert.deepStrictEqual(Core.collectDescriptionContinuations(docLines), ["/// first line"]);
 
     const applied = Core.applyDescriptionContinuations(docLines, ["/// second line"]);
-    assert.deepStrictEqual(applied, [
+    // Content must match the expected insertion order.
+    assert.deepStrictEqual(Array.from(applied), [
         "/// @description Build the packet",
         "/// second line",
         "/// first line",
         "/// @param value"
     ]);
+    // applyDescriptionContinuations sets _preserveDescriptionBreaks to signal
+    // that the manual line breaks should be kept during later formatting.
+    assert.strictEqual(applied._preserveDescriptionBreaks, true);
 
     Core.ensureDescriptionContinuations(docLines);
-    assert.deepStrictEqual(docLines, [
+    assert.deepStrictEqual(Array.from(docLines), [
         "/// @description Build the packet",
         "/// second line",
         "/// first line",
         "/// @param value"
     ]);
+    // ensureDescriptionContinuations also sets the flag when continuations
+    // are present and have been normalised.
+    assert.strictEqual(docLines._preserveDescriptionBreaks, true);
 });


### PR DESCRIPTION
Fixes a reproducible test failure in the `@gmloop/core` workspace.

## Bug

`applyDescriptionContinuations` and `ensureDescriptionContinuations` in `src/core/src/comments/doc-comment/description-utils.ts` set `_preserveDescriptionBreaks = true` directly on their `MutableDocCommentLines` array argument using unnecessary `(docCommentDocs as any)` casts. Node's `assert.deepStrictEqual` checks **all own enumerable properties** on arrays — not just indexed elements — so the existing test assertions, which compared the mutated array against a plain `string[]` literal (which lacks `_preserveDescriptionBreaks`), always failed.

## Changes Made

- **`src/core/src/comments/doc-comment/description-utils.ts`**: Removed two `(docCommentDocs as any)` type escapes. `MutableDocCommentLines` is declared as `Array<string> & { _preserveDescriptionBreaks?: boolean }`, making the direct assignment fully type-safe without the cast.

- **`src/core/test/comments/description-utils.test.ts`**: Updated the failing test to:
  - Declare `docLines` as `MutableDocCommentLines` (the correct type for the parameter).
  - Use `Array.from()` for element-only `deepStrictEqual` comparisons, separating content checks from metadata.
  - Add explicit `assert.strictEqual(…._preserveDescriptionBreaks, true)` assertions to document and enforce the intentional side-effect contract.

## Testing

- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ All 70 core tests pass with no regressions
- ✅ CodeQL scan: 0 alerts

The change set is minimal (2 files, 17 insertions / 6 deletions) and does not touch any golden `.gml` fixtures or unrelated behaviour.