### PR TITLE
refactor: inline `normalizeVersionValue` single-use wrapper (KISS sweep)

### DIFF
--- a/src/cli/src/cli-core/version.ts
+++ b/src/cli/src/cli-core/version.ts
@@ -16,10 +16,6 @@ const PACKAGE_VERSION_CANDIDATES = Object.freeze([
     path.resolve(REPO_ROOT, "src", "format", "package.json")
 ]);
 
-function normalizeVersionValue(value: unknown): string | null {
-    return getNonEmptyTrimmedString(value);
-}
-
 function readPackageVersion(candidate: string): string | null {
     try {
         const contents = readTextFileSync(candidate);
@@ -37,7 +33,7 @@ export function resolveCliVersion(): string {
     ];
 
     for (const candidate of envCandidates) {
-        const version = normalizeVersionValue(candidate);
+        const version = getNonEmptyTrimmedString(candidate);
         if (version) {
             return version;
         }

--- a/src/cli/test/core-version.test.ts
+++ b/src/cli/test/core-version.test.ts
@@ -83,4 +83,52 @@ void describe("resolveCliVersion", { concurrency: 1 }, () => {
             }
         }
     });
+
+    void test("resolveCliVersion skips whitespace-only PRETTIER_PLUGIN_GML_VERSION and falls back to npm_package_version", () => {
+        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
+        const originalNpmVersion = process.env.npm_package_version;
+
+        try {
+            process.env.PRETTIER_PLUGIN_GML_VERSION = "   ";
+            process.env.npm_package_version = "4.5.6";
+
+            assert.equal(resolveCliVersion(), "4.5.6");
+        } finally {
+            if (originalEnv === undefined) {
+                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
+            } else {
+                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
+            }
+
+            if (originalNpmVersion === undefined) {
+                delete process.env.npm_package_version;
+            } else {
+                process.env.npm_package_version = originalNpmVersion;
+            }
+        }
+    });
+
+    void test("resolveCliVersion skips empty PRETTIER_PLUGIN_GML_VERSION and falls back to npm_package_version", () => {
+        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
+        const originalNpmVersion = process.env.npm_package_version;
+
+        try {
+            process.env.PRETTIER_PLUGIN_GML_VERSION = "";
+            process.env.npm_package_version = "2.0.0";
+
+            assert.equal(resolveCliVersion(), "2.0.0");
+        } finally {
+            if (originalEnv === undefined) {
+                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
+            } else {
+                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
+            }
+
+            if (originalNpmVersion === undefined) {
+                delete process.env.npm_package_version;
+            } else {
+                process.env.npm_package_version = originalNpmVersion;
+            }
+        }
+    });
 });

--- a/src/cli/test/core-version.test.ts
+++ b/src/cli/test/core-version.test.ts
@@ -11,124 +11,80 @@ const cliPackageVersion = JSON.parse(
     fs.readFileSync(path.resolve(fileURLToPath(new URL("../../package.json", import.meta.url))), "utf8")
 ).version;
 
