### PR TITLE
lint: emit clean-run summary when no problems found

### DIFF
--- a/src/cli/src/commands/lint.ts
+++ b/src/cli/src/commands/lint.ts
@@ -1413,6 +1413,15 @@ export async function runLintCommand(command: CommanderCommandLike): Promise<voi
             // users and CI pipelines get an explicit success signal rather
             // than a silent zero exit, consistent with the format command's
             // "All matched files are already formatted." message.
+            //
+            // This condition is intentionally formatter-agnostic: the `json`
+            // and `checkstyle` formatters always emit non-empty output even
+            // for clean runs (a JSON array, an XML document), so
+            // `formatterOutput.length === 0` is only true when using `stylish`
+            // or any other formatter that is deliberately silent on success.
+            // We do not check `options.formatter` by name to avoid hardcoding
+            // that assumption and to remain compatible with future formatters
+            // that follow the same silent-on-success convention.
             if (exitCode === 0 && formatterOutput.length === 0 && results.length > 0 && !options.quiet) {
                 emitLintCleanSummary(results.length);
             }

--- a/src/cli/src/commands/lint.ts
+++ b/src/cli/src/commands/lint.ts
@@ -821,6 +821,22 @@ function emitVerboseLintRunTimingSummary(parameters: {
     );
 }
 
