### PR TITLE
Fix malformed doc params for multiline defaults

### DIFF
--- a/src/lint/src/rules/gml/create-gml-rules.ts
+++ b/src/lint/src/rules/gml/create-gml-rules.ts
@@ -13,7 +13,7 @@ import { createNoUnnecessaryStringInterpolationRule } from "./rules/no-unnecessa
 import { createNormalizeBannerCommentsRule } from "./rules/normalize-banner-comments-rule.js";
 import { createNormalizeDataStructureAccessorsRule } from "./rules/normalize-data-structure-accessors-rule.js";
 import { createNormalizeDirectivesRule } from "./rules/normalize-directives-rule.js";
-import { createNormalizeDocCommentsRule } from "./rules/normalize-doc-comments-rule.js";
+import { createNormalizeDocCommentsRule } from "./rules/normalize-doc-comments-multiline-defaults-rule.js";
 import { createNormalizeOperatorAliasesRule } from "./rules/normalize-operator-aliases-rule.js";
 import { createOptimizeLogicalFlowRule } from "./rules/optimize-logical-flow-rule.js";
 import { createOptimizeMathExpressionsRule } from "./rules/optimize-math-expressions-rule.js";

--- a/src/lint/src/rules/gml/rules/normalize-doc-comments-multiline-defaults-rule.ts
+++ b/src/lint/src/rules/gml/rules/normalize-doc-comments-multiline-defaults-rule.ts
@@ -1,0 +1,84 @@
+import type { Rule } from "eslint";
+
+import type { GmlRuleDefinition } from "../index.js";
+import { createNormalizeDocCommentsRule as createUnsafeNormalizeDocCommentsRule } from "./normalize-doc-comments-rule.js";
+
+const malformedOptionalDefaultParamPattern = /^(\s*\/\/\/\s*@param(?:\s+\{[^}\r\n]+\})?\s+)\[([A-Za-z0-9_]+)=.*$/u;
+const docOrCodeLinePattern = /^\s*(?:(?:\/\/\/)|(?:function|var|static|if|for|while|repeat|switch|return)\b|[}])/u;
+
+function findMalformedParamDefaultCloseLine(lines: ReadonlyArray<string>, startIndex: number): number | null {
+    for (let index = startIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (docOrCodeLinePattern.test(line)) {
+            return null;
+        }
+
+        if (line.includes("]")) {
+            return index;
+        }
+    }
+
+    return null;
+}
+
+export function sanitizeDocCommentMultilineOptionalParamDefaults(text: string): string {
+    const lineEnding = text.includes("\r\n") ? "\r\n" : "\n";
+    const lines = text.split(/\r?\n/u);
+    const sanitizedLines: Array<string> = [];
+
+    for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        const malformedOptionalDefaultParamMatch = malformedOptionalDefaultParamPattern.exec(line);
+        if (!malformedOptionalDefaultParamMatch || line.includes("]")) {
+            sanitizedLines.push(line);
+            continue;
+        }
+
+        const closeLineIndex = findMalformedParamDefaultCloseLine(lines, index);
+        if (closeLineIndex === null) {
+            sanitizedLines.push(line);
+            continue;
+        }
+
+        sanitizedLines.push(`${malformedOptionalDefaultParamMatch[1]}[${malformedOptionalDefaultParamMatch[2]}]`);
+        index = closeLineIndex;
+    }
+
+    return sanitizedLines.join(lineEnding);
+}
+
+function createSanitizingContext(context: Rule.RuleContext): Rule.RuleContext {
+    return {
+        ...context,
+        report(payload: Parameters<Rule.RuleContext["report"]>[0]) {
+            if (typeof Reflect.get(payload, "fix") !== "function") {
+                context.report(payload);
+                return;
+            }
+
+            context.report({
+                ...payload,
+                fix(fixer: Rule.RuleFixer) {
+                    const sanitizingFixer = {
+                        ...fixer,
+                        replaceTextRange(range: Parameters<Rule.RuleFixer["replaceTextRange"]>[0], text: string) {
+                            return fixer.replaceTextRange(range, sanitizeDocCommentMultilineOptionalParamDefaults(text));
+                        }
+                    };
+
+                    return Reflect.get(payload, "fix")(sanitizingFixer);
+                }
+            });
+        }
+    } as Rule.RuleContext;
+}
+
+export function createNormalizeDocCommentsRule(definition: GmlRuleDefinition): Rule.RuleModule {
+    const baseRule = createUnsafeNormalizeDocCommentsRule(definition);
+    return Object.freeze({
+        ...baseRule,
+        create(context: Rule.RuleContext): Rule.RuleListener {
+            return baseRule.create(createSanitizingContext(context));
+        }
+    });
+}

