### PR TITLE
ci: fix agent CLI install path

### DIFF
--- a/.github/workflows/minimax-invoke.yml
+++ b/.github/workflows/minimax-invoke.yml
@@ -28,8 +28,22 @@ jobs:
       pr_number: ${{ github.event.issue.number }}
       additional_context: ${{ github.event.comment.body }}
       agent: mini-max
-      agent_package: '@qwen-code/qwen-code@latest'
       openai_base_url: 'https://api.minimax.io/v1'
+      agent_setup_command: |
+        set -euo pipefail
+
+        pnpm_home="${RUNNER_TEMP}/pnpm-global"
+        mkdir -p "${pnpm_home}"
+        echo "PNPM_HOME=${pnpm_home}" >> "$GITHUB_ENV"
+        echo "${pnpm_home}" >> "$GITHUB_PATH"
+        export PNPM_HOME="${pnpm_home}"
+        export PATH="${PNPM_HOME}:${PATH}"
+
+        if ! command -v qwen >/dev/null 2>&1; then
+          pnpm add -g @qwen-code/qwen-code@latest
+        fi
+
+        qwen --version
       agent_command: |
         set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Installs the qwen CLI in the MiniMax workflow setup step.
- Sets PNPM_HOME to a runner temp directory and adds it to PATH before global install.
- Avoids the parent workflow checking for a mini-max executable when the command actually runs qwen.

## Testing

- Not run locally; workflow-only change.