### PR TITLE
refactor: replace bespoke dedup/stringify implementations with Core helpers

### DIFF
--- a/src/cli/src/commands/collect-stats.ts
+++ b/src/cli/src/commands/collect-stats.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+import { Core } from "@gmloop/core";
 import { Command } from "commander";
 
 import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
@@ -29,6 +30,6 @@ export function runCollectStats({ command }: { command?: CommanderCommandLike } 
     const outputDir = path.dirname(outputPath);
     ensureDirSync(outputDir);
 
-    fs.writeFileSync(outputPath, JSON.stringify(stats, null, 2));
+    fs.writeFileSync(outputPath, Core.stringifyJsonForFile(stats, { space: 2 }));
     console.log(`Project health stats written to ${outputPath}`);
 }

--- a/src/cli/src/modules/hot-reload/inject-runtime.ts
+++ b/src/cli/src/modules/hot-reload/inject-runtime.ts
@@ -369,7 +369,7 @@ async function copyRuntimeWrapperAssets(
         force: true,
         filter: shouldCopyRuntimeWrapperAsset
     });
-    await fs.writeFile(manifestPath, `${JSON.stringify(sourceManifest, null, 2)}\n`, "utf8");
+    await fs.writeFile(manifestPath, Core.stringifyJsonForFile(sourceManifest, { space: 2 }), "utf8");
 
     return {
         copiedAssets: true,

--- a/src/cli/test/collect-stats-command.test.ts
+++ b/src/cli/test/collect-stats-command.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { runCollectStats } from "../src/commands/collect-stats.js";
+
+void describe("runCollectStats", () => {
+    const tempDirs: Array<string> = [];
+
+    after(() => {
+        for (const dir of tempDirs) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    function createTempDir(): string {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "collect-stats-test-"));
+        tempDirs.push(dir);
+        return dir;
+    }
+
+    void it("writes a valid JSON file with a trailing newline", () => {
+        const tempDir = createTempDir();
+        const outputPath = path.join(tempDir, "stats.json");
+
+        runCollectStats({ command: { opts: () => ({ output: outputPath }) } });
+
+        assert.ok(fs.existsSync(outputPath), "output file should be written");
+
+        const raw = fs.readFileSync(outputPath, "utf8");
+
+        assert.ok(raw.endsWith("\n"), "output JSON must end with a trailing newline");
+        assert.doesNotThrow(() => JSON.parse(raw), "output must be valid JSON");
+    });
+
+    void it("creates the output directory when it does not exist", () => {
+        const tempDir = createTempDir();
+        const outputPath = path.join(tempDir, "nested", "subdir", "stats.json");
+
+        runCollectStats({ command: { opts: () => ({ output: outputPath }) } });
+
+        assert.ok(fs.existsSync(outputPath), "output file should be created in a nested directory");
+    });
+});

--- a/src/refactor/src/refactor-engine.ts
+++ b/src/refactor/src/refactor-engine.ts
@@ -141,10 +141,6 @@ function deduplicateSymbolOccurrences(occurrences: Array<SymbolOccurrence>): Arr
     return [...deduplicatedByStart.values()];
 }
 
-function deduplicateStableValues(values: ReadonlyArray<string>): Array<string> {
-    return [...new Set(values)];
-}
-
 function semanticSupportsBatchWorkspaceOverlay(
     semantic: PartialSemanticAnalyzer | null
 ): semantic is PartialSemanticAnalyzer &
@@ -1242,8 +1238,8 @@ export class RefactorEngine {
             dryRunOverlayReadCacheMaxEntries = 32,
             dryRunOverlayStorageBackend
         } = request;
-        const targetPaths = deduplicateStableValues(request.targetPaths);
-        const gmlFilePaths = deduplicateStableValues(request.gmlFilePaths);
+        const targetPaths = Core.uniqueArray(request.targetPaths) as Array<string>;
+        const gmlFilePaths = Core.uniqueArray(request.gmlFilePaths) as Array<string>;
 
         Core.assertNonEmptyString(projectRoot, {
             errorMessage: "executeConfiguredCodemods requires a projectRoot"


### PR DESCRIPTION
Surveyed the entire codebase for code that reimplements behaviour already provided by shared helpers or modern platform APIs, then refactored the three clearest opportunities.

## Changes Made

- **`src/refactor/src/refactor-engine.ts`**: Removed the private `deduplicateStableValues` function (which was a thin wrapper around `[...new Set(values)]`) and replaced both call sites with `Core.uniqueArray`, consistent with the existing usage elsewhere in the same file.

- **`src/cli/src/modules/hot-reload/inject-runtime.ts`**: Replaced the manual backtick template `` `${JSON.stringify(sourceManifest, null, 2)}\n` `` with `Core.stringifyJsonForFile(sourceManifest, { space: 2 })`, which already owns this serialise-to-file pattern across the project.

- **`src/cli/src/commands/collect-stats.ts`**: Replaced bare `JSON.stringify(stats, null, 2)` (which produced no trailing newline, diverging from every other JSON-to-file write in the project) with `Core.stringifyJsonForFile(stats, { space: 2 })` and added the missing `Core` import.

- **`src/cli/test/collect-stats-command.test.ts`** _(new)_: Added tests covering the trailing-newline contract and nested-directory creation for `runCollectStats`, which were previously untested.

## Testing

- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ Existing refactor-engine deduplication tests pass
- ✅ Existing hot-reload integration tests pass
- ✅ New `collect-stats-command` tests pass

The diff is minimal and self-contained: no golden `.gml` fixtures are modified, no compatibility shims are added, and behaviour is fully preserved.