### PR TITLE
fix: Recover Failing Tests (semantic, refactor, fixture-runner, cli)

### DIFF
--- a/src/cli/test/fix-command.test.ts
+++ b/src/cli/test/fix-command.test.ts
@@ -138,11 +138,16 @@ void test("fix runs codemods, lint fixes, and formatting in sequence for a proje
         assert.match(result.stdout, /\[3\/3 Format\]/);
         assert.match(result.stdout, /Success! Project codemods, lint fixes, and formatting completed/);
 
-        await access(path.join(projectRoot, "scripts/demo_script/demo_script.gml"));
-        const scriptSource = await readFile(path.join(projectRoot, "scripts/demo_script/demo_script.gml"), "utf8");
-        assert.match(scriptSource, /function demo_script\(\)/);
+        // The naming convention (scriptResourceName: camel) renames demo_script → demoScript.
+        await access(path.join(projectRoot, "scripts/demoScript/demoScript.gml"));
+        const scriptSource = await readFile(path.join(projectRoot, "scripts/demoScript/demoScript.gml"), "utf8");
+        // The refactor codemod renames the function to camelCase.
+        assert.match(scriptSource, /function demoScript\(\)/);
+        // The lint fix adds a @returns annotation.
         assert.match(scriptSource, /@returns/);
+        // The formatter applies spacing around the if-condition parentheses.
         assert.match(scriptSource, /if \(true\) \{/);
+        // The lint fix inlines the variable and expands the numeric literal 1e3 → 1000.
         assert.match(scriptSource, /return 1000;/);
         assert.doesNotMatch(scriptSource, /1e3/);
     } finally {

--- a/src/fixture-runner/src/runner/fixture-suite.ts
+++ b/src/fixture-runner/src/runner/fixture-suite.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { chmod, cp, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, test } from "node:test";
@@ -171,6 +171,11 @@ async function executeFixtureCase(
             if (fixtureCase.projectDirectoryPath) {
                 workingProjectDirectoryPath = await mkdtemp(path.join(os.tmpdir(), "gmloop-fixture-runner-"));
                 await cp(fixtureCase.projectDirectoryPath, workingProjectDirectoryPath, { recursive: true });
+                // The source fixture files may be read-only (e.g. protected golden files).
+                // Make all copied files writable so the refactor engine can write changes.
+                const tempDir = workingProjectDirectoryPath;
+                const copiedFiles = await Core.listRelativeFilePathsRecursively(tempDir);
+                await Promise.all(copiedFiles.map((relPath) => chmod(path.join(tempDir, relPath), 0o644)));
             }
         });
 

--- a/src/refactor/src/naming-convention-policy.ts
+++ b/src/refactor/src/naming-convention-policy.ts
@@ -474,7 +474,8 @@ function toCamelCaseFromLowerSnakeCore(value: string): string {
         }
 
         // Uppercase the character when following an underscore and it's a-z (97–122).
-        formatted += uppercaseNext && code >= 97 && code <= 122 ? String.fromCharCode(code - 32) : String.fromCharCode(code);
+        formatted +=
+            uppercaseNext && code >= 97 && code <= 122 ? String.fromCharCode(code - 32) : String.fromCharCode(code);
         uppercaseNext = false;
     }
 
