### PR TITLE
chore: catalog eslint boundaries v6

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   "@eslint/js": "^10"
   "@types/node": "^25"
   eslint: "^10"
+  eslint-plugin-boundaries: "^6"
   prettier: "^3"
   typescript: "^6"
 


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-boundaries` to the root pnpm catalog pinned to the v6 major line.

## Notes

This is the dependency-side prerequisite for the ESLint boundaries v6 migration. The current `eslint.config.js` already uses `boundaries/dependencies`, which is the v6 rule name/config path that replaces the older `boundaries/element-types` style. The failing Action showed ESLint could not find `boundaries/dependencies`, which indicates the installed plugin was still resolving to a version without that rule.

## Follow-up needed

- Run `pnpm install` locally to refresh `pnpm-lock.yaml` for the v6 catalog entry.
- If any local package manifests still pin `eslint-plugin-boundaries` directly, change them to `catalog:` so the catalog version is actually used everywhere.
- Re-run `pnpm run lint:report` after the lockfile refresh.

I could not regenerate the pnpm lockfile from this environment because package installation requires registry access.