### PR TITLE
Agent: Target State Alignment

### DIFF
--- a/src/lint/src/rules/gml/rule-base-helpers.ts
+++ b/src/lint/src/rules/gml/rule-base-helpers.ts
@@ -99,6 +99,7 @@ export function cloneAstNodeWithoutTraversalLinks<T>(node: T): T {
 type RuleMetaOverrides = Readonly<{
     fixable?: "code" | "whitespace" | null;
     messageText?: string;
+    includeFixableDefault?: boolean;
 }>;
 
 const DEFAULT_EMPTY_GML_RULE_SCHEMA: ReadonlyArray<unknown> = Object.freeze([
@@ -124,7 +125,12 @@ export function createMeta(definition: GmlRuleDefinition, overrides: RuleMetaOve
         messages: Object.freeze(messages)
     };
 
+    const includeFixableDefault = overrides.includeFixableDefault ?? true;
+
     if (overrides.fixable === undefined) {
+        if (!includeFixableDefault) {
+            return Object.freeze(meta);
+        }
         meta.fixable = "code";
     } else if (overrides.fixable !== null) {
         meta.fixable = overrides.fixable;

--- a/src/lint/src/rules/gml/rules/no-globalvar-rule.ts
+++ b/src/lint/src/rules/gml/rules/no-globalvar-rule.ts
@@ -35,7 +35,7 @@ function collectGlobalVarStatementStartOffsets(programNode: unknown): ReadonlyAr
 
 export function createNoGlobalvarRule(definition: GmlRuleDefinition): Rule.RuleModule {
     return Object.freeze({
-        meta: createMeta(definition, { fixable: null }),
+        meta: createMeta(definition, { includeFixableDefault: false }),
         create(context) {
             const listener: Rule.RuleListener = {
                 Program(programNode) {

--- a/src/lint/src/rules/gml/rules/no-globalvar-rule.ts
+++ b/src/lint/src/rules/gml/rules/no-globalvar-rule.ts
@@ -1,27 +1,11 @@
 import * as CoreWorkspace from "@gmloop/core";
 import type { Rule } from "eslint";
 
-import {
-    applySourceTextEdits,
-    createMeta,
-    getNodeEndIndex,
-    getNodeStartIndex,
-    isAstNodeRecord,
-    reportFullTextRewrite,
-    type SourceTextEdit,
-    walkAstNodesWithParent
-} from "../rule-base-helpers.js";
+import { createMeta, getNodeStartIndex, isAstNodeRecord, resolveLocFromIndex } from "../rule-base-helpers.js";
 import type { GmlRuleDefinition } from "../rule-definition.js";
-import { isIdentifier } from "../rule-helpers.js";
 
-type GlobalVarStatementRange = Readonly<{
-    start: number;
-    end: number;
-    names: ReadonlyArray<string>;
-}>;
-
-function collectGlobalVarStatements(programNode: unknown): ReadonlyArray<GlobalVarStatementRange> {
-    const statements: Array<GlobalVarStatementRange> = [];
+function collectGlobalVarStatementStartOffsets(programNode: unknown): ReadonlyArray<number> {
+    const statementStartOffsets: Array<number> = [];
 
     const visit = (node: unknown): void => {
         if (Array.isArray(node)) {
@@ -37,22 +21,8 @@ function collectGlobalVarStatements(programNode: unknown): ReadonlyArray<GlobalV
 
         if (node.type === "GlobalVarStatement") {
             const start = getNodeStartIndex(node);
-            const endExclusive = getNodeEndIndex(node);
-            if (typeof start === "number" && typeof endExclusive === "number") {
-                const declarations = CoreWorkspace.Core.asArray<Record<string, unknown>>(node.declarations);
-                const names = declarations
-                    .map((declaration) => CoreWorkspace.Core.getIdentifierText(declaration.id ?? null))
-                    .filter((name): name is string => isIdentifier(name));
-
-                if (names.length > 0) {
-                    statements.push(
-                        Object.freeze({
-                            start,
-                            end: endExclusive,
-                            names
-                        })
-                    );
-                }
+            if (typeof start === "number") {
+                statementStartOffsets.push(start);
             }
         }
 
@@ -60,116 +30,31 @@ function collectGlobalVarStatements(programNode: unknown): ReadonlyArray<GlobalV
     };
 
     visit(programNode);
-    return statements;
-}
-
-/**
- * Resolve the start offset of the line that contains `offset`, i.e. the index
- * of the character immediately after the preceding `\n` (or 0 for line 1).
- */
-function resolveLineStart(sourceText: string, offset: number): number {
-    const preceding = sourceText.lastIndexOf("\n", Math.max(0, offset - 1));
-    return preceding === -1 ? 0 : preceding + 1;
-}
-
-/**
- * Resolve the exclusive end offset of the line that contains `offset`,
- * including any trailing `\n` so the entire line (and its terminator) is
- * captured by a `[lineStart, lineEnd)` half-open range.
- */
-function resolveLineEnd(sourceText: string, offset: number): number {
-    const next = sourceText.indexOf("\n", offset);
-    return next === -1 ? sourceText.length : next + 1;
-}
-
-/**
- * Build the set of source-text edits needed to auto-fix all `globalvar`
- * violations in one pass:
- *
- *  1. Delete each `globalvar …;` statement line.
- *  2. Prefix every bare identifier that names a globalvar-declared variable
- *     with `global.`, skipping identifiers that are already accessed through a
- *     `global.xxx` member expression and skipping identifiers that appear
- *     inside the `globalvar` declaration itself (which is being deleted).
- */
-function buildGlobalVarFixEdits(
-    sourceText: string,
-    programNode: unknown,
-    statements: ReadonlyArray<GlobalVarStatementRange>
-): ReadonlyArray<SourceTextEdit> {
-    const globalVarNames = new Set<string>();
-    const deletedRanges: Array<{ start: number; end: number }> = [];
-
-    for (const stmt of statements) {
-        for (const name of stmt.names) {
-            globalVarNames.add(name);
-        }
-        // Capture the full line (including its newline terminator) so the
-        // deletion does not leave a stray blank line in the output.
-        const lineStart = resolveLineStart(sourceText, stmt.start);
-        const lineEnd = resolveLineEnd(sourceText, stmt.end - 1);
-        deletedRanges.push({ start: lineStart, end: lineEnd });
-    }
-
-    const edits: Array<SourceTextEdit> = [];
-
-    // Deletion edits for globalvar statement lines.
-    for (const range of deletedRanges) {
-        edits.push({ start: range.start, end: range.end, text: "" });
-    }
-
-    // Identifier prefix edits: insert "global." before each bare reference.
-    walkAstNodesWithParent(programNode, ({ node, parent, parentKey }) => {
-        if (node.type !== "Identifier" || typeof node.name !== "string") {
-            return;
-        }
-
-        if (!globalVarNames.has(node.name)) {
-            return;
-        }
-
-        // Already accessed as global.xxx — the object side of a member
-        // expression whose object is named "global".
-        if (parent !== null && parent.type === "MemberDotExpression" && parentKey === "property") {
-            return;
-        }
-
-        const start = getNodeStartIndex(node);
-        if (typeof start !== "number") {
-            return;
-        }
-
-        // Skip identifiers that sit inside a globalvar declaration being
-        // deleted — we are removing the whole line, so prefixing them would
-        // create a dangling "global.xxx" inside the deleted span.
-        const isInsideDeletedRange = deletedRanges.some((range) => start >= range.start && start < range.end);
-        if (isInsideDeletedRange) {
-            return;
-        }
-
-        // Insert "global." immediately before the identifier.
-        edits.push({ start, end: start, text: "global." });
-    });
-
-    return edits;
+    return statementStartOffsets;
 }
 
 export function createNoGlobalvarRule(definition: GmlRuleDefinition): Rule.RuleModule {
     return Object.freeze({
-        meta: createMeta(definition, { fixable: "code" }),
+        meta: createMeta(definition, { fixable: null }),
         create(context) {
             const listener: Rule.RuleListener = {
                 Program(programNode) {
-                    const globalVarStatements = collectGlobalVarStatements(programNode);
-                    if (globalVarStatements.length === 0) {
+                    const globalVarStatementStartOffsets = collectGlobalVarStatementStartOffsets(programNode);
+                    if (globalVarStatementStartOffsets.length === 0) {
                         return;
                     }
 
                     const sourceText = context.sourceCode.text;
-                    const edits = buildGlobalVarFixEdits(sourceText, programNode, globalVarStatements);
-                    const rewrittenText = applySourceTextEdits(sourceText, edits);
+                    const firstViolationLoc = resolveLocFromIndex(
+                        context,
+                        sourceText,
+                        globalVarStatementStartOffsets[0] ?? 0
+                    );
 
-                    reportFullTextRewrite(context, definition.messageId, sourceText, rewrittenText);
+                    context.report({
+                        loc: firstViolationLoc,
+                        messageId: definition.messageId
+                    });
                 }
             };
 

--- a/src/lint/test/fixtures/no-globalvar/gmloop.json
+++ b/src/lint/test/fixtures/no-globalvar/gmloop.json
@@ -1,9 +1,0 @@
-{
-  "lintRules": {
-    "gml/no-globalvar": "error"
-  },
-  "fixture": {
-    "kind": "lint",
-    "assertion": "transform"
-  }
-}

--- a/src/lint/test/rules/rule-contracts.test.ts
+++ b/src/lint/test/rules/rule-contracts.test.ts
@@ -225,9 +225,8 @@ void test("recommended baseline rules expose stable messageIds and exact schemas
 
         assertEquals(typeof rule.meta?.messages?.[ruleDefinition.messageId], "string");
         assert.deepEqual(rule.meta?.schema, ruleDefinition.schema);
-        if (ruleDefinition.shortName !== "no-globalvar") {
-            assertEquals(rule.meta?.fixable, "code");
-        }
+        const expectedFixable = ruleDefinition.shortName === "no-globalvar" ? undefined : "code";
+        assertEquals(rule.meta?.fixable, expectedFixable);
     }
 });
 

--- a/src/lint/test/rules/rule-standalone.test.ts
+++ b/src/lint/test/rules/rule-standalone.test.ts
@@ -958,19 +958,9 @@ void test("no-globalvar diagnoses declared globals", () => {
         "}",
         ""
     ].join("\n");
-    const expected = [
-        "",
-        "if (should_exit()) return;",
-        "",
-        "",
-        "if (global.doExit == global.exitState) {",
-        "    exit;",
-        "}",
-        ""
-    ].join("\n");
     const result = lintWithRule("no-globalvar", input, {});
     assertEquals(result.messages.length > 0, true);
-    assertEquals(result.output, expected);
+    assertEquals(result.output, input);
 });
 
 void test("no-globalvar diagnoses comma-separated declarations", () => {
@@ -978,17 +968,9 @@ void test("no-globalvar diagnoses comma-separated declarations", () => {
         "\n"
     );
 
-    const expected = [
-        "",
-        "global.score = 1;",
-        "if (global.lives > 0) {",
-        "    global.score += global.lives;",
-        "}",
-        ""
-    ].join("\n");
     const result = lintWithRule("no-globalvar", input, {});
     assertEquals(result.messages.length > 0, true);
-    assertEquals(result.output, expected);
+    assertEquals(result.output, input);
 });
 
 void test("no-globalvar diagnoses comma-separated declarations", () => {
@@ -996,17 +978,9 @@ void test("no-globalvar diagnoses comma-separated declarations", () => {
         "\n"
     );
 
-    const expected = [
-        "",
-        "global.score = 1;",
-        "if (global.lives > 0) {",
-        "    global.score += global.lives;",
-        "}",
-        ""
-    ].join("\n");
     const result = lintWithRule("no-globalvar", input, {});
     assertEquals(result.messages.length > 0, true);
-    assertEquals(result.output, expected);
+    assertEquals(result.output, input);
 });
 
 void test("prefer-hoistable-loop-accessors respects null suffix override by disabling loop-test diagnostics", () => {

--- a/src/lint/test/rules/rule-standalone.test.ts
+++ b/src/lint/test/rules/rule-standalone.test.ts
@@ -963,7 +963,7 @@ void test("no-globalvar diagnoses declared globals", () => {
     assertEquals(result.output, input);
 });
 
-void test("no-globalvar diagnoses comma-separated declarations in repeated runs", () => {
+void test("no-globalvar diagnoses comma-separated declarations without rewriting source", () => {
     const input = ["globalvar score, lives;", "score = 1;", "if (lives > 0) {", "    score += lives;", "}", ""].join(
         "\n"
     );

--- a/src/lint/test/rules/rule-standalone.test.ts
+++ b/src/lint/test/rules/rule-standalone.test.ts
@@ -963,7 +963,7 @@ void test("no-globalvar diagnoses declared globals", () => {
     assertEquals(result.output, input);
 });
 
-void test("no-globalvar diagnoses comma-separated declarations", () => {
+void test("no-globalvar diagnoses comma-separated declarations in repeated runs", () => {
     const input = ["globalvar score, lives;", "score = 1;", "if (lives > 0) {", "    score += lives;", "}", ""].join(
         "\n"
     );

--- a/test/fixtures/integration/test-int-no-globalvar/expected.gml
+++ b/test/fixtures/integration/test-int-no-globalvar/expected.gml
@@ -1,6 +1,8 @@
-global.testGlobalVarName1 = "test global value";
-global.testGlobalVarName1 = "new test global value";
+globalvar testGlobalVarName1, g5;
+testGlobalVarName1 = "test global value";
+testGlobalVarName1 = "new test global value";
 global.testGlobalVarName2 = "different global value";
-global.testGlobalVarName3 = "another global value";
-global.testGlobalVarName4 = "yet another global value";
-global.g5 = "five";
+globalvar testGlobalVarName3, testGlobalVarName4;
+testGlobalVarName3 = "another global value";
+testGlobalVarName4 = "yet another global value";
+g5 = "five";


### PR DESCRIPTION
- [x] Confirm baseline health before edits: `pnpm run build:ts` and `pnpm run lint:quiet` pass
- [x] Confirm architectural violation in `src/lint/src/rules/gml/rules/no-globalvar-rule.ts` (rule currently auto-fixes `globalvar` usage)
- [x] Update `no-globalvar` rule to be diagnostic-only (removed fix generation and full-text rewrite path)
- [x] Update lint rule contract test expectations for `no-globalvar` fixability metadata
- [x] Update standalone `no-globalvar` tests to assert diagnostics without source rewriting
- [x] Remove obsolete `src/lint/test/fixtures/no-globalvar/` fixture case registration
- [x] Address review feedback by clarifying duplicate `no-globalvar` test naming
- [x] Refine meta creation to support explicitly omitting default `fixable` metadata via `includeFixableDefault: false`
- [x] Re-run targeted lint tests for rule contracts/standalone
- [x] Re-run `pnpm run build:ts` and `pnpm run lint:quiet`