### PR TITLE
Enforce formatter/linter split: migrate unary-plus-on-identifier semantic rewrite from format to lint

### DIFF
--- a/src/format/src/printer/print.ts
+++ b/src/format/src/printer/print.ts
@@ -672,10 +672,6 @@ function printBinaryExpressionNode(node, path, options, print) {
 
 function printUnaryLikeExpressionNode(node, _path, _options, print) {
     if (node.prefix) {
-        if (node.operator === "+" && shouldOmitUnaryPlus(node.argument)) {
-            return print("argument");
-        }
-
         // Normalize `-0` to `0`: when a unary minus is applied to a literal zero
         // (including normalized forms like `0.` → `0`), the result is numerically
         // identical to positive zero in GML. Keeping `-0` would generate incorrect
@@ -3099,31 +3095,6 @@ function shouldBreakVariableInitializerOnAssignmentLine(node): boolean {
 
     const initializer = unwrapParensForInitializer(node.init);
     return initializer?.type === "BinaryExpression" && binaryExpressionContainsString(initializer);
-}
-
-function shouldOmitUnaryPlus(argument) {
-    const candidate = unwrapUnaryPlusCandidate(argument);
-
-    if (!candidate || typeof candidate !== OBJECT_TYPE) {
-        return false;
-    }
-
-    return candidate.type === "Identifier";
-}
-
-function unwrapUnaryPlusCandidate(node) {
-    let current = node;
-
-    while (
-        current &&
-        typeof current === OBJECT_TYPE &&
-        current.type === "ParenthesizedExpression" &&
-        current.expression
-    ) {
-        current = current.expression;
-    }
-
-    return current;
 }
 
 function unwrapParenthesizedExpression(childPath, print) {

--- a/src/format/test/formatter-boundaries-ownership.test.ts
+++ b/src/format/test/formatter-boundaries-ownership.test.ts
@@ -761,4 +761,26 @@ void describe("formatter boundaries ownership", () => {
             "Formatter must not return source verbatim as a recovery fallback (§3.2)."
         );
     });
+
+    void it("preserves unary plus before identifiers (semantic rewrite belongs in lint)", async () => {
+        // Silently dropping `+x` changes program behavior when the operand is not
+        // numeric: `+x` applies numeric coercion while bare `x` does not.
+        // That is an explicit content rewrite that must live in the lint rule
+        // `gml/no-unary-plus-on-identifier`, not the formatter.
+        // (target-state.md §2.1, §3.2 — "Formatter must not perform semantic/content rewrites")
+        const source = ["var result = +counter;", ""].join("\n");
+
+        const formatted = await Format.format(source);
+
+        assert.match(
+            formatted,
+            /\+counter/,
+            "Formatter must not strip unary `+` from identifiers — that is a lint-workspace responsibility (gml/no-unary-plus-on-identifier)."
+        );
+        assert.doesNotMatch(
+            formatted,
+            /var result = counter;/,
+            "Formatter must not silently rewrite `+counter` to `counter` (§2.1, §3.2)."
+        );
+    });
 });

--- a/src/format/test/printer-regression.test.ts
+++ b/src/format/test/printer-regression.test.ts
@@ -40,10 +40,14 @@ void test("prints all call arguments in order", async () => {
     );
 });
 
