### PR TITLE
refactor: reduce deep-import coupling in core tests and semantic executor

### DIFF
--- a/src/core/test/ast/syntax-error-guards.test.ts
+++ b/src/core/test/ast/syntax-error-guards.test.ts
@@ -1,41 +1,41 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { isGmlParseError, isSyntaxErrorWithLocation } from "../../src/ast/syntax-error-guards.js";
+import { Core } from "../../index.js";
 
 void describe("isGmlParseError", () => {
     void it("returns true for objects with name GameMakerSyntaxError", () => {
         const parseErrorLike = { name: "GameMakerSyntaxError", message: "Unexpected token" };
-        assert.equal(isGmlParseError(parseErrorLike), true);
+        assert.equal(Core.isGmlParseError(parseErrorLike), true);
     });
 
     void it("returns true for an actual Error with name overridden to GameMakerSyntaxError", () => {
         const error = new Error("Syntax error");
         error.name = "GameMakerSyntaxError";
-        assert.equal(isGmlParseError(error), true);
+        assert.equal(Core.isGmlParseError(error), true);
     });
 
     void it("returns false for a standard Error", () => {
-        assert.equal(isGmlParseError(new Error("boom")), false);
+        assert.equal(Core.isGmlParseError(new Error("boom")), false);
     });
 
     void it("returns false for a SyntaxError (name is SyntaxError, not GameMakerSyntaxError)", () => {
-        assert.equal(isGmlParseError(new SyntaxError("boom")), false);
+        assert.equal(Core.isGmlParseError(new SyntaxError("boom")), false);
     });
 
     void it("returns false for null and undefined", () => {
-        assert.equal(isGmlParseError(null), false);
-        assert.equal(isGmlParseError(undefined), false);
+        assert.equal(Core.isGmlParseError(null), false);
+        assert.equal(Core.isGmlParseError(undefined), false);
     });
 
     void it("returns false for primitive values", () => {
-        assert.equal(isGmlParseError("GameMakerSyntaxError"), false);
-        assert.equal(isGmlParseError(42), false);
+        assert.equal(Core.isGmlParseError("GameMakerSyntaxError"), false);
+        assert.equal(Core.isGmlParseError(42), false);
     });
 
     void it("returns false for plain objects with a different name", () => {
-        assert.equal(isGmlParseError({ name: "TypeError", message: "x" }), false);
-        assert.equal(isGmlParseError({ message: "x" }), false);
+        assert.equal(Core.isGmlParseError({ name: "TypeError", message: "x" }), false);
+        assert.equal(Core.isGmlParseError({ message: "x" }), false);
     });
 });
 
@@ -50,26 +50,26 @@ void describe("isSyntaxErrorWithLocation", () => {
             offendingText: "x"
         };
 
-        assert.equal(isSyntaxErrorWithLocation(syntaxErrorLike), true);
+        assert.equal(Core.isSyntaxErrorWithLocation(syntaxErrorLike), true);
     });
 
     void it("accepts numeric strings for line/column (coercion)", () => {
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", line: "3" }), true);
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", column: "5" }), true);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", line: "3" }), true);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", column: "5" }), true);
     });
 
     void it("rejects non-numeric strings for line/column", () => {
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", line: "abc" }), false);
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", column: "xyz" }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", line: "abc" }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", column: "xyz" }), false);
     });
 
     void it("rejects errors with non-string optional metadata", () => {
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", line: 4, rule: 5 }), false);
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", line: 4, wrongSymbol: 123 }), false);
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom", line: 4, offendingText: true }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", line: 4, rule: 5 }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", line: 4, wrongSymbol: 123 }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom", line: 4, offendingText: true }), false);
     });
 
     void it("rejects errors without location metadata", () => {
-        assert.equal(isSyntaxErrorWithLocation({ message: "boom" }), false);
+        assert.equal(Core.isSyntaxErrorWithLocation({ message: "boom" }), false);
     });
 });

