### PR TITLE
refactor: Move CLI-only timing utilities from core to CLI shared

### DIFF
--- a/src/cli/src/commands/generate-feather-metadata.ts
+++ b/src/cli/src/commands/generate-feather-metadata.ts
@@ -14,16 +14,15 @@ import {
 import { getManualRootMetadataPath, readManualText, resolveManualSourceCommitHash } from "../modules/manual/source.js";
 import { type ManualWorkflowOptions, prepareManualWorkflow } from "../modules/manual/workflow.js";
 import { writeJsonArtifact } from "../shared/fs-artifacts.js";
+import { createVerboseDurationLogger, timeSync } from "../shared/time-utils.js";
 import { resolveFromRepoRoot } from "../shared/workspace-paths.js";
 
 const {
     compactArray,
-    createVerboseDurationLogger,
     escapeRegExp,
     getNonEmptyTrimmedString,
     isNonEmptyArray,
     isNonEmptyString,
-    timeSync,
     toNormalizedLowerCaseSet
 } = Core;
 

--- a/src/cli/src/commands/generate-gml-identifiers.ts
+++ b/src/cli/src/commands/generate-gml-identifiers.ts
@@ -22,14 +22,13 @@ import { getManualRootMetadataPath, readManualText, resolveManualSourceCommitHas
 import { type ManualWorkflowOptions, prepareManualWorkflow } from "../modules/manual/workflow.js";
 import { getDefaultVmEvalTimeoutMs, resolveVmEvalTimeout } from "../runtime-options/vm-eval-timeout.js";
 import { writeJsonArtifact } from "../shared/fs-artifacts.js";
+import { createVerboseDurationLogger, timeSync } from "../shared/time-utils.js";
 import { resolveFromRepoRoot } from "../shared/workspace-paths.js";
 
 const {
-    createVerboseDurationLogger,
     describeValueWithArticle,
     getErrorMessageOrFallback,
     normalizeIdentifierMetadataEntries,
-    timeSync,
     toMutableArray,
     toNormalizedLowerCaseSet,
     toPosixPath,

--- a/src/cli/src/shared/index.ts
+++ b/src/cli/src/shared/index.ts
@@ -7,4 +7,5 @@ export { safeStatOrNull, writeFileArtifact, writeJsonArtifact } from "./fs-artif
 export * from "./module.js";
 export * from "./package-resolution.js";
 export * from "./repo-root.js";
+export * from "./time-utils.js";
 export * from "./workspace-paths.js";

--- a/src/cli/src/shared/time-utils.ts
+++ b/src/cli/src/shared/time-utils.ts
@@ -1,3 +1,14 @@
+/**
+ * CLI-command timing and verbose-logging utilities.
+ *
+ * Previously lived in `@gmloop/core` (`src/core/src/utils/time.ts`) even though the
+ * only consumers were two CLI generator commands (`generate-gml-identifiers` and
+ * `generate-feather-metadata`).  Core is intentionally kept to AST types, traversal
+ * helpers, and workspace-agnostic primitives — timing utilities that surface verbose
+ * progress messages to a CLI user do not belong there.  Moving this module here keeps
+ * core lean and co-locates the timing helpers with the CLI commands that rely on them.
+ */
+
 const MILLISECOND_PER_SECOND = 1000;
 const SUB_SECOND_THRESHOLD_TOLERANCE_MS = 1e-6;
 
@@ -20,6 +31,15 @@ export interface TimeSyncOptions {
     logger?: VerboseLogger;
 }
 
+/**
+ * Format the elapsed time since `startTime` as a human-readable string.
+ *
+ * Returns milliseconds for sub-second durations (e.g. `"200ms"`) and
+ * seconds with one decimal place for longer durations (e.g. `"1.5s"`).
+ *
+ * @param startTime - Epoch millisecond timestamp returned by `Date.now()`.
+ * @returns Human-readable elapsed-time string.
+ */
 export function formatDuration(startTime: number): string {
     const deltaMs = Date.now() - startTime;
     const isEffectivelySubSecond =
@@ -32,6 +52,16 @@ export function formatDuration(startTime: number): string {
     return `${(deltaMs / MILLISECOND_PER_SECOND).toFixed(1)}s`;
 }
 
+/**
+ * Create a zero-argument callback that, when invoked, logs the elapsed
+ * time since the call to `createVerboseDurationLogger`.
+ *
+ * Logging is gated behind `verbose.parsing` so callers can pass the flag
+ * through unchanged and the helper decides silently whether to emit output.
+ *
+ * @param options - Optional logger, format message, and verbose flag.
+ * @returns A callback that emits the duration log line when called.
+ */
 export function createVerboseDurationLogger({
     verbose,
     formatMessage,
@@ -56,6 +86,15 @@ export function createVerboseDurationLogger({
     };
 }
 
+/**
+ * Run `callback` synchronously, optionally printing a start/end banner when
+ * `verbose.parsing` is enabled, and return the callback's result.
+ *
+ * @param label - Short description of the work being timed.
+ * @param callback - Synchronous work to time.
+ * @param options - Optional verbose flag and logger.
+ * @returns Whatever `callback` returns.
+ */
 export function timeSync<TResult>(
     label: string,
     callback: () => TResult,

--- a/src/cli/test/time-utils.test.ts
+++ b/src/cli/test/time-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { formatDuration, timeSync } from "../src/utils/time.js";
+import { formatDuration, timeSync } from "../src/shared/time-utils.js";
 
 function createCollectingLogger() {
     const calls: unknown[][] = [];

--- a/src/core/src/utils/index.ts
+++ b/src/core/src/utils/index.ts
@@ -16,4 +16,3 @@ export * from "./numeric-options.js";
 export * from "./object.js";
 export * from "./regexp.js";
 export * from "./string.js";
-export * from "./time.js";


### PR DESCRIPTION
Performs a focused organization pass, moving `src/core/src/utils/time.ts` → `src/cli/src/shared/time-utils.ts`.

## What Moved

`timeSync`, `formatDuration`, and `createVerboseDurationLogger` (plus their supporting types `VerboseDurationLoggerOptions` and `TimeSyncOptions`) were living in `@gmloop/core` despite having no consumers outside of two CLI generator commands.

## Why the Old Placement Was Suboptimal

Per `docs/target-state.md §2.1`, core should hold "shared doc-comment helpers, AST metadata utilities, and normalization primitives." These are CLI command orchestration timing utilities — with a `verbose.parsing` flag tied directly to CLI generator commands — and do not belong in a workspace-agnostic shared package. Keeping them in core added noise to the `Core` namespace that every consumer of the package sees.

## Changes Made

- **Deleted** `src/core/src/utils/time.ts` and removed its barrel export from `src/core/src/utils/index.ts`
- **Created** `src/cli/src/shared/time-utils.ts` (new canonical home, with improved TSDoc on each export)
- **Updated** `src/cli/src/shared/index.ts` to re-export via `export * from "./time-utils.js"`
- **Updated** `generate-feather-metadata.ts` and `generate-gml-identifiers.ts` to import directly from `../shared/time-utils.js` instead of destructuring from `Core`
- **Moved** `src/core/test/time-utils.test.ts` → `src/cli/test/time-utils.test.ts` with updated import path

## Testing

- ✅ `pnpm run build:ts` passes with no errors
- ✅ `pnpm run lint:quiet` passes with no errors
- ✅ All 5 moved tests pass
- ✅ All 617 core tests continue to pass