-void test("omits redundant unary plus before identifiers", async () => {
+void test("preserves unary plus before identifiers (semantic rewrite belongs in lint)", async () => {
+    // Removing `+x` silently changes program semantics when `x` is not numeric
+    // (e.g. string coercion via `+` differs from the raw identifier access).
+    // This is an explicit content rewrite that belongs in the lint workspace
+    // as `gml/no-unary-plus-on-identifier`. (target-state.md §2.1, §3.2)
     const formatted = await Format.format("var value = +count;\n");
 
-    assert.strictEqual(formatted, "var value = count;\n");
+    assert.strictEqual(formatted, "var value = +count;\n");
 });
 
 void test("retains plus-plus before identifiers", async () => {

--- a/src/lint/src/rules/catalog.ts
+++ b/src/lint/src/rules/catalog.ts
@@ -233,6 +233,12 @@ export const gmlRuleDefinitions: ReadonlyArray<GmlRuleDefinition> = Object.freez
         shortName: "simplify-real-calls",
         fullId: "gml/simplify-real-calls",
         messageId: "simplifyRealCalls"
+    },
+    {
+        mapKey: "GmlNoUnaryPlusOnIdentifier",
+        shortName: "no-unary-plus-on-identifier",
+        fullId: "gml/no-unary-plus-on-identifier",
+        messageId: "noUnaryPlusOnIdentifier"
     }
 ]);
 

--- a/src/lint/src/rules/gml/create-gml-rules.ts
+++ b/src/lint/src/rules/gml/create-gml-rules.ts
@@ -6,6 +6,7 @@ import { createNoEmptyRegionsRule } from "./rules/no-empty-regions-rule.js";
 import { createNoGlobalvarRule } from "./rules/no-globalvar-rule.js";
 import { createNoLegacyApiRule } from "./rules/no-legacy-api-rule.js";
 import { createNoScientificNotationRule } from "./rules/no-scientific-notation-rule.js";
+import { createNoUnaryPlusOnIdentifierRule } from "./rules/no-unary-plus-on-identifier-rule.js";
 import { createNoUnnecessaryStringInterpolationRule } from "./rules/no-unnecessary-string-interpolation-rule.js";
 import { createNormalizeBannerCommentsRule } from "./rules/normalize-banner-comments-rule.js";
 import { createNormalizeDataStructureAccessorsRule } from "./rules/normalize-data-structure-accessors-rule.js";
@@ -123,6 +124,9 @@ export function createGmlRule(definition: GmlRuleDefinition): Rule.RuleModule {
         }
         case "simplify-real-calls": {
             return createSimplifyRealCallsRule(definition);
+        }
+        case "no-unary-plus-on-identifier": {
+            return createNoUnaryPlusOnIdentifierRule(definition);
         }
         default: {
             throw new Error(`Missing gml rule implementation for shortName '${definition.shortName}'.`);

--- a/src/lint/src/rules/gml/rules/no-unary-plus-on-identifier-rule.ts
+++ b/src/lint/src/rules/gml/rules/no-unary-plus-on-identifier-rule.ts
@@ -1,0 +1,83 @@
+import type { Rule } from "eslint";
+
+import { createMeta, getNodeEndIndex, getNodeStartIndex, isAstNodeRecord } from "../rule-base-helpers.js";
+import type { GmlRuleDefinition } from "../rule-definition.js";
+
+/**
+ * Unwraps chains of `ParenthesizedExpression` nodes to retrieve the innermost
+ * expression. Returns the original node when no wrapping is present.
+ */
+function unwrapParenthesizedExpression(node: unknown): unknown {
+    let current = node;
+
+    while (isAstNodeRecord(current) && current.type === "ParenthesizedExpression") {
+        current = current.expression;
+    }
+
+    return current;
+}
+
+/**
+ * Reports and autofixes unary `+` applied directly to an identifier such as
+ * `+count` → `count`. In GML the unary-plus operator has numeric-coercion
+ * semantics (it converts its operand to a number), so `+x` is only equivalent
+ * to `x` when the variable is already known to hold a numeric value.
+ *
+ * Because the formatter cannot guarantee the operand type, it must preserve the
+ * expression verbatim. This rule gives the developer an explicit, auditable
+ * autofix to remove the operator when it is safe to do so.
+ *
+ * Ownership boundary: this rule lives in `@gmloop/lint` because replacing
+ * `+identifier` with `identifier` is a semantic content rewrite, not a layout
+ * transform. (target-state.md §2.1, §3.2)
+ */
+export function createNoUnaryPlusOnIdentifierRule(definition: GmlRuleDefinition): Rule.RuleModule {
+    return Object.freeze({
+        meta: createMeta(definition, {
+            messageText:
+                "Unnecessary unary `+` before identifier — the operator coerces to number and may be removed if the variable is always numeric. Use autofix to apply."
+        }),
+        create(context) {
+            return Object.freeze({
+                UnaryExpression(node) {
+                    if (node.operator !== "+") {
+                        return;
+                    }
+
+                    // Only flag prefix form (`+x`), not postfix (which doesn't exist for `+`).
+                    if (!node.prefix) {
+                        return;
+                    }
+
+                    const innerExpression = unwrapParenthesizedExpression(node.argument);
+
+                    if (!isAstNodeRecord(innerExpression) || innerExpression.type !== "Identifier") {
+                        return;
+                    }
+
+                    const start = getNodeStartIndex(node);
+                    const end = getNodeEndIndex(node);
+                    const argumentStart = getNodeStartIndex(node.argument);
+                    const argumentEnd = getNodeEndIndex(node.argument);
+
+                    if (
+                        typeof start !== "number" ||
+                        typeof end !== "number" ||
+                        typeof argumentStart !== "number" ||
+                        typeof argumentEnd !== "number"
+                    ) {
+                        return;
+                    }
+
+                    const argumentText = context.sourceCode.text.slice(argumentStart, argumentEnd);
+
+                    context.report({
+                        node,
+                        messageId: definition.messageId,
+                        fix: (fixer) => fixer.replaceTextRange([start, end], argumentText)
+                    });
+                }
+            });
+        }
+    });
+}

--- a/src/lint/test/rules/rule-contracts.test.ts
+++ b/src/lint/test/rules/rule-contracts.test.ts
@@ -200,6 +200,11 @@ const expectedRules = Object.freeze([
         shortName: "simplify-real-calls",
         messageId: "simplifyRealCalls",
         schema: [{ type: "object", additionalProperties: false, properties: {} }]
+    },
+    {
+        shortName: "no-unary-plus-on-identifier",
+        messageId: "noUnaryPlusOnIdentifier",
+        schema: [{ type: "object", additionalProperties: false, properties: {} }]
     }
 ]);
 

--- a/src/lint/test/rules/rule-standalone.test.ts
+++ b/src/lint/test/rules/rule-standalone.test.ts
@@ -1759,3 +1759,59 @@ void test("optimize-logical-flow parenthesizes nested ternary consequents in aut
         "Expected autofix output to avoid malformed nested ternary syntax."
     );
 });
