### PR TITLE
test: prevent lint test runner stalls

### DIFF
--- a/src/lint/package.json
+++ b/src/lint/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build:types": "tsc -b tsconfig.json",
     "clean:types": "rm -rf dist",
-    "test": "pnpm run build:types && node --test 'dist/test/**/*.test.js'"
+    "test": "pnpm run build:types && node --test --test-force-exit 'dist/test/**/*.test.js'"
   },
   "dependencies": {
     "@gmloop/core": "workspace:*",


### PR DESCRIPTION
## Summary

- Adds `--test-force-exit` to the `@gmloop/lint` workspace test command.
- Targets the observed stall after the lint rule tests complete, where the Node test process appears to remain alive after the last reported assertions.

## Diagnosis

The pasted log reaches the lint rule suite and prints successful completion through `no-unnecessary-string-interpolation preserves valid interpolation`. The next tests in the lint workspace are still lightweight/synchronous rule tests, so a 27+ minute stall is more consistent with a leaked active handle than with a single slow assertion.

The lint workspace also contains at least one integration-style rule test that constructs ESLint runtime machinery. If that leaves an active worker, timer, or file-system handle alive, Node's test runner can finish the visible tests but not exit. `--test-force-exit` is the intended Node test runner guard for that failure mode: it exits after tests complete instead of waiting forever on lingering handles.

## Notes

- This is intentionally scoped to `src/lint/package.json`, where the stalled tests are coming from.
- I attempted a more surgical replacement of the suspicious ESLint-based test with a lower-level `Linter.verifyAndFix` test, but the repository connector blocked that file replacement.
- This branch was created from the commit shown in the failing run; main has moved since then, so GitHub may require updating the branch before merge.

## Validation

Not run here; this environment cannot install and execute the repo test suite.