@@ -653,7 +654,11 @@ function stripOneAffixDirection(
 
             if (
                 prefixWord === coreTargetPrefix ||
-                prefixWord === coreTargetPrefix[0] ||
+                // Only strip a single-char prefix-word when it is underscore-separated
+                // (e.g. "o_camera" → strip "o_" → "camera"). For camelCase names like
+                // "oCamera" the leading "o" is part of the word structure and must not
+                // be stripped—it will be kept and converted as a normal word.
+                (prefixWord === coreTargetPrefix[0] && separator === "_") ||
                 (prefixWord.length > 1 && coreTargetPrefix.startsWith(prefixWord))
             ) {
                 return separator === "_" ? remainder : separator + remainder;

--- a/src/refactor/test/naming-convention-policy.test.ts
+++ b/src/refactor/test/naming-convention-policy.test.ts
@@ -223,6 +223,36 @@ void test("evaluateNamingConvention replaces underscore resource prefixes for sh
     assert.equal(evaluation.suggestedName, "shd_cm_debug");
 });
 
+void test("evaluateNamingConvention preserves camelCase prefix-word when it matches only the first character of the target prefix", () => {
+    // "oCamera" has a camelCase prefix-word "o" that happens to match the first character
+    // of the target prefix "obj". The "o" must NOT be stripped—it is part of the word
+    // structure and should be kept, producing "obj_o_camera" (not "obj_camera").
+    const policy = Refactor.normalizeNamingConventionPolicy({
+        rules: {
+            resource: {
+                caseStyle: "lower_snake"
+            },
+            objectResourceName: {
+                prefix: "obj_"
+            }
+        }
+    });
+    const resolved = Refactor.resolveNamingConventionRules(policy);
+
+    const camera = Refactor.evaluateNamingConvention("oCamera", "objectResourceName", policy, resolved);
+    assert.equal(camera.compliant, false);
+    assert.equal(camera.suggestedName, "obj_o_camera");
+
+    const compound = Refactor.evaluateNamingConvention("oColmesh2DemoCylinder", "objectResourceName", policy, resolved);
+    assert.equal(compound.compliant, false);
+    assert.equal(compound.suggestedName, "obj_o_colmesh2demo_cylinder");
+
+    // Underscore-separated prefix "o_" IS stripped (that's a real prefix, not a word).
+    const underscorePrefixed = Refactor.evaluateNamingConvention("o_camera", "objectResourceName", policy, resolved);
+    assert.equal(underscorePrefixed.compliant, false);
+    assert.equal(underscorePrefixed.suggestedName, "obj_camera");
+});
+
 void test("evaluateNamingConvention fast-path handles simple case-style-only rules", () => {
     const policy = Refactor.normalizeNamingConventionPolicy({
         rules: {

--- a/src/semantic/src/project-index/resource-analysis.ts
+++ b/src/semantic/src/project-index/resource-analysis.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { Core } from "@gmloop/core";
 
-import { isProjectMetadataParseError, parseProjectMetadataDocumentWithSchema } from "../project-metadata/yy-adapter.js";
+import { isProjectMetadataParseError, parseProjectMetadataDocument } from "../project-metadata/yy-adapter.js";
 import {
     isProjectManifestPath,
     matchProjectResourceMetadataExtension,
@@ -184,8 +184,7 @@ function createResourceAnalysisContext() {
 async function loadResourceDocument(
     file,
     fsFacade: Required<Pick<ProjectIndexFsFacade, "readFile">> = defaultFsFacade,
-    options = {},
-    logger: { log: typeof console.log } | null = null
+    options = {}
 ) {
     const { ensureNotAborted } = Core.createAbortGuard(options, {
         fallbackMessage: RESOURCE_ANALYSIS_ABORT_MESSAGE
@@ -203,14 +202,12 @@ async function loadResourceDocument(
     ensureNotAborted();
 
     try {
-        const parsed = parseProjectMetadataDocumentWithSchema(rawContents, file.absolutePath ?? file.relativePath);
-        if (parsed.schemaName && !parsed.schemaValidated && logger) {
-            logger.log(
-                `WARN: Resource metadata at '${file.relativePath}' does not fully match '${parsed.schemaName}' schema; continuing with parsed document.`
-            );
-        }
-
-        return parsed.document;
+        // Use plain parse (no schema) to preserve the original document structure.
+        // Schema-validated parsing fills in schema defaults and can replace custom
+        // fields (e.g. sprite sequence channel data) with empty defaults, causing
+        // asset reference data loss. Schema validation is only needed for mutation
+        // workflows, not for read-only resource analysis.
+        return parseProjectMetadataDocument(rawContents, file.absolutePath ?? file.relativePath);
     } catch (error) {
         if (isProjectMetadataParseError(error)) {
             return null;
@@ -354,7 +351,7 @@ export async function analyseResourceFiles({
 
     await Core.runSequentially(yyFiles, async (file) => {
         Core.throwIfAborted(signal, RESOURCE_ANALYSIS_ABORT_MESSAGE);
-        const parsed = await loadResourceDocument(file, fsFacade, { signal }, logger);
+        const parsed = await loadResourceDocument(file, fsFacade, { signal });
         if (!parsed) {
             skippedCount++;
             return;


### PR DESCRIPTION
Fixes four distinct failing tests identified by running the full automated test suite (`pnpm test`).

## Root Causes & Fixes

### 1. `analyseResourceFiles captures sprite keyframe Id references` (`semantic`)
`loadResourceDocument` was calling `parseProjectMetadataDocumentWithSchema`, which applies the `@bscotch/yy` schema to sprite YY documents and replaces custom `sequence.tracks` channel data (including `Channels.0.Id` asset references) with empty schema defaults. Changed to plain `parseProjectMetadataDocument` — resource analysis is read-only and only needs the raw document structure; schema validation belongs in mutation workflows only.

### 2. Refactor fixture `EACCES: permission denied` failures (`fixture-runner`)
Golden-fixture source files are stored read-only (`-r--r--r--`). Node's `fs.cp()` preserves those permissions into the temp working directory, causing the refactor engine to fail with `EACCES` when attempting to write changes. Added a `chmod 0o644` pass over all copied files immediately after `cp` in `fixture-suite.ts`.

### 3. Naming-convention camelCase object renames (tests 246 & 251, `refactor`)
The prefix-word detection in `stripOneAffixDirection` had an overly broad condition (`prefixWord === coreTargetPrefix[0]`) that incorrectly matched the `o` in camelCase names like `oCamera` against the first character of the target prefix `obj_`, stripping it and producing `obj_camera` instead of the correct `obj_o_camera`. Fixed by restricting this branch to underscore-separated prefix style only (added `&& separator === "_"`). Added a focused unit test covering the corrected behaviour and the contrasting underscore-separated case.

### 4. `fix runs codemods, lint fixes, and formatting in sequence` (`cli`)
Test assertions referenced stale file paths (`scripts/demo_script/demo_script.gml`) and function name (`function demo_script()`) that no longer exist after the `scriptResourceName: camel` naming convention correctly renames `demo_script → demoScript`. Updated assertions to match the actual post-fix state (`scripts/demoScript/demoScript.gml`, `function demoScript()`).

## Testing

- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ All four previously-failing tests now pass; no previously-passing tests regressed
- ✅ CodeQL security scan: 0 alerts

Pre-existing formatter/integration fixture content mismatches (golden file differences) remain — these are unrelated to the changes above and were failing before this PR.