### PR TITLE
refactor(cli): improve DRY-ness in semantic-bridge reference occurrence collection

### DIFF
--- a/src/cli/src/modules/refactor/semantic-bridge.ts
+++ b/src/cli/src/modules/refactor/semantic-bridge.ts
@@ -100,6 +100,15 @@ type SymbolOccurrence = {
     start: number;
 };
 
+/** Minimal shape of a reference record within a semantic identifier entry's `references` array. */
+type SemanticEntryReferenceRecord = {
+    end?: { index?: number };
+    filePath?: unknown;
+    location?: { end?: { index?: number }; start?: { index?: number } };
+    scopeId?: unknown;
+    start?: { index?: number };
+};
+
 type FileSymbol = {
     id: string;
 };
@@ -307,6 +316,29 @@ function toExclusiveEndIndex(endIndex: number): number {
 
 function resolveOccurrenceEndIndex(endIndex: unknown): number | null {
     return typeof endIndex === "number" ? toExclusiveEndIndex(endIndex) : null;
+}
+
+/**
+ * Extract position data from a semantic entry reference record and push a validated
+ * reference occurrence onto the accumulator. Silently skips records with missing or
+ * invalid location data.
+ */
+function pushEntryReferenceOccurrence(ref: SemanticEntryReferenceRecord, occurrences: Array<SymbolOccurrence>): void {
+    const start = ref.start?.index ?? ref.location?.start?.index ?? 0;
+    const end = resolveOccurrenceEndIndex(ref.end?.index ?? ref.location?.end?.index);
+    const filePath = typeof ref.filePath === "string" ? ref.filePath : "";
+
+    if (!Core.isNonEmptyString(filePath) || end === null || end <= start) {
+        return;
+    }
+
+    occurrences.push({
+        path: filePath,
+        start,
+        end,
+        scopeId: typeof ref.scopeId === "string" ? ref.scopeId : undefined,
+        kind: "reference"
+    });
 }
 
 function createWorkspaceEdit(): WorkspaceEdit {
@@ -1755,21 +1787,7 @@ export class GmlSemanticBridge {
                         continue;
                     }
 
-                    const start = ref.start?.index ?? ref.location?.start?.index ?? 0;
-                    const end = resolveOccurrenceEndIndex(ref.end?.index ?? ref.location?.end?.index);
-                    const filePath = typeof ref.filePath === "string" ? ref.filePath : "";
-
-                    if (!Core.isNonEmptyString(filePath) || end === null || end <= start) {
-                        continue;
-                    }
-
-                    occurrences.push({
-                        path: filePath,
-                        start,
-                        end,
-                        scopeId: ref.scopeId,
-                        kind: "reference"
-                    });
+                    pushEntryReferenceOccurrence(ref, occurrences);
                 }
             }
 
@@ -1785,21 +1803,7 @@ export class GmlSemanticBridge {
         if (Array.isArray(entry.references)) {
             for (const ref of entry.references) {
                 if (ref.targetName === symbolName) {
-                    const start = ref.start?.index ?? ref.location?.start?.index ?? 0;
-                    const end = resolveOccurrenceEndIndex(ref.end?.index ?? ref.location?.end?.index);
-                    const filePath = typeof ref.filePath === "string" ? ref.filePath : "";
-
-                    if (!Core.isNonEmptyString(filePath) || end === null || end <= start) {
-                        continue;
-                    }
-
-                    occurrences.push({
-                        path: filePath,
-                        start,
-                        end,
-                        scopeId: ref.scopeId,
-                        kind: "reference"
-                    });
+                    pushEntryReferenceOccurrence(ref, occurrences);
                 }
             }
         }
@@ -1899,21 +1903,7 @@ export class GmlSemanticBridge {
         // Add references
         if (Array.isArray(entry.references)) {
             for (const ref of entry.references) {
-                const start = ref.start?.index ?? ref.location?.start?.index ?? 0;
-                const end = resolveOccurrenceEndIndex(ref.end?.index ?? ref.location?.end?.index);
-                const filePath = typeof ref.filePath === "string" ? ref.filePath : "";
-
-                if (!Core.isNonEmptyString(filePath) || end === null || end <= start) {
-                    continue;
-                }
-
-                occurrences.push({
-                    path: filePath,
-                    start,
-                    end,
-                    scopeId: ref.scopeId,
-                    kind: "reference"
-                });
+                pushEntryReferenceOccurrence(ref, occurrences);
             }
         }
     }


### PR DESCRIPTION
Reduces duplication in `src/cli/src/modules/refactor/semantic-bridge.ts` by extracting a shared helper for the repeated pattern of pushing a validated reference occurrence from a semantic entry reference record.

## Changes Made

- **New type `SemanticEntryReferenceRecord`**: Captures the minimal shape of records in `SemanticIdentifierEntry.references`, replacing implicit reliance on `any` with a properly typed interface.
- **New helper `pushEntryReferenceOccurrence(ref, occurrences)`**: Extracts the identical 13-line block (8 executable lines) that was duplicated verbatim across three methods — `collectOccurrencesFromEntry` (Case A), `collectOccurrencesFromEntry` (Case C), and `collectAllFromEntry` — into a single module-level function called in all three places.
- **Tightened `scopeId` handling**: The helper uses an explicit `typeof ref.scopeId === "string"` guard instead of the previous unguarded assignment from an `any`-typed source.

## Testing

- ✅ `pnpm run build:ts` — 0 TypeScript errors
- ✅ `pnpm run lint:quiet` — clean
- ✅ 52/52 `gml-semantic-bridge` tests pass
- ✅ No pre-existing passing tests were broken

The diff is minimal and focused entirely on eliminating duplicated logic without altering external behavior.