### PR TITLE
refactor: Extract shared config-validation helper to improve DRY-ness and maintainability

### DIFF
--- a/src/refactor/src/codemod-registry.ts
+++ b/src/refactor/src/codemod-registry.ts
@@ -2,7 +2,10 @@ import { Core } from "@gmloop/core";
 
 import { executeNamingConventionCodemod } from "./codemods/naming-convention/index.js";
 import { normalizeNamingConventionPolicy } from "./naming-convention-policy.js";
-import { assertRefactorConfigPlainObject } from "./refactor-config-assertions.js";
+import {
+    assertRefactorConfigPlainObject,
+    assertRefactorConfigPlainObjectWithAllowedKeys
+} from "./refactor-config-assertions.js";
 import type {
     CodemodEngine,
     ConfiguredCodemodRunRequest,
@@ -41,6 +44,8 @@ function isNullableString(value: unknown): value is string | null {
     return typeof value === "string" || value === null;
 }
 
+const LOOP_LENGTH_HOISTING_ALLOWED_KEYS = new Set(["functionSuffixes"]);
+
 function normalizeLoopLengthHoistingConfig(
     value: unknown,
     context: string
@@ -49,14 +54,7 @@ function normalizeLoopLengthHoistingConfig(
         return false;
     }
 
-    const object = assertRefactorConfigPlainObject(value, context);
-    const allowedKeys = new Set(["functionSuffixes"]);
-
-    for (const key of Object.keys(object)) {
-        if (!allowedKeys.has(key)) {
-            throw new TypeError(`${context} contains unknown property ${JSON.stringify(key)}`);
-        }
-    }
+    const object = assertRefactorConfigPlainObjectWithAllowedKeys(value, LOOP_LENGTH_HOISTING_ALLOWED_KEYS, context);
 
     if (object.functionSuffixes === undefined) {
         return {};

--- a/src/refactor/src/naming-convention-policy.ts
+++ b/src/refactor/src/naming-convention-policy.ts
@@ -1,6 +1,9 @@
 import { Core } from "@gmloop/core";
 
-import { assertRefactorConfigPlainObject } from "./refactor-config-assertions.js";
+import {
+    assertRefactorConfigPlainObject,
+    assertRefactorConfigPlainObjectWithAllowedKeys
+} from "./refactor-config-assertions.js";
 import type {
     NamingCaseStyle,
     NamingCategory,
@@ -63,6 +66,18 @@ type RuntimeResolvedNamingRule = ResolvedNamingRule & {
 const NAMING_CATEGORY_SET = new Set(Object.keys(NAMING_CATEGORY_PARENTS));
 const NAMING_CASE_STYLE_SET: ReadonlySet<string> = new Set(NAMING_CASE_STYLES);
 
+const NAMING_RULE_CONFIG_ALLOWED_KEYS = new Set([
+    "caseStyle",
+    "prefix",
+    "suffix",
+    "minChars",
+    "maxChars",
+    "bannedPrefixes",
+    "bannedSuffixes"
+]);
+
+const NAMING_CONVENTION_POLICY_ALLOWED_KEYS = new Set(["rules", "exclusivePrefixes", "exclusiveSuffixes"]);
+
 function isNamingCategory(value: unknown): value is NamingCategory {
     return typeof value === "string" && NAMING_CATEGORY_SET.has(value);
 }
@@ -86,22 +101,7 @@ function normalizeStringArray(value: unknown, context: string): Array<string> {
 }
 
 function normalizeNamingRuleConfig(config: unknown, context: string): NamingRuleConfig {
-    const object = assertRefactorConfigPlainObject(config, context);
-    const allowedKeys = new Set([
-        "caseStyle",
-        "prefix",
-        "suffix",
-        "minChars",
-        "maxChars",
-        "bannedPrefixes",
-        "bannedSuffixes"
-    ]);
-
-    for (const key of Object.keys(object)) {
-        if (!allowedKeys.has(key)) {
-            throw new TypeError(`${context} contains unknown property ${JSON.stringify(key)}`);
-        }
-    }
+    const object = assertRefactorConfigPlainObjectWithAllowedKeys(config, NAMING_RULE_CONFIG_ALLOWED_KEYS, context);
 
     const normalized: NamingRuleConfig = {};
 
@@ -190,14 +190,11 @@ export function normalizeNamingConventionPolicy(
         };
     }
 
-    const object = assertRefactorConfigPlainObject(policy, context);
-    const allowedKeys = new Set(["rules", "exclusivePrefixes", "exclusiveSuffixes"]);
-
-    for (const key of Object.keys(object)) {
-        if (!allowedKeys.has(key)) {
-            throw new TypeError(`${context} contains unknown property ${JSON.stringify(key)}`);
-        }
-    }
+    const object = assertRefactorConfigPlainObjectWithAllowedKeys(
+        policy,
+        NAMING_CONVENTION_POLICY_ALLOWED_KEYS,
+        context
+    );
 
     const rulesObject = assertRefactorConfigPlainObject(object.rules ?? {}, `${context}.rules`);
     const rules: NamingConventionPolicy["rules"] = {};

--- a/src/refactor/src/project-config.ts
+++ b/src/refactor/src/project-config.ts
@@ -1,5 +1,8 @@
 import { listRegisteredCodemods, normalizeRegisteredCodemodConfig } from "./codemod-registry.js";
-import { assertRefactorConfigPlainObject } from "./refactor-config-assertions.js";
+import {
+    assertRefactorConfigPlainObject,
+    assertRefactorConfigPlainObjectWithAllowedKeys
+} from "./refactor-config-assertions.js";
 import type { RefactorCodemodId, RefactorProjectConfig } from "./types.js";
 
 const REFACTOR_CONFIG_KEYS = new Set(["codemods"]);
@@ -21,13 +24,11 @@ export function normalizeRefactorProjectConfig(config: unknown): RefactorProject
         return {};
     }
 
-    const object = assertRefactorConfigPlainObject(config, "gmloop.json refactor config");
-
-    for (const key of Object.keys(object)) {
-        if (!REFACTOR_CONFIG_KEYS.has(key)) {
-            throw new TypeError(`gmloop.json refactor config contains unknown property ${JSON.stringify(key)}`);
-        }
-    }
+    const object = assertRefactorConfigPlainObjectWithAllowedKeys(
+        config,
+        REFACTOR_CONFIG_KEYS,
+        "gmloop.json refactor config"
+    );
 
     const normalized: RefactorProjectConfig = {};
 

--- a/src/refactor/src/refactor-config-assertions.ts
+++ b/src/refactor/src/refactor-config-assertions.ts
@@ -8,3 +8,22 @@ export function assertRefactorConfigPlainObject(value: unknown, context: string)
         errorMessage: `${context} must be a plain object`
     });
 }
+
+/**
+ * Assert that a config segment is a plain object whose keys are all members of
+ * `allowedKeys`. Throws a TypeError naming the first unexpected key, keeping
+ * error messages consistent across every config-parsing call site.
+ */
+export function assertRefactorConfigPlainObjectWithAllowedKeys(
+    value: unknown,
+    allowedKeys: ReadonlySet<string>,
+    context: string
+): Record<string, unknown> {
+    const object = assertRefactorConfigPlainObject(value, context);
+    for (const key of Object.keys(object)) {
+        if (!allowedKeys.has(key)) {
+            throw new TypeError(`${context} contains unknown property ${JSON.stringify(key)}`);
+        }
+    }
+    return object;
+}


### PR DESCRIPTION
Surveyed the entire codebase and identified a high-impact DRY violation in the refactor workspace's config-parsing layer. The pattern of `assertRefactorConfigPlainObject()` immediately followed by a 4-line unknown-key validation loop was duplicated verbatim 4 times across 3 files.

## Changes Made

- **New helper**: Added `assertRefactorConfigPlainObjectWithAllowedKeys(value, allowedKeys, context)` to `src/refactor/src/refactor-config-assertions.ts`, combining the plain-object assertion and the unknown-key validation loop into a single, documented function
- **Hoisted constants**: Inline `new Set([...])` literals at each call site were promoted to named module-level constants (`LOOP_LENGTH_HOISTING_ALLOWED_KEYS`, `NAMING_RULE_CONFIG_ALLOWED_KEYS`, `NAMING_CONVENTION_POLICY_ALLOWED_KEYS`), making each config shape self-documenting and avoiding repeated Set allocation on every validation call
- **4 call sites updated** across `codemod-registry.ts`, `naming-convention-policy.ts` (×2), and `project-config.ts`

No behavior change; all error messages are identical to before.

## Testing

- ✅ `pnpm run build:ts` passes cleanly
- ✅ `pnpm run lint:quiet` passes cleanly
- ✅ All 569 functional refactor tests pass