### PR TITLE
refactor: replace `createPortValidator()` zero-arg factory with `portValidator` constant

### DIFF
--- a/src/cli/src/cli-core/command-parsing.ts
+++ b/src/cli/src/cli-core/command-parsing.ts
@@ -18,20 +18,16 @@ export interface ParseCommandLineResult {
 }
 
 /**
- * Create an argParser for Commander.js options that validates port numbers.
- * Ports must be integers in the range 1-65535.
- *
- * @returns {(value: string) => number} An argParser function for Commander.js
+ * An argParser for Commander.js options that validates port numbers.
+ * Ports must be integers in the range 1–65535.
  */
-export function createPortValidator() {
-    return wrapInvalidArgumentResolver((value: string) => {
-        const parsed = Number.parseInt(value);
-        if (Number.isNaN(parsed) || parsed < 1 || parsed > 65_535) {
-            throw new Error("Port must be between 1 and 65535");
-        }
-        return parsed;
-    });
-}
+export const portValidator = wrapInvalidArgumentResolver((value: string) => {
+    const parsed = Number.parseInt(value);
+    if (Number.isNaN(parsed) || parsed < 1 || parsed > 65_535) {
+        throw new Error("Port must be between 1 and 65535");
+    }
+    return parsed;
+});
 
 /**
  * Create an argParser for Commander.js options that validates integers against

--- a/src/cli/src/commands/watch-status.ts
+++ b/src/cli/src/commands/watch-status.ts
@@ -9,7 +9,7 @@
 import { Core } from "@gmloop/core";
 import { Command, Option } from "commander";
 
-import { createPortValidator } from "../cli-core/command-parsing.js";
+import { portValidator } from "../cli-core/command-parsing.js";
 import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 
 const { getErrorMessage } = Core;
@@ -236,7 +236,7 @@ export function createWatchStatusCommand(): Command {
         )
         .addOption(
             new Option("--status-port <port>", "Status server port")
-                .argParser(createPortValidator())
+                .argParser(portValidator)
                 .default(17_891)
                 .env("WATCH_STATUS_PORT")
         )

--- a/src/cli/src/commands/watch.ts
+++ b/src/cli/src/commands/watch.ts
@@ -22,7 +22,7 @@ import { Parser } from "@gmloop/parser";
 import { Transpiler } from "@gmloop/transpiler";
 import { Command, Option } from "commander";
 
-import { createMinimumValueValidator, createPortValidator } from "../cli-core/command-parsing.js";
+import { createMinimumValueValidator, portValidator } from "../cli-core/command-parsing.js";
 import { applyStandardCommandOptions } from "../cli-core/command-standard-options.js";
 import { formatCliError } from "../cli-core/errors.js";
 import { normalizeExtensions } from "../cli-core/extension-normalizer.js";
@@ -569,7 +569,7 @@ export function createWatchCommand(): Command {
         )
         .addOption(
             new Option("--websocket-port <port>", "WebSocket server port for streaming patches")
-                .argParser(createPortValidator())
+                .argParser(portValidator)
                 .default(17_890)
         )
         .addOption(
@@ -578,7 +578,7 @@ export function createWatchCommand(): Command {
         .option("--no-websocket-server", "Disable starting the WebSocket server for patch streaming.")
         .addOption(
             new Option("--status-port <port>", "HTTP status server port for querying watch command status")
-                .argParser(createPortValidator())
+                .argParser(portValidator)
                 .default(17_891)
         )
         .addOption(

--- a/src/cli/test/core-command-parsing.test.ts
+++ b/src/cli/test/core-command-parsing.test.ts
@@ -190,13 +190,6 @@ void describe("portValidator", () => {
             (error) => error instanceof InvalidArgumentError && /Port must be between 1 and 65535/.test(error.message)
         );
     });
-
-    void it("is the same object reference on each import (not recreated)", () => {
-        // portValidator is a constant, not a factory: the same wrapped function
-        // instance is shared across all call sites rather than allocated fresh
-        // on each Commander option registration.
-        assert.strictEqual(typeof portValidator, "function");
-    });
 });
 
 void describe("integer coercion helpers: import from Core, not command-parsing", () => {

--- a/src/cli/test/core-command-parsing.test.ts
+++ b/src/cli/test/core-command-parsing.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { Core } from "@gmloop/core";
 import { Command, InvalidArgumentError } from "commander";
 
-import { parseCommandLine, wrapInvalidArgumentResolver } from "../src/cli-core/command-parsing.js";
+import { parseCommandLine, portValidator, wrapInvalidArgumentResolver } from "../src/cli-core/command-parsing.js";
 import { isCliUsageError } from "../src/cli-core/errors.js";
 
 const { isObjectLike } = Core;
@@ -143,6 +143,59 @@ void describe("wrapInvalidArgumentResolver", () => {
                 error.message === "bad news" &&
                 error.cause instanceof Error
         );
+    });
+});
+
+void describe("portValidator", () => {
+    void it("accepts the minimum valid port (1)", () => {
+        assert.strictEqual(portValidator("1"), 1);
+    });
+
+    void it("accepts a typical HTTP port (80)", () => {
+        assert.strictEqual(portValidator("80"), 80);
+    });
+
+    void it("accepts a common dev server port (8080)", () => {
+        assert.strictEqual(portValidator("8080"), 8080);
+    });
+
+    void it("accepts the maximum valid port (65535)", () => {
+        assert.strictEqual(portValidator("65535"), 65_535);
+    });
+
+    void it("rejects port zero", () => {
+        assert.throws(
+            () => portValidator("0"),
+            (error) => error instanceof InvalidArgumentError && /Port must be between 1 and 65535/.test(error.message)
+        );
+    });
+
+    void it("rejects a port above the maximum", () => {
+        assert.throws(
+            () => portValidator("65536"),
+            (error) => error instanceof InvalidArgumentError && /Port must be between 1 and 65535/.test(error.message)
+        );
+    });
+
+    void it("rejects a negative port number", () => {
+        assert.throws(
+            () => portValidator("-1"),
+            (error) => error instanceof InvalidArgumentError && /Port must be between 1 and 65535/.test(error.message)
+        );
+    });
+
+    void it("rejects non-numeric input", () => {
+        assert.throws(
+            () => portValidator("abc"),
+            (error) => error instanceof InvalidArgumentError && /Port must be between 1 and 65535/.test(error.message)
+        );
+    });
+
+    void it("is the same object reference on each import (not recreated)", () => {
+        // portValidator is a constant, not a factory: the same wrapped function
+        // instance is shared across all call sites rather than allocated fresh
+        // on each Commander option registration.
+        assert.strictEqual(typeof portValidator, "function");
     });
 });
 


### PR DESCRIPTION
`createPortValidator()` was a zero-argument factory that always returned the same stateless closure—allocating a fresh function object on each of its three Commander `argParser` call sites despite holding no mutable state.

## Changes

- **`command-parsing.ts`** — replace factory function with a module-level `portValidator` constant; the wrapped validator is stateless, so one shared reference is equivalent
- **`watch.ts`, `watch-status.ts`** — update imports and call sites from `.argParser(createPortValidator())` → `.argParser(portValidator)`
- **`core-command-parsing.test.ts`** — add 8 regression tests covering boundary ports (1, 65535), typical ports (80, 8080), and invalid inputs (0, 65536, −1, non-numeric)

```ts
// Before
export function createPortValidator() {
    return wrapInvalidArgumentResolver((value: string) => {
        const parsed = Number.parseInt(value);
        if (Number.isNaN(parsed) || parsed < 1 || parsed > 65_535) {
            throw new Error("Port must be between 1 and 65535");
        }
        return parsed;
    });
}
// .argParser(createPortValidator()) — new closure on every registration

// After
export const portValidator = wrapInvalidArgumentResolver((value: string) => {
    const parsed = Number.parseInt(value);
    if (Number.isNaN(parsed) || parsed < 1 || parsed > 65_535) {
        throw new Error("Port must be between 1 and 65535");
    }
    return parsed;
});
// .argParser(portValidator) — shared reference, same behavior
```