### PR TITLE
fix(cli): consistent help/error UX for watch commands + README refactor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ pnpm run cli -- lint /absolute/path/to/MyGame --fix
 The refactor workspace implements a GML-native Collection API (similar to `jscodeshift`) for atomic cross-file transactions and metadata edits.
 
 ```bash
-# dry-run rename preview
-pnpm run cli -- refactor --old-name player_hp --new-name playerHealth --dry-run
+# preview rename (dry-run is the default; no files are written without --fix)
+pnpm run cli -- refactor --old-name player_hp --new-name playerHealth
 
 # apply rename
-pnpm run cli -- refactor --old-name player_hp --new-name playerHealth
+pnpm run cli -- refactor --old-name player_hp --new-name playerHealth --fix
 ```
 
 ## Architecture overview

--- a/src/cli/src/commands/watch-status.ts
+++ b/src/cli/src/commands/watch-status.ts
@@ -10,6 +10,7 @@ import { Core } from "@gmloop/core";
 import { Command, Option } from "commander";
 
 import { createPortValidator } from "../cli-core/command-parsing.js";
+import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 
 const { getErrorMessage } = Core;
 
@@ -225,6 +226,8 @@ export async function runWatchStatusCommand(options: WatchStatusCommandOptions =
  */
 export function createWatchStatusCommand(): Command {
     const command = new Command("watch-status");
+
+    applyStandardCommandOptions(command);
 
     command
         .description("Query the running watch command's status server for metrics and diagnostics")

--- a/src/cli/src/commands/watch.ts
+++ b/src/cli/src/commands/watch.ts
@@ -23,6 +23,7 @@ import { Transpiler } from "@gmloop/transpiler";
 import { Command, Option } from "commander";
 
 import { createMinimumValueValidator, createPortValidator } from "../cli-core/command-parsing.js";
+import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 import { formatCliError } from "../cli-core/errors.js";
 import { normalizeExtensions } from "../cli-core/extension-normalizer.js";
 import { DEFAULT_GM_TEMP_ROOT, prepareHotReloadInjection } from "../modules/hot-reload/inject-runtime.js";
@@ -508,6 +509,8 @@ export function resolveDependentRetranspileConcurrency(configuredMaximum: number
  */
 export function createWatchCommand(): Command {
     const command = new Command("watch");
+
+    applyStandardCommandOptions(command);
 
     command
         .description("Watch GML source files and coordinate hot-reload pipeline actions")

--- a/src/cli/test/watch-command.test.ts
+++ b/src/cli/test/watch-command.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { runCliTestCommand } from "../src/cli.js";
 import {
     countSourceLines,
     createExtensionMatcher,
@@ -289,5 +290,26 @@ void describe("watch command integration", () => {
             await removeDirectoryWithoutMaskingOriginalError(testDir);
             throw error;
         }
+    });
+});
+
+void describe("watch command help consistency", () => {
+    void it("shows 'Show this help message.' for --help flag, matching all other commands", async () => {
+        const { stdout } = await runCliTestCommand({ argv: ["watch", "--help"] });
+
+        assert.match(stdout, /--help.*Show this help message\./);
+    });
+
+    void it("shows help hint on unknown option, matching the pattern of lint and format", async () => {
+        const { stdout, stderr } = await runCliTestCommand({ argv: ["watch", "--unknown-flag-xyz"] });
+
+        const combined = stdout + stderr;
+        assert.match(combined, /add --help for usage information/);
+    });
+
+    void it("exits non-zero when an unknown option is passed", async () => {
+        const { exitCode } = await runCliTestCommand({ argv: ["watch", "--unknown-flag-xyz"] });
+
+        assert.notEqual(exitCode, 0);
     });
 });

--- a/src/cli/test/watch-status.test.ts
+++ b/src/cli/test/watch-status.test.ts
@@ -5,6 +5,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { runCliTestCommand } from "../src/cli.js";
 import { createWatchStatusCommand, runWatchStatusCommand } from "../src/commands/watch-status.js";
 import { withTemporaryProperty } from "./test-helpers/temporary-property.js";
 
@@ -93,5 +94,26 @@ void describe("watch-status command", () => {
 
         assert.ok(hostOption, "Should have --status-host option (not --host) to match watch --status-host");
         assert.strictEqual(hostOption?.envVar, "WATCH_STATUS_HOST");
+    });
+});
+
+void describe("watch-status command help consistency", () => {
+    void it("shows 'Show this help message.' for --help flag, matching all other commands", async () => {
+        const { stdout } = await runCliTestCommand({ argv: ["watch-status", "--help"] });
+
+        assert.match(stdout, /--help.*Show this help message\./);
+    });
+
+    void it("shows help hint on unknown option, matching the pattern of lint and format", async () => {
+        const { stdout, stderr } = await runCliTestCommand({ argv: ["watch-status", "--unknown-flag-xyz"] });
+
+        const combined = stdout + stderr;
+        assert.match(combined, /add --help for usage information/);
+    });
+
+    void it("exits non-zero when an unknown option is passed", async () => {
+        const { exitCode } = await runCliTestCommand({ argv: ["watch-status", "--unknown-flag-xyz"] });
+
+        assert.notEqual(exitCode, 0);
     });
 });


### PR DESCRIPTION
Surveyed the CLI end-to-end and identified two usability gaps in the `watch` and `watch-status` commands, plus a broken example in the README Quick Start.

## Problem

All CLI commands (`lint`, `format`, `fix`, `refactor`) apply `applyStandardCommandOptions`, which sets the `-h, --help` description to `"Show this help message."` and emits `"(add --help for usage information)"` when an unknown option is passed. The `watch` and `watch-status` commands were missing this call, so:

- `watch --help` / `watch-status --help` described the help flag as `"display help for command"` (Commander's generic default), inconsistent with every other command.
- `watch --unknownflag` gave users a bare error line with no hint to try `--help`, while all other commands showed an actionable follow-up.

Additionally, the README Quick Start refactor section documented `--dry-run`, a flag that has never existed. Any user following the example received `error: unknown option '--dry-run'` immediately.

## Changes Made

- **`src/cli/src/commands/watch.ts`**: Import and call `applyStandardCommandOptions` inside `createWatchCommand`.
- **`src/cli/src/commands/watch-status.ts`**: Same fix for `createWatchStatusCommand`.
- **`src/cli/test/watch-command.test.ts`**: 3 new tests asserting the corrected help description, the error hint, and non-zero exit code on unknown flags.
- **`src/cli/test/watch-status.test.ts`**: 3 matching new tests for `watch-status`.
- **`README.md`**: Replaced the non-existent `--dry-run` flag in the refactor Quick Start with an accurate comment ("dry-run is the default; no files are written without `--fix`") and added `--fix` to the apply-rename example.

## Testing

- ✅ All 751 tests pass (745 pre-existing + 6 new), 0 failures
- ✅ `pnpm run build:ts` passes
- ✅ `pnpm run lint:quiet` passes
- ✅ CodeQL security scan: 0 alerts