### PR TITLE
refactor(lint): Eliminate Redundant Control Flow and Bespoke Loc Resolver in optimize-logical-flow-rule

### DIFF
--- a/src/lint/src/rules/gml/rules/optimize-logical-flow-rule.ts
+++ b/src/lint/src/rules/gml/rules/optimize-logical-flow-rule.ts
@@ -2,7 +2,7 @@ import { Core } from "@gmloop/core";
 import type { Rule } from "eslint";
 
 import { printNodeForAutofix } from "../print-expression.js";
-import { cloneAstNodeWithoutTraversalLinks, createMeta } from "../rule-base-helpers.js";
+import { cloneAstNodeWithoutTraversalLinks, createMeta, resolveLocFromIndex } from "../rule-base-helpers.js";
 import type { GmlRuleDefinition } from "../rule-definition.js";
 import { applyLogicalNormalizationWithChangeMetadata } from "../transforms/logical-expression-traversal-normalization.js";
 
@@ -274,25 +274,15 @@ function canLogicalExpressionBenefitFromNormalization(node: unknown): boolean {
         return true;
     }
 
-    if (logicalExpression.operator === "&&") {
-        return (
-            left.type === "LogicalExpression" ||
-            right.type === "LogicalExpression" ||
-            left.type === "BinaryExpression" ||
-            right.type === "BinaryExpression"
-        );
-    }
-
-    if (logicalExpression.operator === "||") {
-        return (
-            left.type === "LogicalExpression" ||
-            right.type === "LogicalExpression" ||
-            left.type === "BinaryExpression" ||
-            right.type === "BinaryExpression"
-        );
-    }
-
-    return false;
+    // At this point the operator is guaranteed to be "&&" or "||" (checked above).
+    // Both operators share the same structural heuristic: normalize when either
+    // operand is itself a logical/binary expression that could be further simplified.
+    return (
+        left.type === "LogicalExpression" ||
+        right.type === "LogicalExpression" ||
+        left.type === "BinaryExpression" ||
+        right.type === "BinaryExpression"
+    );
 }
 
 function getNodeRange(node: unknown): SourceTextRange | null {
@@ -318,43 +308,6 @@ function isRangeInsideAnyRange(range: SourceTextRange, existingRanges: ReadonlyA
     return existingRanges.some((existingRange) => {
         return range.start >= existingRange.start && range.end <= existingRange.end;
     });
-}
-
-function resolveSafeNodeLoc(context: Rule.RuleContext, node: unknown): { line: number; column: number } {
-    const sourceText = context.sourceCode.text;
-    const rawStart = Core.getNodeStartIndex(node as any);
-    const startIndex =
-        typeof rawStart === "number" && Number.isFinite(rawStart) ? Core.clamp(rawStart, 0, sourceText.length) : 0;
-    const sourceCodeWithLocator = context.sourceCode as Rule.RuleContext["sourceCode"] & {
-        getLocFromIndex?: (index: number) => { line: number; column: number } | undefined;
-    };
-    const located =
-        typeof sourceCodeWithLocator.getLocFromIndex === "function"
-            ? sourceCodeWithLocator.getLocFromIndex(startIndex)
-            : undefined;
-    if (
-        located &&
-        typeof located.line === "number" &&
-        typeof located.column === "number" &&
-        Number.isFinite(located.line) &&
-        Number.isFinite(located.column)
-    ) {
-        return located;
-    }
-
-    let line = 1;
-    let lastLineStart = 0;
-    for (let index = 0; index < startIndex; index += 1) {
-        if (sourceText[index] === "\n") {
-            line += 1;
-            lastLineStart = index + 1;
-        }
-    }
-
-    return {
-        line,
-        column: startIndex - lastLineStart
-    };
 }
 
 export function createOptimizeLogicalFlowRule(definition: GmlRuleDefinition): Rule.RuleModule {
@@ -434,7 +387,11 @@ export function createOptimizeLogicalFlowRule(definition: GmlRuleDefinition): Ru
                         rewrittenNodeRanges.push(nodeRange);
 
                         context.report({
-                            loc: resolveSafeNodeLoc(context, originalNode as unknown),
+                            loc: resolveLocFromIndex(
+                                context,
+                                fullSourceText,
+                                Core.getNodeStartIndex(originalNode) ?? 0
+                            ),
                             messageId: definition.messageId,
                             fix(fixer) {
                                 return fixer.replaceTextRange([nodeRange.start, nodeRange.end], newText);

--- a/src/refactor/src/codemods/naming-convention/path-selection.ts
+++ b/src/refactor/src/codemods/naming-convention/path-selection.ts
@@ -52,26 +52,14 @@ export function createPathSelectionMatcher(
                 isPathInsideSelection(absoluteTargetPath, absoluteSelectionPath)
             );
         if (!isAllowed) {
-<<<<<<< HEAD
             cache.set(targetPath, false);
-            return false;
-        }
-
-        const isDenied = absoluteDeniedPaths.some((absoluteSelectionPath) =>
-            isPathInsideSelection(absoluteTargetPath, absoluteSelectionPath)
-        );
-        const result = !isDenied;
-        cache.set(targetPath, result);
-=======
-            resultCache.set(targetPath, false);
             return false;
         }
 
         const result = !absoluteDeniedPaths.some((absoluteSelectionPath) =>
             isPathInsideSelection(absoluteTargetPath, absoluteSelectionPath)
         );
-        resultCache.set(targetPath, result);
->>>>>>> 33846f47c (perf(refactor): eliminate hot-path bottlenecks in naming-convention codemod)
+        cache.set(targetPath, result);
         return result;
     };
 }

--- a/src/refactor/src/naming-convention-policy.ts
+++ b/src/refactor/src/naming-convention-policy.ts
@@ -462,11 +462,6 @@ function stripOneAffixDirection(
         return stripAffix(coreName, exclusive[0], position);
     }
 
-<<<<<<< HEAD
-    for (const banned of bannedAffixes) {
-        if (banned.length > 0 && hasAffix(coreName, banned)) {
-            return stripAffix(coreName, banned, position);
-=======
     // bannedAffixes is pre-sorted descending by length in resolveNamingConventionRules,
     // so we can iterate without creating an intermediate sorted copy.
     for (const banned of bannedAffixes) {
@@ -475,7 +470,6 @@ function stripOneAffixDirection(
             if (matches) {
                 return stripAffix(coreName, banned, position);
             }
->>>>>>> 33846f47c (perf(refactor): eliminate hot-path bottlenecks in naming-convention codemod)
         }
     }
 
@@ -524,14 +518,10 @@ export function evaluateNamingConvention(
         };
     }
     let issueMessage: string | null = null;
-<<<<<<< HEAD
-    let precomputedSuggestedName: string | null = null;
-=======
     // When the case-style branch detects a violation it already computes the
     // expected name, so we capture it here to avoid a second identical call to
     // composeExpectedIdentifierName at the bottom of the function.
     let precomputedSuggestedName: string | undefined;
->>>>>>> 33846f47c (perf(refactor): eliminate hot-path bottlenecks in naming-convention codemod)
     const coreName = stripKnownAffixes(currentName, rule, policy, category);
     const exclusivePrefix = longestMatchingAffix(currentName, policy.exclusivePrefixes, "prefix");
     const exclusiveSuffix = longestMatchingAffix(currentName, policy.exclusiveSuffixes, "suffix");
@@ -556,7 +546,6 @@ export function evaluateNamingConvention(
         precomputedSuggestedName = composeExpectedIdentifierName(coreName, rule);
         if (precomputedSuggestedName !== currentName) {
             issueMessage = `Identifier ${JSON.stringify(currentName)} does not match ${rule.caseStyle} case.`;
-            precomputedSuggestedName = expectedName;
         }
     }
 
@@ -579,14 +568,9 @@ export function evaluateNamingConvention(
         };
     }
 
-<<<<<<< HEAD
-    const suggestedName =
-        precomputedSuggestedName === null ? composeExpectedIdentifierName(coreName, rule) : precomputedSuggestedName;
-=======
     // Reuse the expected name already computed in the case-style branch when
     // available; otherwise compute it now for other violation types.
     const suggestedName = precomputedSuggestedName ?? composeExpectedIdentifierName(coreName, rule);
->>>>>>> 33846f47c (perf(refactor): eliminate hot-path bottlenecks in naming-convention codemod)
 
     return {
         compliant: suggestedName === currentName,


### PR DESCRIPTION
Refactors two over-engineered patterns in `src/lint/src/rules/gml/rules/optimize-logical-flow-rule.ts` identified after a full codebase survey.

## Changes Made

### 1. Collapsed duplicate `if` branches in `canLogicalExpressionBenefitFromNormalization`

The function had separate `if (operator === "&&")` and `if (operator === "||")` blocks that returned **identical** expressions. The guard at the top of the function already rejected any other operator, making the two branches mutually unreachable. Both were collapsed into a single unconditional `return` with an explanatory comment, removing ~14 lines of dead control flow.

### 2. Replaced bespoke `resolveSafeNodeLoc` with the shared `resolveLocFromIndex` helper

A 36-line private function reimplemented the same `getLocFromIndex`-then-manual-line-scan logic already present in (and exported by) `resolveLocFromIndex` from `rule-base-helpers.ts`. The local copy was removed entirely and its one call site updated to use the shared helper.

### 3. Resolved pre-existing merge conflicts

Two files (`src/refactor/src/codemods/naming-convention/path-selection.ts` and `src/refactor/src/naming-convention-policy.ts`) had unresolved conflict markers from a previous perf commit that blocked `pnpm run build:ts`. Resolved by taking the optimised incoming form and removing a stray `precomputedSuggestedName = expectedName` reference to an undeclared variable introduced as merge debris.

## Testing

- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ All `optimize-logical-flow` rule tests pass
- ✅ No golden `.gml` fixtures modified
- ✅ No behaviour change — refactor only

Net: −71 lines across the three files.