--- a/src/core/test/comments/banner-comment-normalization.test.ts
+++ b/src/core/test/comments/banner-comment-normalization.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { Core } from "../../src/index.js";
+import { Core } from "../../index.js";
 
 void describe("normalizeBannerCommentText", () => {
     void it("remains stable across repeated calls for single-decoration banners", () => {

--- a/src/core/test/comments/comment-utils.test.ts
+++ b/src/core/test/comments/comment-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { Core } from "../../src/index.js";
+import { Core } from "../../index.js";
 
 void describe("suppressTrailingLineComment", () => {
     void it("removes matching line comments from the owner comment list", () => {

--- a/src/core/test/comments/description-utils.test.ts
+++ b/src/core/test/comments/description-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { Core, type MutableDocCommentLines } from "../../src/index.js";
+import { Core, type MutableDocCommentLines } from "../../index.js";
 
 void test("collectDescriptionContinuationText normalizes multiline description payloads with consumed-line metadata", () => {
     const docLines = [

--- a/src/core/test/comments/doc-comment/array-flags.test.ts
+++ b/src/core/test/comments/doc-comment/array-flags.test.ts
@@ -1,48 +1,48 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { copyDocCommentArrayFlags } from "../../../src/comments/doc-comment/array-flags.js";
+import { Core } from "../../../index.js";
 
-void test("copyDocCommentArrayFlags copies all three flags when present", () => {
+void test("Core.copyDocCommentArrayFlags copies all three flags when present", () => {
     const source = ["line1", "line2"] as any;
     source._preserveDescriptionBreaks = true;
     source._suppressLeadingBlank = true;
     source._blockCommentDocs = true;
 
     const target = ["line3", "line4"] as any;
-    copyDocCommentArrayFlags(source, target);
+    Core.copyDocCommentArrayFlags(source, target);
 
     assert.strictEqual(target._preserveDescriptionBreaks, true);
     assert.strictEqual(target._suppressLeadingBlank, true);
     assert.strictEqual(target._blockCommentDocs, true);
 });
 
-void test("copyDocCommentArrayFlags only copies flags that are true", () => {
+void test("Core.copyDocCommentArrayFlags only copies flags that are true", () => {
     const source = ["line1"] as any;
     source._preserveDescriptionBreaks = true;
     // _suppressLeadingBlank is not set
     source._blockCommentDocs = false;
 
     const target = ["line2"] as any;
-    copyDocCommentArrayFlags(source, target);
+    Core.copyDocCommentArrayFlags(source, target);
 
     assert.strictEqual(target._preserveDescriptionBreaks, true);
     assert.strictEqual(target._suppressLeadingBlank, undefined);
     assert.strictEqual(target._blockCommentDocs, undefined);
 });
 
-void test("copyDocCommentArrayFlags returns target for chaining", () => {
+void test("Core.copyDocCommentArrayFlags returns target for chaining", () => {
     const source = ["line1"] as any;
     const target = ["line2"] as any;
 
-    const result = copyDocCommentArrayFlags(source, target);
+    const result = Core.copyDocCommentArrayFlags(source, target);
 
     assert.strictEqual(result, target);
 });
 
-void test("copyDocCommentArrayFlags handles non-array inputs gracefully", () => {
+void test("Core.copyDocCommentArrayFlags handles non-array inputs gracefully", () => {
     const target = ["line"] as any;
 
-    assert.doesNotThrow(() => copyDocCommentArrayFlags(null as any, target));
-    assert.doesNotThrow(() => copyDocCommentArrayFlags(["line"] as any, null as any));
+    assert.doesNotThrow(() => Core.copyDocCommentArrayFlags(null as any, target));
+    assert.doesNotThrow(() => Core.copyDocCommentArrayFlags(["line"] as any, null as any));
 });

--- a/src/core/test/comments/function-doc-comment-attachments.test.ts
+++ b/src/core/test/comments/function-doc-comment-attachments.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { normalizeFunctionDocCommentAttachments } from "../../src/comments/doc-comment/function-doc-comment-attachments.js";
+import { Core } from "../../index.js";
 
 type CommentLike = {
     type: string;
@@ -42,21 +42,21 @@ function createDocCommentFixture(functionStartIndex: number): {
     return { comment, functionNode, rootNode };
 }
 
-void test("normalizeFunctionDocCommentAttachments attaches reachable function tag comments", () => {
+void test("Core.normalizeFunctionDocCommentAttachments attaches reachable function tag comments", () => {
     const { comment, functionNode, rootNode } = createDocCommentFixture(20);
     const sourceText = ["/// @function demo()", "function demo() {}", ""].join("\n");
 
-    normalizeFunctionDocCommentAttachments(rootNode, [comment], sourceText);
+    Core.normalizeFunctionDocCommentAttachments(rootNode, [comment], sourceText);
 
     assert.deepStrictEqual(functionNode.docComments, [comment]);
     assert.equal(comment._gmlAttachedDocComment, true);
 });
 
-void test("normalizeFunctionDocCommentAttachments does not cross non-comment code when finding a target", () => {
+void test("Core.normalizeFunctionDocCommentAttachments does not cross non-comment code when finding a target", () => {
     const { comment, functionNode, rootNode } = createDocCommentFixture(31);
     const sourceText = ["/// @function demo()", "var blocker = 1;", "function demo() {}", ""].join("\n");
 
-    normalizeFunctionDocCommentAttachments(rootNode, [comment], sourceText);
+    Core.normalizeFunctionDocCommentAttachments(rootNode, [comment], sourceText);
 
     assert.equal(functionNode.docComments, undefined);
     assert.equal(comment._gmlAttachedDocComment, undefined);

--- a/src/core/test/comments/line-comment-options-normalization.test.ts
+++ b/src/core/test/comments/line-comment-options-normalization.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
-import { Core } from "../../src/index.js";
+import { Core } from "../../index.js";
 
 const {
     DEFAULT_COMMENTED_OUT_CODE_PATTERNS,

--- a/src/core/test/comments/string-comment-scan.test.ts
+++ b/src/core/test/comments/string-comment-scan.test.ts
@@ -1,49 +1,43 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import {
-    advanceStringCommentScan,
-    advanceThroughComment,
-    advanceThroughStringLiteral,
-    createStringCommentScanState,
-    tryStartStringOrComment
-} from "../../src/comments/string-comment-scan.js";
+import { Core } from "../../index.js";
 
 void describe("string-comment scan helpers", () => {
     void it("tracks quoted strings and escapes", () => {
         const text = String.raw`"a\"b"`;
-        const state = createStringCommentScanState();
+        const state = Core.createStringCommentScanState();
 
-        let index = tryStartStringOrComment(text, text.length, 0, state);
+        let index = Core.tryStartStringOrComment(text, text.length, 0, state);
         assert.strictEqual(index, 1);
         assert.strictEqual(state.stringQuote, '"');
 
-        index = advanceThroughStringLiteral(text, index, state);
+        index = Core.advanceThroughStringLiteral(text, index, state);
         assert.strictEqual(index, 2);
 
-        index = advanceThroughStringLiteral(text, index, state);
+        index = Core.advanceThroughStringLiteral(text, index, state);
         assert.strictEqual(index, 3);
 
-        index = advanceThroughStringLiteral(text, index, state);
+        index = Core.advanceThroughStringLiteral(text, index, state);
         assert.strictEqual(index, 4);
 
-        index = advanceThroughStringLiteral(text, index, state);
+        index = Core.advanceThroughStringLiteral(text, index, state);
         assert.strictEqual(index, 5);
 
-        index = advanceThroughStringLiteral(text, index, state);
+        index = Core.advanceThroughStringLiteral(text, index, state);
         assert.strictEqual(index, 6);
         assert.strictEqual(state.stringQuote, null);
     });
 
     void it("advances through line comments until newline", () => {
         const text = "// hi\nx";
-        const state = createStringCommentScanState();
+        const state = Core.createStringCommentScanState();
 
-        let index = tryStartStringOrComment(text, text.length, 0, state);
+        let index = Core.tryStartStringOrComment(text, text.length, 0, state);
         assert.strictEqual(state.inLineComment, true);
 
         while (state.inLineComment && index < text.length) {
-            index = advanceThroughComment(text, text.length, index, state);
+            index = Core.advanceThroughComment(text, text.length, index, state);
         }
 
         assert.strictEqual(state.inLineComment, false);
@@ -52,13 +46,13 @@ void describe("string-comment scan helpers", () => {
 
     void it("advances through block comments until closing token", () => {
         const text = "/* note */x";
-        const state = createStringCommentScanState();
+        const state = Core.createStringCommentScanState();
 
-        let index = tryStartStringOrComment(text, text.length, 0, state);
+        let index = Core.tryStartStringOrComment(text, text.length, 0, state);
         assert.strictEqual(state.inBlockComment, true);
 
         while (state.inBlockComment && index < text.length) {
-            index = advanceThroughComment(text, text.length, index, state);
+            index = Core.advanceThroughComment(text, text.length, index, state);
         }
 
         assert.strictEqual(state.inBlockComment, false);
@@ -67,14 +61,14 @@ void describe("string-comment scan helpers", () => {
 
     void it("advances through @-prefixed strings when enabled", () => {
         const text = '@"hi" {';
-        const state = createStringCommentScanState();
+        const state = Core.createStringCommentScanState();
 
-        let index = advanceStringCommentScan(text, text.length, 0, state, true);
+        let index = Core.advanceStringCommentScan(text, text.length, 0, state, true);
         assert.strictEqual(index, 2);
         assert.strictEqual(state.stringQuote, '"');
 
         while (state.stringQuote && index < text.length) {
-            index = advanceStringCommentScan(text, text.length, index, state, true);
+            index = Core.advanceStringCommentScan(text, text.length, index, state, true);
         }
 
         assert.strictEqual(state.stringQuote, null);
@@ -83,9 +77,9 @@ void describe("string-comment scan helpers", () => {
 
     void it("skips @-prefixed strings when disabled", () => {
         const text = '@"hi"';
-        const state = createStringCommentScanState();
+        const state = Core.createStringCommentScanState();
 
-        const index = advanceStringCommentScan(text, text.length, 0, state, false);
+        const index = Core.advanceStringCommentScan(text, text.length, 0, state, false);
         assert.strictEqual(index, 0);
         assert.strictEqual(state.stringQuote, null);
     });

--- a/src/core/test/text/line-breaks.test.ts
+++ b/src/core/test/text/line-breaks.test.ts
@@ -1,43 +1,51 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { dominantLineEnding, getLineBreakCount, getLineBreakSpans, splitLines } from "../../src/text/line-breaks.js";
+import { Core } from "../../index.js";
 
 void describe("line-breaks", () => {
     void describe("splitLines", () => {
         void it("splits common newline sequences", () => {
             const text = "alpha\r\nbeta\ngamma\rdelta\u2028epsilon\u2029theta\u0085iota";
 
-            assert.deepStrictEqual(splitLines(text), ["alpha", "beta", "gamma", "delta", "epsilon", "theta", "iota"]);
+            assert.deepStrictEqual(Core.splitLines(text), [
+                "alpha",
+                "beta",
+                "gamma",
+                "delta",
+                "epsilon",
+                "theta",
+                "iota"
+            ]);
         });
 
         void it("returns a single entry for text without newlines", () => {
             const text = "single line";
-            assert.deepStrictEqual(splitLines(text), [text]);
+            assert.deepStrictEqual(Core.splitLines(text), [text]);
         });
 
         void it("normalizes non-string input to an empty array", () => {
             // explicit undefined mirrors optional metadata usage
-            assert.deepStrictEqual(splitLines(undefined), []);
-            assert.deepStrictEqual(splitLines(null), []);
+            assert.deepStrictEqual(Core.splitLines(undefined), []);
+            assert.deepStrictEqual(Core.splitLines(null), []);
         });
 
         void it("mirrors String#split for empty strings", () => {
-            assert.deepStrictEqual(splitLines(""), [""]);
+            assert.deepStrictEqual(Core.splitLines(""), [""]);
         });
     });
 
     void describe("getLineBreakCount", () => {
         void it("counts the number of recognized break characters", () => {
             const text = "line1\r\nline2\nline3\rline4\u2028line5\u2029line6";
-            assert.strictEqual(getLineBreakCount(text), 5);
+            assert.strictEqual(Core.getLineBreakCount(text), 5);
         });
     });
 
     void describe("getLineBreakSpans", () => {
         void it("locates each line break sequence", () => {
             const text = "alpha\r\nbeta\n\r\u2028gamma\u2029delta\u0085";
-            assert.deepStrictEqual(getLineBreakSpans(text), [
+            assert.deepStrictEqual(Core.getLineBreakSpans(text), [
                 { index: 5, length: 2 },
                 { index: 11, length: 1 },
                 { index: 12, length: 1 },
@@ -50,30 +58,30 @@ void describe("line-breaks", () => {
 
     void describe("dominantLineEnding", () => {
         void it("returns LF for a file that uses only LF line endings", () => {
-            assert.strictEqual(dominantLineEnding("line1\nline2\nline3\n"), "\n");
+            assert.strictEqual(Core.dominantLineEnding("line1\nline2\nline3\n"), "\n");
         });
 
         void it("returns CRLF for a file that uses only CRLF line endings", () => {
-            assert.strictEqual(dominantLineEnding("line1\r\nline2\r\nline3\r\n"), "\r\n");
+            assert.strictEqual(Core.dominantLineEnding("line1\r\nline2\r\nline3\r\n"), "\r\n");
         });
 
         void it("returns the dominant ending when CRLF is strictly more common than LF", () => {
             // 3 CRLF vs 1 bare LF → dominant is CRLF
-            assert.strictEqual(dominantLineEnding("a\r\nb\r\nc\r\nd\ne"), "\r\n");
+            assert.strictEqual(Core.dominantLineEnding("a\r\nb\r\nc\r\nd\ne"), "\r\n");
         });
 
         void it("returns LF when LF is strictly more common than CRLF", () => {
             // 1 CRLF vs 3 bare LF → dominant is LF
-            assert.strictEqual(dominantLineEnding("a\r\nb\nc\nd\ne"), "\n");
+            assert.strictEqual(Core.dominantLineEnding("a\r\nb\nc\nd\ne"), "\n");
         });
 
         void it("returns LF as the tie-break default when counts are equal", () => {
             // 1 CRLF vs 1 bare LF → tie, defaults to LF
-            assert.strictEqual(dominantLineEnding("a\r\nb\nc"), "\n");
+            assert.strictEqual(Core.dominantLineEnding("a\r\nb\nc"), "\n");
         });
 
         void it("ignores bare carriage returns when counting LF-vs-CRLF dominance", () => {
-            assert.strictEqual(dominantLineEnding("a\rb\r\nc\rd\n"), "\n");
+            assert.strictEqual(Core.dominantLineEnding("a\rb\r\nc\rd\n"), "\n");
         });
 
         void it("matches a reference implementation across mixed newline sequences", () => {
@@ -82,11 +90,11 @@ void describe("line-breaks", () => {
             );
             const expected = computeDominantLineEndingWithReferenceRegex(text);
 
-            assert.strictEqual(dominantLineEnding(text), expected);
+            assert.strictEqual(Core.dominantLineEnding(text), expected);
         });
 
         void it("returns LF for text with no line breaks", () => {
-            assert.strictEqual(dominantLineEnding("no newlines here"), "\n");
+            assert.strictEqual(Core.dominantLineEnding("no newlines here"), "\n");
         });
     });
 });

--- a/src/semantic/src/identifier-case/asset-renames/executor.ts
+++ b/src/semantic/src/identifier-case/asset-renames/executor.ts
@@ -9,7 +9,7 @@ import {
     stringifyProjectMetadataDocument,
     updateProjectMetadataReferenceByPath,
     writeProjectMetadataDocumentToFile
-} from "../../project-metadata/yy-adapter.js";
+} from "../../project-metadata/index.js";
 import { DEFAULT_WRITE_ACCESS_MODE, defaultIdentifierCaseFsFacade as defaultFsFacade } from "../fs-facade.js";
 
 type IdentifierCaseProjectIndex = {


### PR DESCRIPTION
Audit of all workspaces for deep relative imports (`../..` or deeper) and `/internal/` path segments. No cross-workspace violations were found — all inter-workspace imports correctly use `@gmloop/<name>` package names. Two intra-workspace coupling risks were identified and fixed.

## Changes Made

### Production code — `src/semantic/src/identifier-case/asset-renames/executor.ts`
The executor imported 6 symbols directly from the leaf implementation file `../../project-metadata/yy-adapter.js`, bypassing the module's own `index.ts`. This couples the consumer to a specific filename rather than the module's stable public surface. Changed to `../../project-metadata/index.js`, which already re-exports everything from `yy-adapter.ts`. Behaviour is identical.

### Core workspace tests — 9 test files
Five test files bypassed the workspace public API by importing directly from internal `../../src/<subdir>/<file>.js` paths (one at depth-3: `../../../src/…`). All five functions were already in the `Core` namespace; each test now imports `Core` from the workspace root (`../../index.js` / `../../../index.js`) and calls helpers as `Core.<helper>()`, consistent with the established convention in sibling test files:

- `src/core/test/text/line-breaks.test.ts`
- `src/core/test/ast/syntax-error-guards.test.ts`
- `src/core/test/comments/string-comment-scan.test.ts`
- `src/core/test/comments/function-doc-comment-attachments.test.ts`
- `src/core/test/comments/doc-comment/array-flags.test.ts`

Four additional tests imported `Core` via `../../src/index.js` (the src-level internal barrel) rather than `../../index.js` (the canonical package entry point); these are now standardised.

The `lint/src/rules/gml/transforms/doc-comment-services.ts` file, which uses a depth-3 import, was deliberately left unchanged — it is itself the adapter/facade that shields downstream rule transforms from that depth, as documented in its own header comment.

## Testing

- ✅ `pnpm run build:ts` passes (0 TypeScript errors)
- ✅ `pnpm run lint:quiet` passes (0 lint warnings)
- ✅ Core workspace: 548/548 tests pass
- ✅ Semantic workspace: 33/33 tests pass
- ✅ Code review: no issues
- ✅ CodeQL security scan: 0 alerts