### PR TITLE
Agent: Tune Overly Specific Behavior

### DIFF
--- a/src/cli/src/modules/game-maker-cli/catalog.ts
+++ b/src/cli/src/modules/game-maker-cli/catalog.ts
@@ -126,12 +126,14 @@ export function createGameMakerCliInvocationPlan(
     toolPath: string | null,
     forwardedArguments: ReadonlyArray<string>
 ): ReadonlyArray<GameMakerCliInvocation> {
-    if (toolPath !== null) {
+    const normalizedToolPath = normalizeConfiguredToolPath(toolPath);
+
+    if (normalizedToolPath !== null) {
         return [
             Object.freeze({
                 args: [...forwardedArguments],
-                command: toolPath,
-                displayName: toolPath
+                command: normalizedToolPath,
+                displayName: normalizedToolPath
             })
         ];
     }
@@ -148,6 +150,15 @@ export function createGameMakerCliInvocationPlan(
             displayName: "npx @gamemaker/gm-cli@latest"
         })
     ];
+}
+
+function normalizeConfiguredToolPath(toolPath: string | null): string | null {
+    if (toolPath === null) {
+        return null;
+    }
+
+    const trimmedToolPath = toolPath.trim();
+    return trimmedToolPath.length > 0 ? trimmedToolPath : null;
 }
 
 /**

--- a/src/cli/test/game-maker-cli-catalog.test.ts
+++ b/src/cli/test/game-maker-cli-catalog.test.ts
@@ -19,3 +19,20 @@ void test("createGameMakerCliInvocationPlan falls back to npx latest when no exp
         }
     ]);
 });
+
+void test("createGameMakerCliInvocationPlan treats blank tool path values as unconfigured", () => {
+    const plan = createGameMakerCliInvocationPlan("   ", ["--help"]);
+
+    assert.deepEqual(plan, [
+        {
+            args: ["--help"],
+            command: "gm-cli",
+            displayName: "gm-cli"
+        },
+        {
+            args: ["--yes", "@gamemaker/gm-cli@latest", "--help"],
+            command: "npx",
+            displayName: "npx @gamemaker/gm-cli@latest"
+        }
+    ]);
+});


### PR DESCRIPTION
Generalizes an overly specific CLI invocation behavior so valid configured inputs are handled more robustly without changing public APIs.

### What changed

- Updated `createGameMakerCliInvocationPlan` in `src/cli/src/modules/game-maker-cli/catalog.ts` to normalize configured `toolPath` values.
- Whitespace-only `toolPath` values are now treated as unconfigured (same behavior as `null`), so the existing fallback invocation plan is used instead of attempting to execute a blank command.
- Added coverage in `src/cli/test/game-maker-cli-catalog.test.ts` with a new test:
  - `createGameMakerCliInvocationPlan treats blank tool path values as unconfigured`

### Why

The previous implementation effectively assumed any non-`null` string was a valid executable path, which was overly narrow for realistic configuration input (for example, blank values after trimming).

### Validation

- `pnpm run build:ts` ✅
- `pnpm run lint:quiet` ✅
- Targeted CLI catalog test ✅