### PR TITLE
ci: approve pnpm build dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,8 @@ packages:
   - src/refactor
   - src/fixture-runner
   - src/mcp
+
+onlyBuiltDependencies:
+  - esbuild
+  - fast-folder-size
+  - unrs-resolver


### PR DESCRIPTION
## Summary

- Adds pnpm build-script approvals for `esbuild`, `fast-folder-size`, and `unrs-resolver` in `pnpm-workspace.yaml`.
- Fixes CI installs failing under pnpm 11 with `ERR_PNPM_IGNORED_BUILDS` before tests run.

## Notes

The failing action log showed `pnpm install --frozen-lockfile` completing dependency resolution, then failing because pnpm ignored those dependency build scripts and requested `pnpm approve-builds`.

## Testing

- Not run locally in this environment; change is limited to pnpm workspace install configuration.