### PR TITLE
ci: allow pnpm dependency builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,8 @@ onlyBuiltDependencies:
   - esbuild
   - fast-folder-size
   - unrs-resolver
+
+allowBuilds:
+  esbuild: true
+  fast-folder-size: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

- Keeps the existing `onlyBuiltDependencies` approvals.
- Adds the explicit `allowBuilds` map for `esbuild`, `fast-folder-size`, and `unrs-resolver` so pnpm 11 CI installs recognize the allowed build scripts.

## Notes

A follow-up workflow run still failed with `ERR_PNPM_IGNORED_BUILDS` after the workspace-level approvals were merged, so this adds the explicit allow map form as well.

The `pnpm link --global` PATH warning is separate from the hard install failure because the postinstall command already swallows it with `|| true`, but it remains noisy and can be cleaned up in a separate PR if desired.

## Testing

- Not run locally in this environment; config-only CI install fix.