### PR TITLE
refactor(cli): Extract `readSemanticLocationIndex` shared helper to eliminate duplicated location-index extraction logic

### DIFF
--- a/src/cli/src/modules/refactor/macro-expansion-dependencies.ts
+++ b/src/cli/src/modules/refactor/macro-expansion-dependencies.ts
@@ -5,6 +5,8 @@ import { Core } from "@gmloop/core";
 import { Parser } from "@gmloop/parser";
 import { Semantic } from "@gmloop/semantic";
 
+import { readSemanticLocationIndex } from "./semantic-index-helpers.js";
+
 type MacroIdentifierEntry = {
     declarations?: Array<Record<string, unknown>>;
 };
@@ -230,26 +232,13 @@ function collectMacroReferenceNames(tokens: ReadonlyArray<unknown>): Set<string>
     }
 }
 
-function readLocationIndex(location: unknown): number | null {
-    if (typeof location === "number") {
-        return location;
-    }
-
-    if (!Core.isObjectLike(location)) {
-        return null;
-    }
-
-    const typedLocation = location as { index?: unknown };
-    return typeof typedLocation.index === "number" ? typedLocation.index : null;
-}
-
 function readMacroBodyStartIndex(statement: {
     keywordRange?: unknown;
     name?: unknown;
     start?: unknown;
 }): number | null {
     const macroNameNode = Core.isIdentifierNode(statement.name) ? (statement.name as { end?: unknown }) : null;
-    const macroNameEnd = readLocationIndex(macroNameNode?.end);
+    const macroNameEnd = readSemanticLocationIndex(macroNameNode?.end);
     if (typeof macroNameEnd === "number") {
         return macroNameEnd + 1;
     }
@@ -261,7 +250,7 @@ function readMacroBodyStartIndex(statement: {
         return keywordRange.end;
     }
 
-    return readLocationIndex(statement.start);
+    return readSemanticLocationIndex(statement.start);
 }
 
 function collectMacroDeclarationReferenceRecordsFromFile(
@@ -308,7 +297,7 @@ function collectMacroDeclarationReferenceRecordsFromFile(
         }
 
         const bodyStart = readMacroBodyStartIndex(macroStatement);
-        const statementEnd = readLocationIndex(macroStatement.end);
+        const statementEnd = readSemanticLocationIndex(macroStatement.end);
         const bodyEnd = typeof statementEnd === "number" ? statementEnd + 1 : sourceText.length;
         if (typeof bodyStart !== "number" || bodyEnd <= bodyStart) {
             records.push({

--- a/src/cli/src/modules/refactor/semantic-bridge.ts
+++ b/src/cli/src/modules/refactor/semantic-bridge.ts
@@ -13,6 +13,7 @@ import {
     listMacroExpansionDependencies
 } from "./macro-expansion-dependencies.js";
 import { ParsedLocalNamingCategoryResolver } from "./parsed-local-naming-categories.js";
+import { readExclusiveSemanticLocationIndex, readSemanticLocationIndex } from "./semantic-index-helpers.js";
 
 type ResourceAssetReferenceRecord = {
     propertyPath: string;
@@ -705,7 +706,7 @@ export class GmlSemanticBridge {
             entriesByRelatedName.set(name, new Set([entry]));
         };
 
-        const appendLookupEntry = (name: string, scopeId: string | undefined): void => {
+        const appendLookupEntry = (name: string, scopeId?: string): void => {
             if (!Core.isNonEmptyString(name)) {
                 return;
             }
@@ -819,7 +820,7 @@ export class GmlSemanticBridge {
             const resourceScipId = this.generateResourceScipId(resource);
             resourcesByExactName.set(resource.name, resource);
             resourcesByLowerName.set(resource.name.toLowerCase(), resource);
-            appendLookupEntry(resource.name, undefined);
+            appendLookupEntry(resource.name);
             registerResolveSymbolId(resource.name, resourceScipId);
 
             if (!Core.isNonEmptyString(resource.path)) {
@@ -2806,8 +2807,8 @@ export class GmlSemanticBridge {
                 continue;
             }
 
-            const startIndex = this.readLocationIndex(reference.start);
-            const endIndex = this.readExclusiveLocationIndex(reference.end);
+            const startIndex = readSemanticLocationIndex(reference.start);
+            const endIndex = readExclusiveSemanticLocationIndex(reference.end);
             if (startIndex === null || endIndex === null) {
                 continue;
             }
@@ -2816,7 +2817,7 @@ export class GmlSemanticBridge {
                 continue;
             }
 
-            const declarationStartIndex = this.readLocationIndex(referenceDeclaration.start);
+            const declarationStartIndex = readSemanticLocationIndex(referenceDeclaration.start);
             const declarationScopeId =
                 typeof referenceDeclaration.scopeId === "string" ? referenceDeclaration.scopeId : null;
             const referenceKey = this.createLocalReferenceKey(
@@ -2837,16 +2838,6 @@ export class GmlSemanticBridge {
 
         this.localReferenceOccurrencesByFilePath.set(filePath, indexedOccurrences);
         return indexedOccurrences;
-    }
-
-    private readLocationIndex(location: unknown): number | null {
-        const record = Core.isObjectLike(location) ? (location as Record<string, unknown>) : null;
-        return typeof record?.index === "number" ? record.index : null;
-    }
-
-    private readExclusiveLocationIndex(location: unknown): number | null {
-        const index = this.readLocationIndex(location);
-        return index === null ? null : toExclusiveEndIndex(index);
     }
 
     private isMemberAccessReference(sourceText: string | null, startIndex: number): boolean {
@@ -2872,16 +2863,8 @@ export class GmlSemanticBridge {
         const occurrences: Array<SymbolOccurrence> = [];
 
         for (const declaration of entry.declarations ?? []) {
-            const declarationStartRecord = Core.isObjectLike(declaration.start)
-                ? (declaration.start as Record<string, unknown>)
-                : null;
-            const declarationEndRecord = Core.isObjectLike(declaration.end)
-                ? (declaration.end as Record<string, unknown>)
-                : null;
-            const declarationStart =
-                typeof declarationStartRecord?.index === "number" ? declarationStartRecord.index : 0;
-            const declarationEnd =
-                typeof declarationEndRecord?.index === "number" ? toExclusiveEndIndex(declarationEndRecord.index) : 0;
+            const declarationStart = readSemanticLocationIndex(declaration.start) ?? 0;
+            const declarationEnd = readExclusiveSemanticLocationIndex(declaration.end) ?? 0;
 
             occurrences.push({
                 path: typeof declaration.filePath === "string" ? declaration.filePath : "",
@@ -2893,27 +2876,13 @@ export class GmlSemanticBridge {
         }
 
         for (const reference of entry.references ?? []) {
-            const referenceStartRecord = Core.isObjectLike(reference.start)
-                ? (reference.start as Record<string, unknown>)
-                : null;
-            const referenceEndRecord = Core.isObjectLike(reference.end)
-                ? (reference.end as Record<string, unknown>)
-                : null;
             const referenceLocationRecord = Core.isObjectLike(reference.location)
                 ? (reference.location as Record<string, unknown>)
                 : null;
-            const locationStartRecord = Core.isObjectLike(referenceLocationRecord?.start)
-                ? (referenceLocationRecord.start as Record<string, unknown>)
-                : null;
-            const locationEndRecord = Core.isObjectLike(referenceLocationRecord?.end)
-                ? (referenceLocationRecord.end as Record<string, unknown>)
-                : null;
-            const referenceStart = typeof referenceStartRecord?.index === "number" ? referenceStartRecord.index : 0;
-            const referenceEnd =
-                typeof referenceEndRecord?.index === "number" ? toExclusiveEndIndex(referenceEndRecord.index) : 0;
-            const locationStart = typeof locationStartRecord?.index === "number" ? locationStartRecord.index : 0;
-            const locationEnd =
-                typeof locationEndRecord?.index === "number" ? toExclusiveEndIndex(locationEndRecord.index) : 0;
+            const referenceStart = readSemanticLocationIndex(reference.start) ?? 0;
+            const referenceEnd = readExclusiveSemanticLocationIndex(reference.end) ?? 0;
+            const locationStart = readSemanticLocationIndex(referenceLocationRecord?.start) ?? 0;
+            const locationEnd = readExclusiveSemanticLocationIndex(referenceLocationRecord?.end) ?? 0;
 
             occurrences.push({
                 path: typeof reference.filePath === "string" ? reference.filePath : "",
@@ -2947,14 +2916,8 @@ export class GmlSemanticBridge {
                 continue;
             }
 
-            const startRecord = Core.isObjectLike(unresolvedReference.reference.start)
-                ? (unresolvedReference.reference.start as Record<string, unknown>)
-                : null;
-            const endRecord = Core.isObjectLike(unresolvedReference.reference.end)
-                ? (unresolvedReference.reference.end as Record<string, unknown>)
-                : null;
-            const start = typeof startRecord?.index === "number" ? startRecord.index : null;
-            const end = typeof endRecord?.index === "number" ? toExclusiveEndIndex(endRecord.index) : null;
+            const start = readSemanticLocationIndex(unresolvedReference.reference.start);
+            const end = readExclusiveSemanticLocationIndex(unresolvedReference.reference.end);
 
             if (start === null || end === null || end <= start) {
                 continue;
@@ -2985,14 +2948,8 @@ export class GmlSemanticBridge {
 
         for (const unresolvedReference of this.getIndexes().unresolvedReferencesByExactName.get(symbolName) ?? []) {
             const classifications = Core.asArray(unresolvedReference.reference.classifications);
-            const startRecord = Core.isObjectLike(unresolvedReference.reference.start)
-                ? (unresolvedReference.reference.start as Record<string, unknown>)
-                : null;
-            const endRecord = Core.isObjectLike(unresolvedReference.reference.end)
-                ? (unresolvedReference.reference.end as Record<string, unknown>)
-                : null;
-            const start = typeof startRecord?.index === "number" ? startRecord.index : null;
-            const end = typeof endRecord?.index === "number" ? toExclusiveEndIndex(endRecord.index) : null;
+            const start = readSemanticLocationIndex(unresolvedReference.reference.start);
+            const end = readExclusiveSemanticLocationIndex(unresolvedReference.reference.end);
 
             if (start === null || end === null || end <= start) {
                 continue;
@@ -3123,10 +3080,7 @@ export class GmlSemanticBridge {
         declaration: Record<string, unknown>,
         sourceText: string | null
     ): Extract<BridgeNamingConventionCategory, "localVariable" | "loopIndexVariable" | "staticVariable"> {
-        const declarationStart = Core.isObjectLike(declaration.start)
-            ? (declaration.start as Record<string, unknown>)
-            : null;
-        const startIndex = typeof declarationStart?.index === "number" ? declarationStart.index : null;
+        const startIndex = readSemanticLocationIndex(declaration.start);
         if (typeof declaration.name !== "string" || startIndex === null) {
             return "localVariable";
         }
@@ -3142,10 +3096,7 @@ export class GmlSemanticBridge {
         declaration: Record<string, unknown>,
         sourceText: string | null
     ): boolean {
-        const declarationStart = Core.isObjectLike(declaration.start)
-            ? (declaration.start as Record<string, unknown>)
-            : null;
-        const startIndex = typeof declarationStart?.index === "number" ? declarationStart.index : null;
+        const startIndex = readSemanticLocationIndex(declaration.start);
         if (typeof declaration.name !== "string" || startIndex === null) {
             return false;
         }
@@ -3176,10 +3127,7 @@ export class GmlSemanticBridge {
         )) {
             const sourceText = this.readProjectSourceText(filePath);
             for (const declaration of fileRecord.declarations ?? []) {
-                const declarationStart = Core.isObjectLike(declaration.start)
-                    ? (declaration.start as Record<string, unknown>)
-                    : null;
-                const startIndex = typeof declarationStart?.index === "number" ? declarationStart.index : null;
+                const startIndex = readSemanticLocationIndex(declaration.start);
                 if (typeof declaration.name !== "string" || startIndex === null) {
                     continue;
                 }

--- a/src/cli/src/modules/refactor/semantic-index-helpers.ts
+++ b/src/cli/src/modules/refactor/semantic-index-helpers.ts
@@ -1,0 +1,37 @@
+import { Core } from "@gmloop/core";
+
+/**
+ * Extracts a numeric character index from a semantic project-index location value.
+ *
+ * Location values in the semantic project index appear in two forms:
+ * - A plain number (the index itself, produced by parser AST nodes when
+ *   `simplifyLocations: true`).
+ * - An object with a numeric `index` property (e.g. `{ index: 42, line: 3,
+ *   column: 10 }`), produced when `simplifyLocations: false`.
+ *
+ * Returns `null` when the input matches neither form.
+ */
+export function readSemanticLocationIndex(location: unknown): number | null {
+    if (typeof location === "number") {
+        return location;
+    }
+
+    if (!Core.isObjectLike(location)) {
+        return null;
+    }
+
+    const record = location as { index?: unknown };
+    return typeof record.index === "number" ? record.index : null;
+}
+
+/**
+ * Like {@link readSemanticLocationIndex}, but converts the inclusive end index
+ * stored by the semantic project index into the exclusive (one-past-the-end)
+ * form expected by refactor text-edit ranges and `string.slice()`.
+ *
+ * Returns `null` when the input does not encode a valid index.
+ */
+export function readExclusiveSemanticLocationIndex(location: unknown): number | null {
+    const index = readSemanticLocationIndex(location);
+    return index === null ? null : index + 1;
+}

--- a/src/cli/test/semantic-index-helpers.test.ts
+++ b/src/cli/test/semantic-index-helpers.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+    readExclusiveSemanticLocationIndex,
+    readSemanticLocationIndex
+} from "../src/modules/refactor/semantic-index-helpers.js";
+
+void describe("readSemanticLocationIndex", () => {
+    void it("returns a plain number directly", () => {
+        assert.equal(readSemanticLocationIndex(42), 42);
+        assert.equal(readSemanticLocationIndex(0), 0);
+    });
+
+    void it("returns the index property from an object", () => {
+        assert.equal(readSemanticLocationIndex({ index: 10 }), 10);
+        assert.equal(readSemanticLocationIndex({ index: 0, line: 1, column: 0 }), 0);
+    });
+
+    void it("returns null for null", () => {
+        assert.equal(readSemanticLocationIndex(null), null);
+    });
+
+    void it("returns null for undefined", () => {
+        assert.equal(readSemanticLocationIndex(undefined), null);
+    });
+
+    void it("returns null for an object without a numeric index property", () => {
+        assert.equal(readSemanticLocationIndex({}), null);
+        assert.equal(readSemanticLocationIndex({ index: "42" }), null);
+        assert.equal(readSemanticLocationIndex({ index: null }), null);
+    });
+
+    void it("returns null for non-object, non-number primitives", () => {
+        assert.equal(readSemanticLocationIndex("42"), null);
+        assert.equal(readSemanticLocationIndex(true), null);
+    });
+});
+
+void describe("readExclusiveSemanticLocationIndex", () => {
+    void it("converts a plain number to one-past-the-end", () => {
+        assert.equal(readExclusiveSemanticLocationIndex(41), 42);
+        assert.equal(readExclusiveSemanticLocationIndex(0), 1);
+    });
+
+    void it("converts an object index to one-past-the-end", () => {
+        assert.equal(readExclusiveSemanticLocationIndex({ index: 9 }), 10);
+        assert.equal(readExclusiveSemanticLocationIndex({ index: 99, line: 5, column: 3 }), 100);
+    });
+
+    void it("returns null for null", () => {
+        assert.equal(readExclusiveSemanticLocationIndex(null), null);
+    });
+
+    void it("returns null for undefined", () => {
+        assert.equal(readExclusiveSemanticLocationIndex(undefined), null);
+    });
+
+    void it("returns null for objects without a numeric index property", () => {
+        assert.equal(readExclusiveSemanticLocationIndex({}), null);
+        assert.equal(readExclusiveSemanticLocationIndex({ index: "5" }), null);
+    });
+});


### PR DESCRIPTION
Unifies a duplicated location-index extraction pattern that appeared in two separate, slightly-diverging implementations across the `@gmloop/cli` refactor module.

## Duplication Removed

The pattern of extracting a numeric character index from a semantic project-index location value (either a plain number or an object with a `.index` property) was copied in two places:

1. **`macro-expansion-dependencies.ts`** — a module-level `readLocationIndex` free function, called at 3 sites (macro name end, statement start, statement end).
2. **`semantic-bridge.ts`** — near-identical private `readLocationIndex` / `readExclusiveLocationIndex` class methods (3 direct call sites), plus **7 additional inline occurrences** of the same 4-line `Core.isObjectLike + typeof record?.index` pattern spread across `collectEntryOccurrences`, `collectUnresolvedEnumMemberOccurrences`, `tryCollectUnresolvedConstructorStaticMemberOccurrences`, `resolveLocalNamingConventionCategory`, `isConstructorStaticMemberDeclaration`, and `getConstructorStaticMemberNameCounts`.

## Changes Made

- **New:** `src/cli/src/modules/refactor/semantic-index-helpers.ts` — canonical `readSemanticLocationIndex` and `readExclusiveSemanticLocationIndex` helpers with TSDoc comments, handling both plain-number and `{ index: number }` location shapes.
- **`macro-expansion-dependencies.ts`** — removed local duplicate; all 3 call sites updated to import from the shared module.
- **`semantic-bridge.ts`** — removed private class methods; all 3 direct call sites and 7 inline 4-line patterns updated to use the shared helpers. Made `appendLookupEntry`'s `scopeId` parameter optional (`scopeId?: string`) to align with the ESLint `unicorn/no-useless-undefined` rule enforced by the pre-commit hook.
- **New:** `src/cli/test/semantic-index-helpers.test.ts` — 11 unit tests covering both helpers across all input shapes (plain number, `{ index }` object, null, undefined, non-numeric index).

## Testing

- ✅ `pnpm run build:ts` passes with no TypeScript errors
- ✅ `pnpm run lint:quiet` passes
- ✅ All 63 affected tests pass (52 existing `GmlSemanticBridge` tests + 11 new helper tests)
- ✅ Pre-existing test failures in unrelated suites are unchanged