### PR TITLE
Remove `gmlParserFacade` legacy OOP-facade shim; canonicalize on `parseGml`

### DIFF
--- a/src/semantic/src/project-index/bootstrap-descriptor.ts
+++ b/src/semantic/src/project-index/bootstrap-descriptor.ts
@@ -1,9 +1,5 @@
 import { Core } from "@gmloop/core";
 
-type ProjectIndexParserFacade = {
-    parse?: (text: string, filePath?: string) => unknown;
-};
-
 type ProjectIndexConcurrencySettings = {
     gml: number;
     gmlParsing: number;
@@ -16,9 +12,7 @@ type ProjectIndexBuildOptions = {
     // can accept either legacy or current option shapes passed by callers.
     concurrency?: ProjectIndexConcurrencySettings | null;
     projectIndexConcurrency?: number | ProjectIndexConcurrencySettings | null;
-    gmlParserFacade?: ProjectIndexParserFacade | null;
     parserOverride?: {
-        facade?: ProjectIndexParserFacade | null;
         parse?: (text: string, filePath?: string) => unknown;
     } | null;
     parseGml?: (text: string, filePath?: string) => unknown;
@@ -62,11 +56,7 @@ export function createProjectIndexBuildOptions({
         return buildOptions;
     }
 
-    const { facade, parse } = parserOverride;
-
-    if (facade) {
-        buildOptions.gmlParserFacade = facade;
-    }
+    const { parse } = parserOverride;
 
     buildOptions.parseGml = parse as ((text: string, filePath?: string) => unknown) | null;
 

--- a/src/semantic/src/project-index/gml-parser-facade.ts
+++ b/src/semantic/src/project-index/gml-parser-facade.ts
@@ -107,16 +107,8 @@ export function getProjectIndexParserOverride(options) {
         return null;
     }
 
-    const facade = options.gmlParserFacade;
-    if (typeof facade?.parse === "function") {
-        return {
-            facade,
-            parse: facade.parse.bind(facade)
-        };
-    }
-
     const parse = options.parseGml;
-    return typeof parse === "function" ? { facade: null, parse } : null;
+    return typeof parse === "function" ? { parse } : null;
 }
 
 export function resolveProjectIndexParser(options) {

--- a/src/semantic/test/project-index-parser-facade.test.ts
+++ b/src/semantic/test/project-index-parser-facade.test.ts
@@ -3,16 +3,15 @@ import test from "node:test";
 
 import { resolveProjectIndexParser } from "../src/project-index/index.js";
 
-void test("resolveProjectIndexParser prefers facade overrides", () => {
+void test("resolveProjectIndexParser uses parseGml override when provided", () => {
     const calls: Array<string> = [];
-    const facade = {
-        parse(sourceText: string) {
+
+    const parser = resolveProjectIndexParser({
+        parseGml(sourceText: string) {
             calls.push(sourceText);
             return { ok: true };
         }
-    };
-
-    const parser = resolveProjectIndexParser({ gmlParserFacade: facade });
+    });
 
     const result = parser("test_source");
 
@@ -20,7 +19,7 @@ void test("resolveProjectIndexParser prefers facade overrides", () => {
     assert.deepEqual(calls, ["test_source"]);
 });
 
-void test("resolveProjectIndexParser ignores legacy parserFacade alias and uses canonical parseGml", () => {
+void test("resolveProjectIndexParser ignores unrecognised alias properties and uses canonical parseGml", () => {
     const legacyCalls: Array<string> = [];
     const canonicalCalls: Array<string> = [];
 


### PR DESCRIPTION
`ProjectIndexBuildOptions` carried two parallel parser-override APIs: the legacy `gmlParserFacade` (object with `.parse()`) and the canonical `parseGml` (direct function). No production caller ever passed `gmlParserFacade`; `bootstrap-descriptor.ts` preserved it with an explicit comment acknowledging it as a historical name.

## Changes

- **`gml-parser-facade.ts`** — `getProjectIndexParserOverride` now reads only `options.parseGml`; the dead `gmlParserFacade` branch is removed.
- **`bootstrap-descriptor.ts`** — Removes `ProjectIndexParserFacade` type, the `gmlParserFacade` field from `ProjectIndexBuildOptions`, and the `facade` sub-field from the internal `parserOverride` shape. `createProjectIndexBuildOptions` no longer reconstructs the legacy field.
- **`project-index-parser-facade.test.ts`** — Replaces the "prefers facade overrides" test (which exercised `gmlParserFacade`) with an equivalent test using the canonical `parseGml` path.

**Before:**
```ts
// Two paths, one dead in production
const facade = options.gmlParserFacade;
if (typeof facade?.parse === "function") {
    return { facade, parse: facade.parse.bind(facade) };
}
const parse = options.parseGml;
return typeof parse === "function" ? { facade: null, parse } : null;
```

**After:**
```ts
const parse = options.parseGml;
return typeof parse === "function" ? { parse } : null;
```