+/**
+ * Print a confirmation message when all linted files pass with no diagnostics.
+ *
+ * The message mirrors the `format` command's "All matched files are already
+ * formatted." signal, giving users and CI pipelines an unambiguous success
+ * indicator instead of a silent exit.  It is intentionally suppressed when:
+ * - the ESLint formatter already produced visible output (e.g. the `json` and
+ *   `checkstyle` formatters always emit content, so they don't need an extra
+ *   line); or
+ * - `--quiet` is active (callers have explicitly opted for minimal output).
+ */
+function emitLintCleanSummary(fileCount: number): void {
+    const fileLabel = fileCount === 1 ? "file" : "files";
+    console.log(`✓ ${fileCount} ${fileLabel} checked, no problems found.`);
+}
+
 function toEslintOverrideConfig(): NonNullable<ConstructorParameters<typeof ESLint>[0]>["overrideConfig"] {
     const entries = LINT_NAMESPACE.configs.recommended.map((entry) => ({
         ...entry,
@@ -1381,23 +1397,31 @@ export async function runLintCommand(command: CommanderCommandLike): Promise<voi
             if (formatterOutput.length > 0) {
                 process.stdout.write(`${formatterOutput}\n`);
             }
-        } catch (error) {
-            console.error(Core.isErrorLike(error) ? error.message : String(error));
-            setProcessExitCode(2);
-            return;
-        }
 
-        const totals = aggregateLintTotals(results, {
-            allowParseErrors: options.allowParseErrors
-        });
+            const totals = aggregateLintTotals(results, {
+                allowParseErrors: options.allowParseErrors
+            });
 
-        setProcessExitCode(
-            resolveExitCode({
+            const exitCode = resolveExitCode({
                 errorCount: totals.errorCount,
                 warningCount: totals.warningCount,
                 maxWarnings: options.maxWarnings
-            })
-        );
+            });
+
+            // When the stylish formatter produces no output it means no
+            // diagnostics were reported.  Emit a single confirmation line so
+            // users and CI pipelines get an explicit success signal rather
+            // than a silent zero exit, consistent with the format command's
+            // "All matched files are already formatted." message.
+            if (exitCode === 0 && formatterOutput.length === 0 && results.length > 0 && !options.quiet) {
+                emitLintCleanSummary(results.length);
+            }
+
+            setProcessExitCode(exitCode);
+        } catch (error) {
+            console.error(Core.isErrorLike(error) ? error.message : String(error));
+            setProcessExitCode(2);
+        }
     } finally {
         if (options.verbose) {
             const elapsedNanoseconds = calculateElapsedNanoseconds({
@@ -1446,5 +1470,6 @@ export const __lintCommandTest__ = Object.freeze({
     collectOutOfRootFilePaths,
     formatPathSample,
     formatOutOfRootWarning,
-    OUT_OF_ROOT_DISPLAY_LIMIT
+    OUT_OF_ROOT_DISPLAY_LIMIT,
+    emitLintCleanSummary
 });

--- a/src/cli/test/lint-command-definition.test.ts
+++ b/src/cli/test/lint-command-definition.test.ts
@@ -65,3 +65,93 @@ void test("lint reports when no .gml files are found in the provided path", asyn
         await rm(temporaryDirectory, { recursive: true, force: true });
     }
 });
+
+void test("lint prints a clean-run summary when all files pass with no diagnostics", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-clean-"));
+
+    try {
+        // A trivial GML script that triggers no lint rules.
+        await writeFile(path.join(temporaryDirectory, "clean.gml"), "var x = 1;\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        assert.match(result.stdout, /✓.*file.*checked.*no problems found/);
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});
+
+void test("lint clean-run summary is suppressed when --quiet is active", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-quiet-"));
+
+    try {
+        await writeFile(path.join(temporaryDirectory, "clean.gml"), "var x = 1;\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--quiet", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        assert.equal(result.stdout, "");
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});
+
+void test("lint clean-run summary is not printed when the formatter produces its own output", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-json-"));
+
+    try {
+        await writeFile(path.join(temporaryDirectory, "clean.gml"), "var x = 1;\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--formatter", "json", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        // JSON formatter always produces output; the clean summary must not be appended.
+        assert.doesNotMatch(result.stdout, /✓.*no problems found/);
+        // Output must still be valid JSON.
+        assert.doesNotThrow(() => JSON.parse(result.stdout));
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});
+
+void test("lint clean-run summary uses singular 'file' for exactly one file", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-singular-"));
+
+    try {
+        await writeFile(path.join(temporaryDirectory, "clean.gml"), "var x = 1;\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        assert.match(result.stdout, /✓ 1 file checked, no problems found\./);
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});
+
+void test("lint clean-run summary uses plural 'files' for more than one file", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-plural-"));
+
+    try {
+        await writeFile(path.join(temporaryDirectory, "a.gml"), "var x = 1;\n", "utf8");
+        await writeFile(path.join(temporaryDirectory, "b.gml"), "var y = 2;\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        assert.match(result.stdout, /✓ 2 files checked, no problems found\./);
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});

--- a/src/cli/test/lint-result-aggregation.test.ts
+++ b/src/cli/test/lint-result-aggregation.test.ts
@@ -9,7 +9,8 @@ const {
     collectOutOfRootFilePaths,
     formatPathSample,
     formatOutOfRootWarning,
-    OUT_OF_ROOT_DISPLAY_LIMIT
+    OUT_OF_ROOT_DISPLAY_LIMIT,
+    emitLintCleanSummary
 } = __lintCommandTest__;
 
 // ---------------------------------------------------------------------------
@@ -294,4 +295,38 @@ void test("formatOutOfRootWarning delegates truncation to formatPathSample", () 
     const output = formatOutOfRootWarning(paths);
     assert.ok(output.startsWith("GML_PROJECT_OUT_OF_ROOT:\n"));
     assert.ok(output.includes("and 7 more..."), `expected suffix in: ${output}`);
+});
+
+// ---------------------------------------------------------------------------
+// emitLintCleanSummary
+// ---------------------------------------------------------------------------
+
+void test("emitLintCleanSummary logs singular 'file' label for fileCount of 1", () => {
+    const logged: Array<string> = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+        logged.push(args.map(String).join(" "));
+    };
+    try {
+        emitLintCleanSummary(1);
+    } finally {
+        console.log = original;
+    }
+    assert.equal(logged.length, 1);
+    assert.match(logged[0], /✓ 1 file checked, no problems found\./);
+});
+
+void test("emitLintCleanSummary logs plural 'files' label for fileCount greater than 1", () => {
+    const logged: Array<string> = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+        logged.push(args.map(String).join(" "));
+    };
+    try {
+        emitLintCleanSummary(3);
+    } finally {
+        console.log = original;
+    }
+    assert.equal(logged.length, 1);
+    assert.match(logged[0], /✓ 3 files checked, no problems found\./);
 });


### PR DESCRIPTION
After surveying the CLI entry points end-to-end, the most painful usability gap found was that the `lint` command produces **no output** when all checked files pass with zero diagnostics. A silent zero exit gives users and CI pipelines no confirmation that lint actually ran and found files to check — in contrast, the `format` command clearly prints `"All matched files are already formatted."` on a clean run.

## Changes Made

- **`src/cli/src/commands/lint.ts`**: Added `emitLintCleanSummary(fileCount)` helper that prints `✓ N file(s) checked, no problems found.` after a clean lint run. The message is emitted only when:
  - The formatter produced no output (the `stylish` formatter is silent on success; `json` and `checkstyle` always emit non-empty content so they are unaffected)
  - The resolved exit code is 0 (errors or `--max-warnings` exceeded suppress it)
  - At least one file was actually linted
  - `--quiet` is not active

- **`src/cli/test/lint-command-definition.test.ts`**: 5 new integration tests covering singular/plural file labelling, quiet-mode suppression, and JSON formatter pass-through (ensuring the clean summary is never appended to machine-readable output).

- **`src/cli/test/lint-result-aggregation.test.ts`**: 2 new unit tests for the `emitLintCleanSummary` helper function exported via `__lintCommandTest__`.

## Before / After

```
# Before — silent on a clean run
$ pnpm run cli -- lint --path ./vendor/MyProject
<exit 0, no output>

# After
$ pnpm run cli -- lint --path ./vendor/MyProject
✓ 4 files checked, no problems found.
```

## Testing

- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ All 33 lint-specific tests pass (12 definition + 21 aggregation/unit)
- ✅ Pre-existing `refactor codemod` failures are unrelated to these changes