--- a/src/lint/test/rules/normalize-doc-comments-multiline-defaults-rule.test.ts
+++ b/src/lint/test/rules/normalize-doc-comments-multiline-defaults-rule.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import * as LintWorkspace from "@gmloop/lint";
+
+import { runGmlRule } from "./rule-test-harness.js";
+
+function runNormalizeDocCommentsRule(code: string, programNode: Record<string, unknown>): string {
+    return runGmlRule({
+        rule: LintWorkspace.Lint.plugin.rules["normalize-doc-comments"],
+        code,
+        programNode
+    }).output;
+}
+
+function createProgramForMultilineDefaultFunction(code: string): Record<string, unknown> {
+    const functionStart = code.indexOf("function bake");
+    const matrixStart = code.indexOf("matrix =");
+    const matrixEnd = code.indexOf("), mask");
+    const maskStart = code.indexOf("mask = 0");
+    const maskEnd = code.indexOf(") {", maskStart);
+
+    assert.notEqual(functionStart, -1);
+    assert.notEqual(matrixStart, -1);
+    assert.notEqual(matrixEnd, -1);
+    assert.notEqual(maskStart, -1);
+    assert.notEqual(maskEnd, -1);
+
+    return {
+        type: "Program",
+        body: [
+            {
+                type: "FunctionDeclaration",
+                id: { type: "Identifier", name: "bake" },
+                params: [
+                    { type: "Identifier", name: "aab" },
+                    {
+                        type: "DefaultParameter",
+                        left: { type: "Identifier", name: "matrix" },
+                        range: [matrixStart, matrixEnd + 1]
+                    },
+                    {
+                        type: "DefaultParameter",
+                        left: { type: "Identifier", name: "mask" },
+                        range: [maskStart, maskEnd]
+                    }
+                ],
+                body: { type: "BlockStatement", body: [] },
+                range: [functionStart, code.length],
+                start: functionStart,
+                end: code.length
+            }
+        ]
+    };
+}
+
+void test("normalize-doc-comments omits multiline default values from generated @param tags", () => {
+    const input = [
+        "function bake(aab, matrix = matrix_build_identity(",
+        "), mask = 0) {",
+        "    return matrix;",
+        "}"
+    ].join("\n");
+
+    const output = runNormalizeDocCommentsRule(input, createProgramForMultilineDefaultFunction(input));
+
+    assert.match(output, /^\/\/\/ @param aab$/m);
+    assert.match(output, /^\/\/\/ @param \[matrix\]$/m);
+    assert.match(output, /^\/\/\/ @param \[mask=0\]$/m);
+    assert.doesNotMatch(output, /^\/\/\/ @param \[matrix=matrix_build_identity\($/m);
+    assert.doesNotMatch(output, /^\)\]$/m);
+});


### PR DESCRIPTION
## Summary

- Reproduces the malformed `normalize-doc-comments` fix output for a function parameter whose default value spans multiple source lines.
- Adds a regression test that asserts the generated doc block uses `@param [matrix]` instead of emitting a multi-line optional default like `@param [matrix=matrix_build_identity(` followed by a bare `)]` line.
- Routes the `normalize-doc-comments` rule through a small sanitizer wrapper that removes unsafe multi-line optional defaults from generated doc-comment replacement text while preserving normal single-line defaults such as `[mask=0]`.

## TDD order

1. `test(lint): reproduce malformed multiline default doc params`
2. `fix(lint): route doc comment normalization through multiline default guard`
3. `fix(lint): guard doc comment defaults spanning lines`

## Validation

- Verified the branch diff against `main`: 3 commits, 3 files changed.
- I did not run the full package test suite locally from this connector-only environment; CI should run the lint package tests.