-void describe("resolveCliVersion", { concurrency: 1 }, () => {
-    void test("resolveCliVersion prefers the PRETTIER_PLUGIN_GML_VERSION override", () => {
-        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
-        const originalNpmVersion = process.env.npm_package_version;
+interface VersionEnv {
+    PRETTIER_PLUGIN_GML_VERSION?: string;
+    npm_package_version?: string;
+}
 
-        try {
-            process.env.PRETTIER_PLUGIN_GML_VERSION = "  1.2.3  ";
-            process.env.npm_package_version = "ignored";
+/**
+ * Run a test with a controlled version environment, then restore the original
+ * process.env values regardless of success or failure.
+ */
+function withVersionEnv(env: VersionEnv, fn: () => void): void {
+    const originalPluginVersion = process.env.PRETTIER_PLUGIN_GML_VERSION;
+    const originalNpmVersion = process.env.npm_package_version;
 
-            assert.equal(resolveCliVersion(), "1.2.3");
-        } finally {
-            if (originalEnv === undefined) {
+    try {
+        if ("PRETTIER_PLUGIN_GML_VERSION" in env) {
+            if (env.PRETTIER_PLUGIN_GML_VERSION === undefined) {
                 delete process.env.PRETTIER_PLUGIN_GML_VERSION;
             } else {
-                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
-            }
-
-            if (originalNpmVersion === undefined) {
-                delete process.env.npm_package_version;
-            } else {
-                process.env.npm_package_version = originalNpmVersion;
+                process.env.PRETTIER_PLUGIN_GML_VERSION = env.PRETTIER_PLUGIN_GML_VERSION;
             }
         }
+
+        if ("npm_package_version" in env) {
+            if (env.npm_package_version === undefined) {
+                delete process.env.npm_package_version;
+            } else {
+                process.env.npm_package_version = env.npm_package_version;
+            }
+        }
+
+        fn();
+    } finally {
+        if (originalPluginVersion === undefined) {
+            delete process.env.PRETTIER_PLUGIN_GML_VERSION;
+        } else {
+            process.env.PRETTIER_PLUGIN_GML_VERSION = originalPluginVersion;
+        }
+
+        if (originalNpmVersion === undefined) {
+            delete process.env.npm_package_version;
+        } else {
+            process.env.npm_package_version = originalNpmVersion;
+        }
+    }
+}
+
+void describe("resolveCliVersion", { concurrency: 1 }, () => {
+    void test("resolveCliVersion prefers the PRETTIER_PLUGIN_GML_VERSION override", () => {
+        withVersionEnv({ PRETTIER_PLUGIN_GML_VERSION: "  1.2.3  ", npm_package_version: "ignored" }, () => {
+            assert.equal(resolveCliVersion(), "1.2.3");
+        });
     });
 
     void test("resolveCliVersion falls back to the CLI package version when metadata is available", () => {
-        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
-        const originalNpmVersion = process.env.npm_package_version;
-
-        try {
-            delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            delete process.env.npm_package_version;
-
+        withVersionEnv({ PRETTIER_PLUGIN_GML_VERSION: undefined, npm_package_version: undefined }, () => {
             assert.equal(resolveCliVersion(), cliPackageVersion);
-        } finally {
-            if (originalEnv === undefined) {
-                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            } else {
-                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
-            }
-
-            if (originalNpmVersion === undefined) {
-                delete process.env.npm_package_version;
-            } else {
-                process.env.npm_package_version = originalNpmVersion;
-            }
-        }
+        });
     });
 
     void test("resolveCliVersion falls back to npm_package_version when no override is set", () => {
-        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
-        const originalNpmVersion = process.env.npm_package_version;
-
-        try {
-            delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            process.env.npm_package_version = " 9.8.7 ";
-
+        withVersionEnv({ PRETTIER_PLUGIN_GML_VERSION: undefined, npm_package_version: " 9.8.7 " }, () => {
             assert.equal(resolveCliVersion(), "9.8.7");
-        } finally {
-            if (originalEnv === undefined) {
-                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            } else {
-                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
-            }
-
-            if (originalNpmVersion === undefined) {
-                delete process.env.npm_package_version;
-            } else {
-                process.env.npm_package_version = originalNpmVersion;
-            }
-        }
+        });
     });
 
     void test("resolveCliVersion skips whitespace-only PRETTIER_PLUGIN_GML_VERSION and falls back to npm_package_version", () => {
-        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
-        const originalNpmVersion = process.env.npm_package_version;
-
-        try {
-            process.env.PRETTIER_PLUGIN_GML_VERSION = "   ";
-            process.env.npm_package_version = "4.5.6";
-
+        withVersionEnv({ PRETTIER_PLUGIN_GML_VERSION: "   ", npm_package_version: "4.5.6" }, () => {
             assert.equal(resolveCliVersion(), "4.5.6");
-        } finally {
-            if (originalEnv === undefined) {
-                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            } else {
-                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
-            }
-
-            if (originalNpmVersion === undefined) {
-                delete process.env.npm_package_version;
-            } else {
-                process.env.npm_package_version = originalNpmVersion;
-            }
-        }
+        });
     });
 
     void test("resolveCliVersion skips empty PRETTIER_PLUGIN_GML_VERSION and falls back to npm_package_version", () => {
-        const originalEnv = process.env.PRETTIER_PLUGIN_GML_VERSION;
-        const originalNpmVersion = process.env.npm_package_version;
-
-        try {
-            process.env.PRETTIER_PLUGIN_GML_VERSION = "";
-            process.env.npm_package_version = "2.0.0";
-
+        withVersionEnv({ PRETTIER_PLUGIN_GML_VERSION: "", npm_package_version: "2.0.0" }, () => {
             assert.equal(resolveCliVersion(), "2.0.0");
-        } finally {
-            if (originalEnv === undefined) {
-                delete process.env.PRETTIER_PLUGIN_GML_VERSION;
-            } else {
-                process.env.PRETTIER_PLUGIN_GML_VERSION = originalEnv;
-            }
-
-            if (originalNpmVersion === undefined) {
-                delete process.env.npm_package_version;
-            } else {
-                process.env.npm_package_version = originalNpmVersion;
-            }
-        }
+        });
     });
 });


### PR DESCRIPTION
`normalizeVersionValue` in `version.ts` was a private, single-call function whose entire body forwarded to `getNonEmptyTrimmedString` — an exact replica of the `defaultNow()` anti-pattern. The wrapper name implied version-specific logic that did not exist, adding a misleading layer of indirection.

## Changes

- **`src/cli/src/cli-core/version.ts`** — Removed `normalizeVersionValue`; its one call site now calls `getNonEmptyTrimmedString(candidate)` directly.

```ts
// Before
function normalizeVersionValue(value: unknown): string | null {
    return getNonEmptyTrimmedString(value);
}
const version = normalizeVersionValue(candidate);

// After
const version = getNonEmptyTrimmedString(candidate);
```

- **`src/cli/test/core-version.test.ts`** — Added two regression tests exercising the `getNonEmptyTrimmedString` null-return path (whitespace-only and empty `PRETTIER_PLUGIN_GML_VERSION` are skipped in favour of the next candidate). Extracted a `withVersionEnv` helper to replace ~80 lines of repeated env save/restore teardown across all five tests.