### PR TITLE
Optimize naming-convention codemod planning for whole-project selection and add performance test

### DIFF
--- a/src/refactor/src/codemods/naming-convention/naming-convention-codemod.ts
+++ b/src/refactor/src/codemods/naming-convention/naming-convention-codemod.ts
@@ -652,6 +652,15 @@ function buildNamingTargetQueryPaths(projectRoot: string, selectedFilePaths: Arr
     return [...queryPaths];
 }
 
+function includesWholeProjectSelection(projectRoot: string, targetPaths: ReadonlyArray<string>): boolean {
+    if (targetPaths.length === 0) {
+        return true;
+    }
+
+    const absoluteProjectRoot = resolveProjectPath(projectRoot, projectRoot);
+    return targetPaths.every((targetPath) => resolveProjectPath(projectRoot, targetPath) === absoluteProjectRoot);
+}
+
 function getNamingTargetIdentity(target: NamingConventionTarget): string {
     const occurrenceIdentity = target.occurrences
         .map(
@@ -782,6 +791,7 @@ export async function planNamingConventionCodemod(
     const includeViolations = parameters.includeViolations !== false;
     const resolvedRules = resolveNamingConventionRules(policy);
     const requestedCategories = Object.keys(resolvedRules) as Array<NamingCategory>;
+    const tracksLocalTargets = requestedCategoriesMayContainLocalTargets(requestedCategories);
     let workspace = new WorkspaceEditClass();
     const warnings: Array<string> = [];
     const errors: Array<string> = [];
@@ -791,9 +801,14 @@ export async function planNamingConventionCodemod(
     const seenTopLevelRenames = new Set<string>();
     let localRenameCount = 0;
     const isSelectedTargetPath = createPathSelectionMatcher(parameters.projectRoot, parameters.targetPaths, []);
-
-    const selectedFilePaths = (parameters.gmlFilePaths ?? []).filter((filePath) => isSelectedTargetPath(filePath));
-    const queryPaths = buildNamingTargetQueryPaths(parameters.projectRoot, selectedFilePaths);
+    const selectedWholeProject =
+        includesWholeProjectSelection(parameters.projectRoot, parameters.targetPaths) && !tracksLocalTargets;
+    const selectedFilePaths = selectedWholeProject
+        ? [...(parameters.gmlFilePaths ?? [])]
+        : (parameters.gmlFilePaths ?? []).filter((filePath) => isSelectedTargetPath(filePath));
+    const queryPaths = selectedWholeProject
+        ? []
+        : buildNamingTargetQueryPaths(parameters.projectRoot, selectedFilePaths);
     const namingTargetProvider = {
         listNamingConventionTargets: semantic.listNamingConventionTargets.bind(semantic)
     };
@@ -808,7 +823,7 @@ export async function planNamingConventionCodemod(
         queriedTargets,
         queryPaths,
         isSelectedTargetPath,
-        trackLocalTargets: requestedCategoriesMayContainLocalTargets(requestedCategories)
+        trackLocalTargets: tracksLocalTargets
     });
     const macroDependencyNamesByFile =
         hasLocalNamingTargets && typeof semantic.listMacroExpansionDependencies === "function"

--- a/src/refactor/test/naming-convention-performance.test.ts
+++ b/src/refactor/test/naming-convention-performance.test.ts
@@ -13,6 +13,13 @@ import type {
 const FILE_COUNT = 180;
 const TARGETS_PER_FILE = 32;
 const PERFORMANCE_THRESHOLD_MS = 700;
+const DEFAULT_LOCAL_VARIABLE_NAMING_CONFIG: RefactorProjectConfig["codemods"]["namingConvention"] = {
+    rules: {
+        localVariable: {
+            caseStyle: "camel"
+        }
+    }
+};
 
 type SyntheticFileFixture = {
     sourceText: string;
@@ -146,17 +153,12 @@ function buildNamingConventionCodemodExecutor(
     engine: InstanceType<typeof Refactor.RefactorEngine>,
     gmlFilePaths: Array<string>,
     sourceTexts: Map<string, string>,
-    projectRoot: string
+    projectRoot: string,
+    namingConfig?: RefactorProjectConfig["codemods"]["namingConvention"]
 ): () => Promise<ConfiguredCodemodRunResult> {
     const config: RefactorProjectConfig = {
         codemods: {
-            namingConvention: {
-                rules: {
-                    localVariable: {
-                        caseStyle: "camel"
-                    }
-                }
-            }
+            namingConvention: namingConfig ?? DEFAULT_LOCAL_VARIABLE_NAMING_CONFIG
         }
     };
 
@@ -239,6 +241,8 @@ void test("namingConvention stress test stays within the selected-file planning 
 const LARGE_FILE_COUNT = 300;
 const LARGE_TARGETS_PER_FILE = 50;
 const LARGE_PERFORMANCE_THRESHOLD_MS = 700;
+const ROOT_SELECTION_FILE_COUNT = 5000;
+const ROOT_SELECTION_THRESHOLD_MS = 140;
 
 void test("namingConvention large-scale stress test locks in the hot-path optimisation gain", async () => {
     const projectRoot = "/project";
@@ -270,6 +274,48 @@ void test("namingConvention large-scale stress test locks in the hot-path optimi
     assert.ok(
         durationMs <= LARGE_PERFORMANCE_THRESHOLD_MS,
         `Expected large-scale namingConvention stress test to finish within ${LARGE_PERFORMANCE_THRESHOLD_MS}ms, ` +
+            `received ${durationMs.toFixed(2)}ms`
+    );
+});
+
+void test("namingConvention full-project selection stays within the root-target discovery threshold", async () => {
+    const projectRoot = "/project";
+    const gmlFilePaths = Array.from(
+        { length: ROOT_SELECTION_FILE_COUNT },
+        (_, fileIndex) => `scripts/script_${fileIndex}.gml`
+    );
+    const sourceTexts = new Map(gmlFilePaths.map((filePath) => [filePath, `function ${filePath.length}() {}\n`]));
+
+    const semantic: PartialSemanticAnalyzer = {
+        listNamingConventionTargets: async (filePaths?: Array<string>) => {
+            assert.equal(filePaths, undefined);
+            return [];
+        },
+        validateEdits: async () => ({
+            errors: [],
+            warnings: []
+        })
+    };
+
+    const engine = new Refactor.RefactorEngine({ semantic });
+    const executeStressRun = buildNamingConventionCodemodExecutor(engine, gmlFilePaths, sourceTexts, projectRoot, {
+        rules: {
+            scriptResourceName: {
+                caseStyle: "camel"
+            }
+        }
+    });
+
+    await executeStressRun();
+
+    const SAMPLE_COUNT = 5;
+    const { durationMs, result } = await measureMedianDurationMs(SAMPLE_COUNT, executeStressRun);
+    assert.equal(result.summaries.length, 1);
+    assert.equal(result.summaries[0]?.id, "namingConvention");
+    assert.equal(result.summaries[0]?.changed, false);
+    assert.ok(
+        durationMs <= ROOT_SELECTION_THRESHOLD_MS,
+        `Expected root-target namingConvention discovery to finish within ${ROOT_SELECTION_THRESHOLD_MS}ms, ` +
             `received ${durationMs.toFixed(2)}ms`
     );
 });


### PR DESCRIPTION
### Motivation
- Avoid expensive per-file target queries when the codemod is invoked for a whole-project selection and no local-scoped targets are being tracked. 

### Description
- Add `includesWholeProjectSelection` to detect when `targetPaths` represents a full-project selection. 
- Cache `tracksLocalTargets` from `requestedCategoriesMayContainLocalTargets` and use it to skip local-target collection when not needed. 
- When a whole-project selection is detected and local targets are not tracked, set `queryPaths` to an empty array and treat all `gmlFilePaths` as selected to avoid per-file `listNamingConventionTargets` queries. 
- Update performance test harness to allow injecting a naming-config, introduce `DEFAULT_LOCAL_VARIABLE_NAMING_CONFIG`, and add a new stress test `namingConvention full-project selection stays within the root-target discovery threshold` that asserts `listNamingConventionTargets` is invoked for the whole project and that discovery finishes within the allotted threshold. 

### Testing
- Ran the `src/refactor/test/naming-convention-performance.test.ts` suite which includes the small-scale, large-scale, and new full-project selection stress tests and all tests passed. 
- Measured durations for the added full-project discovery test and the large-scale stress test and observed they stayed within their configured thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04b1a6178832fa8d03f203d810ab6)