+
+void test("no-unary-plus-on-identifier autofixes +identifier to bare identifier", () => {
+    const input = "var value = +count;\n";
+    const expected = "var value = count;\n";
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 1);
+    assertEquals(result.messages[0]?.messageId, "noUnaryPlusOnIdentifier");
+    assertEquals(result.output, expected);
+});
+
+void test("no-unary-plus-on-identifier handles multiple unary plus usages in one file", () => {
+    const input = ["var a = +score;", "var b = +lives;", ""].join("\n");
+    const expected = ["var a = score;", "var b = lives;", ""].join("\n");
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 2);
+    assertEquals(result.output, expected);
+});
+
+void test("no-unary-plus-on-identifier preserves unary plus on non-identifier operands", () => {
+    // `+"5"` coerces a string literal to a number — a useful conversion that is
+    // not a simple "remove the operator" case; only identifier operands are flagged.
+    const input = 'var value = +"5";\n';
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 0);
+    assertEquals(result.output, input);
+});
+
+void test("no-unary-plus-on-identifier preserves unary plus on call-expression operands", () => {
+    const input = "var value = +get_count();\n";
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 0);
+    assertEquals(result.output, input);
+});
+
+void test("no-unary-plus-on-identifier autofixes +identifier when wrapped in parentheses", () => {
+    // `+(count)` still has an Identifier as its innermost operand once the
+    // synthetic parentheses are unwrapped.
+    const input = "var value = +(count);\n";
+    const expected = "var value = (count);\n";
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 1);
+    assertEquals(result.output, expected);
+});
+
+void test("no-unary-plus-on-identifier does not flag prefix increment (++)", () => {
+    const input = "var value = ++count;\n";
+
+    const result = lintWithRule("no-unary-plus-on-identifier", input, {});
+    assertEquals(result.messages.length, 0);
+    assertEquals(result.output, input);
+});


### PR DESCRIPTION
`shouldOmitUnaryPlus` in `format/src/printer/print.ts` was silently dropping `+identifier` → `identifier` during formatting — a semantic content rewrite, not a layout transform. In GML, `+x` applies numeric coercion; bare `x` does not. The formatter cannot know the operand type, so this transform belongs in lint as an explicit, opt-in autofix. (target-state.md §2.1, §3.2)

## Formatter (`@gmloop/format`)
- Remove `shouldOmitUnaryPlus` and `unwrapUnaryPlusCandidate` from `print.ts`; `+identifier` is now preserved verbatim
- Update the regression test that asserted the silent drop to assert preservation instead
- Add a `formatter-boundaries-ownership` test documenting the invariant

## Lint (`@gmloop/lint`)
- Add new rule `gml/no-unary-plus-on-identifier` with autofix — makes the rewrite explicit and auditable
- Register in catalog, factory switch, and rule-contracts stable list

```gml
// Before: formatter silently rewrote this
var speed = +raw_value;  // → var speed = raw_value;

// After: formatter preserves it; lint reports + autofixes on demand
var speed = +raw_value;  // formatter: unchanged
//          ^ gml/no-unary-plus-on-identifier [autofix available]
```