### PR TITLE
Remove `isFsErrorCode` wrapper alias from core

### DIFF
--- a/src/cli/src/commands/watch.ts
+++ b/src/cli/src/commands/watch.ts
@@ -78,7 +78,7 @@ import {
     DEFAULT_WATCH_POLLING_INTERVAL_MS
 } from "./watch-constants.js";
 
-const { debounce, getErrorMessage, getLineBreakCount, isFsErrorCode } = Core;
+const { debounce, getErrorMessage, getLineBreakCount, isErrorWithCode } = Core;
 
 type RuntimeDescriptorFormatter = (source: RuntimeSourceDescriptor) => string;
 
@@ -1475,7 +1475,7 @@ async function handleFileChange(
 
             await processTranspileResult(runtimeContext, filePath, result, verbose, quiet);
         } catch (error) {
-            if (runtimeContext && isFsErrorCode(error, "ENOENT")) {
+            if (runtimeContext && isErrorWithCode(error, "ENOENT")) {
                 cleanupRemovedFile(runtimeContext, filePath, verbose, quiet);
                 if (verbose && !quiet) {
                     console.log("  ↳ File missing during read (deleted before processing)");

--- a/src/cli/src/modules/manual/source.ts
+++ b/src/cli/src/modules/manual/source.ts
@@ -15,7 +15,7 @@ import {
 const {
     assertNonEmptyString,
     getErrorMessageOrFallback,
-    isFsErrorCode,
+    isErrorWithCode,
     parseJsonWithContext,
     resolveContainedRelativePath,
     toPosixPath
@@ -44,7 +44,7 @@ async function ensureDirectoryExists(root, { required, label }) {
         }
         return true;
     } catch (error) {
-        if (!required && isFsErrorCode(error, "ENOENT")) {
+        if (!required && isErrorWithCode(error, "ENOENT")) {
             return false;
         }
 

--- a/src/cli/src/modules/runtime/server.ts
+++ b/src/cli/src/modules/runtime/server.ts
@@ -8,7 +8,7 @@ import { Core } from "@gmloop/core";
 
 import type { ServerEndpoint, ServerLifecycle } from "../server/index.js";
 
-const { isFsErrorCode, getErrorMessage } = Core;
+const { isErrorWithCode, getErrorMessage } = Core;
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 0;
@@ -241,7 +241,7 @@ export async function startRuntimeStaticServer({
     const resolvedRoot = path.resolve(runtimeRoot);
 
     const initialStats = await fs.stat(resolvedRoot).catch((error) => {
-        if (isFsErrorCode(error, "ENOENT")) {
+        if (isErrorWithCode(error, "ENOENT")) {
             throw new Error(`Runtime root '${resolvedRoot}' does not exist. Did hydration succeed?`);
         }
         throw error;
@@ -280,7 +280,7 @@ export async function startRuntimeStaticServer({
         }
 
         sendFileResponse(res, targetPath, { method }).catch((error) => {
-            const statusCode = getRuntimeHttpErrorStatus(error) ?? (isFsErrorCode(error, "ENOENT") ? 404 : 500);
+            const statusCode = getRuntimeHttpErrorStatus(error) ?? (isErrorWithCode(error, "ENOENT") ? 404 : 500);
             const fallbackMessage =
                 statusCode === 404
                     ? "Not Found"

--- a/src/core/src/fs/io.ts
+++ b/src/core/src/fs/io.ts
@@ -18,21 +18,6 @@ export interface FileSystemStatReader {
 }
 
 /**
- * Type-safe wrapper over {@link isErrorWithCode} so callers can narrow thrown
- * filesystem errors to specific Node-style `code` strings without repeating the
- * shared utility import. Accepts the same loose inputs as the underlying
- * helper, mirroring how error guards are typically used in catch blocks.
- *
- * @param {unknown} error Candidate error thrown by the filesystem facade.
- * @param {...string} codes Node-style error codes (for example `"ENOENT"`).
- * @returns {error is NodeJS.ErrnoException} `true` when {@link error} exposes a
- *          matching {@link NodeJS.ErrnoException.code} value.
- */
-export function isFsErrorCode(error, ...codes) {
-    return isErrorWithCode(error, ...codes);
-}
-
-/**
  * Enumerate the entries in {@link directoryPath} while respecting the abort
  * semantics shared by long-running filesystem workflows. Missing directories
  * resolve to an empty array so callers can treat them as already-processed
@@ -64,7 +49,7 @@ export async function listDirectory(
 
         return toArrayFromIterable(entries);
     } catch (error) {
-        if (isFsErrorCode(error, "ENOENT", "ENOTDIR")) {
+        if (isErrorWithCode(error, "ENOENT", "ENOTDIR")) {
             return [];
         }
         throw error;
@@ -100,7 +85,7 @@ export async function getFileMtime(
         guard.ensureNotAborted();
         return typeof stats.mtimeMs === "number" ? stats.mtimeMs : null;
     } catch (error) {
-        if (isFsErrorCode(error, "ENOENT")) {
+        if (isErrorWithCode(error, "ENOENT")) {
             return null;
         }
         throw error;

--- a/src/core/test/fs-io.test.ts
+++ b/src/core/test/fs-io.test.ts
@@ -2,6 +2,28 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { getFileMtime, listDirectory } from "../src/fs/index.js";
+import { isErrorWithCode } from "../src/utils/error.js";
+
+void test("isErrorWithCode matches Node.js-style error codes", () => {
+    const enoent = new Error("no such file") as NodeJS.ErrnoException;
+    enoent.code = "ENOENT";
+
+    assert.ok(isErrorWithCode(enoent, "ENOENT"), "should match ENOENT");
+    assert.ok(isErrorWithCode(enoent, "ENOENT", "EACCES"), "should match when ENOENT is in a multi-code list");
+    assert.ok(!isErrorWithCode(enoent, "EACCES"), "should not match a different code");
+});
+
+void test("isErrorWithCode returns false for non-Error values", () => {
+    assert.ok(!isErrorWithCode(null, "ENOENT"));
+    assert.ok(!isErrorWithCode(undefined, "ENOENT"));
+    assert.ok(!isErrorWithCode("string error", "ENOENT"));
+    assert.ok(!isErrorWithCode(42, "ENOENT"));
+    assert.ok(!isErrorWithCode({}, "ENOENT"));
+});
+
+void test("isErrorWithCode returns false when error has no code property", () => {
+    assert.ok(!isErrorWithCode(new Error("plain error"), "ENOENT"));
+});
 
 void test("listDirectory snapshots iterable results", async () => {
     const source = ["alpha", "beta"];

--- a/src/semantic/src/identifier-case/asset-renames/executor.ts
+++ b/src/semantic/src/identifier-case/asset-renames/executor.ts
@@ -42,7 +42,7 @@ function tryAccess(fsFacade, method, targetPath, ...args) {
         const result = fn.call(fsFacade, targetPath, ...args);
         return method === "existsSync" ? Boolean(result) : true;
     } catch (error) {
-        if (Core.isFsErrorCode(error, "ENOENT")) {
+        if (Core.isErrorWithCode(error, "ENOENT")) {
             return false;
         }
         throw error;

--- a/src/semantic/src/project-index/builder.ts
+++ b/src/semantic/src/project-index/builder.ts
@@ -1446,7 +1446,7 @@ async function readProjectGmlFile({ file, fsFacade, metrics }) {
         metrics.counters.increment("io.gmlBytes", Buffer.byteLength(contents));
         return contents;
     } catch (error) {
-        if (Core.isFsErrorCode(error, "ENOENT")) {
+        if (Core.isErrorWithCode(error, "ENOENT")) {
             metrics.counters.increment("files.missingDuringRead");
             return null;
         }

--- a/src/semantic/src/project-index/cache.ts
+++ b/src/semantic/src/project-index/cache.ts
@@ -244,7 +244,7 @@ export async function loadProjectIndexCache(
     try {
         rawContents = await fsFacade.readFile(cacheFilePath, "utf8");
     } catch (error) {
-        if (Core.isFsErrorCode(error, "ENOENT")) {
+        if (Core.isErrorWithCode(error, "ENOENT")) {
             return createCacheMiss(cacheFilePath, ProjectIndexCacheMissReason.NOT_FOUND);
         }
         throw error;

--- a/src/semantic/src/project-index/project-tree.ts
+++ b/src/semantic/src/project-index/project-tree.ts
@@ -114,7 +114,7 @@ async function resolveEntryStats({ absolutePath, fsFacade, ensureNotAborted, met
         ensureNotAborted();
         return stats;
     } catch (error) {
-        if (Core.isFsErrorCode(error, "ENOENT")) {
+        if (Core.isErrorWithCode(error, "ENOENT")) {
             metrics?.counters?.increment("io.skippedMissingEntries");
             return null;
         }

--- a/src/semantic/src/project-index/resource-analysis.ts
+++ b/src/semantic/src/project-index/resource-analysis.ts
@@ -193,7 +193,7 @@ async function loadResourceDocument(
     try {
         rawContents = await fsFacade.readFile(file.absolutePath, "utf8");
     } catch (error) {
-        if (Core.isFsErrorCode(error, "ENOENT")) {
+        if (Core.isErrorWithCode(error, "ENOENT")) {
             return null;
         }
         throw error;


### PR DESCRIPTION
`isFsErrorCode` in `src/core/src/fs/io.ts` was a pure pass-through alias for `isErrorWithCode` — identical signature, identical body, zero added semantics — while both were simultaneously exported from the `Core` namespace.

## Changes

- **`src/core/src/fs/io.ts`** — deleted `isFsErrorCode`; replaced 2 internal call sites with `isErrorWithCode` directly
- **`src/core/test/fs-io.test.ts`** — added explicit regression tests for `isErrorWithCode` covering ENOENT matching, multi-code lists, and non-Error inputs
- **`src/cli/` + `src/semantic/`** (8 files) — updated all 9 external `Core.isFsErrorCode` call sites to `Core.isErrorWithCode`

```ts
// Before — alias with no added semantics
export function isFsErrorCode(error, ...codes) {
    return isErrorWithCode(error, ...codes);
}

// After — callers use isErrorWithCode directly (already in Core namespace)
if (Core.isErrorWithCode(error, "ENOENT")) { ... }
```