### PR TITLE
Fix validate project machine-readable failures

### DIFF
--- a/src/cli/src/commands/validate.ts
+++ b/src/cli/src/commands/validate.ts
@@ -1,4 +1,5 @@
 import { lstat } from "node:fs/promises";
+import path from "node:path";
 
 import { Core } from "@gmloop/core";
 import * as ParserWorkspace from "@gmloop/parser";
@@ -20,6 +21,29 @@ type ValidateSharedOptions = Readonly<{
     toolsetRoot?: string;
 }>;
 
+type ValidateScope = "file" | "project" | "resource" | "room";
+
+async function runValidateAction(
+    scope: ValidateScope,
+    options: ValidateSharedOptions,
+    action: () => Promise<void>
+): Promise<void> {
+    try {
+        await action();
+    } catch (error) {
+        if (options.json !== true) {
+            throw error;
+        }
+
+        printProjectPayload({
+            error: { message: Core.getErrorMessage(error) },
+            ok: false,
+            scope
+        });
+        process.exitCode = 1;
+    }
+}
+
 async function runValidateFileAction(targetPath: string, options: ValidateSharedOptions): Promise<void> {
     const sourceText = await Core.readTextFile(targetPath);
     const ast = ParserWorkspace.Parser.GMLParser.parse(sourceText);
@@ -40,6 +64,7 @@ async function runValidateFileAction(targetPath: string, options: ValidateShared
 
 async function runValidateProjectAction(options: ValidateSharedOptions): Promise<void> {
     const context = await resolveCommandProjectContext(options);
+    await requireGameMakerProjectRoot(context.projectRoot);
     const graphIndex = await Semantic.buildGraphIndex({
         databasePath: options.databasePath,
         projectConfig: context.projectConfig,
@@ -127,6 +152,23 @@ async function requireReadableFilePath(filePath: string): Promise<void> {
     }
 }
 
+async function requireGameMakerProjectRoot(projectRoot: string): Promise<void> {
+    const projectRootStats = await lstat(projectRoot).catch(() => {
+        throw new Error(`GameMaker project directory does not exist: ${projectRoot}`);
+    });
+
+    if (!projectRootStats.isDirectory()) {
+        throw new Error(`Expected GameMaker project directory, received non-directory target: ${projectRoot}`);
+    }
+
+    const discoveredProjectRoot = await Semantic.findProjectRoot({
+        filepath: path.join(projectRoot, "gmloop.json")
+    });
+    if (!discoveredProjectRoot || path.resolve(discoveredProjectRoot) !== path.resolve(projectRoot)) {
+        throw new Error(`Could not find a .yyp manifest in GameMaker project directory: ${projectRoot}`);
+    }
+}
+
 export function createValidateCommand(): Command {
     const command = applyStandardCommandOptions(new Command("validate")).description(
         "Validate file/project/room/resource targets for parser and graph integrity."
@@ -138,8 +180,11 @@ export function createValidateCommand(): Command {
             .argument("<target>", "Path to a .gml file.")
     );
     file.action(async function validateFileAction(targetPath: string) {
-        await requireReadableFilePath(targetPath);
-        await runValidateFileAction(targetPath, this.opts<ValidateSharedOptions>());
+        const options = this.opts<ValidateSharedOptions>();
+        await runValidateAction("file", options, async () => {
+            await requireReadableFilePath(targetPath);
+            await runValidateFileAction(targetPath, options);
+        });
     });
 
     const project = addValidateSharedOptions(
@@ -148,7 +193,8 @@ export function createValidateCommand(): Command {
         )
     );
     project.action(async function validateProjectAction() {
-        await runValidateProjectAction(this.opts<ValidateSharedOptions>());
+        const options = this.opts<ValidateSharedOptions>();
+        await runValidateAction("project", options, () => runValidateProjectAction(options));
     });
 
     const room = addValidateSharedOptions(
@@ -157,7 +203,8 @@ export function createValidateCommand(): Command {
             .argument("<room>", "Room name or graph identifier.")
     );
     room.action(async function validateRoomAction(roomNameOrId: string) {
-        await runValidateRoomAction(roomNameOrId, this.opts<ValidateSharedOptions>());
+        const options = this.opts<ValidateSharedOptions>();
+        await runValidateAction("room", options, () => runValidateRoomAction(roomNameOrId, options));
     });
 
     const resource = addValidateSharedOptions(
@@ -166,7 +213,8 @@ export function createValidateCommand(): Command {
             .argument("<resource>", "Resource name or graph identifier.")
     );
     resource.action(async function validateResourceAction(resourceNameOrId: string) {
-        await runValidateResourceAction(resourceNameOrId, this.opts<ValidateSharedOptions>());
+        const options = this.opts<ValidateSharedOptions>();
+        await runValidateAction("resource", options, () => runValidateResourceAction(resourceNameOrId, options));
     });
 
     command.addCommand(file);

--- a/src/cli/test/validate-command.test.ts
+++ b/src/cli/test/validate-command.test.ts
@@ -1,10 +1,25 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { runCliTestCommand } from "../src/cli.js";
+
+const cliEntrypoint = fileURLToPath(new URL("../index.js", import.meta.url));
+
+function runValidateCli(args: ReadonlyArray<string>): { exitCode: number; stderr: string; stdout: string } {
+    const result = spawnSync(process.execPath, ["--disable-warning=ExperimentalWarning", cliEntrypoint, ...args], {
+        encoding: "utf8"
+    });
+    return {
+        exitCode: result.status ?? 1,
+        stderr: result.stderr,
+        stdout: result.stdout
+    };
+}
 
 async function withTempDir<T>(callback: (dir: string) => Promise<T>): Promise<T> {
     const dir = await mkdtemp(path.join(os.tmpdir(), "gmloop-validate-"));
@@ -57,4 +72,70 @@ void test("validate file accepts kind/scope/fix options", async () => {
         assert.equal(payload.payload.scope, "syntax");
         assert.equal(payload.payload.fixApplied, false);
     });
+});
+
+void test("validate project rejects a missing project directory with JSON output", async () => {
+    const missingProjectRoot = path.join(
+        os.tmpdir(),
+        `gmloop-missing-project-${String(process.pid)}-${String(Date.now())}`
+    );
+    const result = runValidateCli(["validate", "project", "--path", missingProjectRoot, "--json"]);
+
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stderr, "");
+    const payload = JSON.parse(result.stdout) as {
+        error: { message: string };
+        ok: boolean;
+        scope: string;
+    };
+    assert.equal(payload.ok, false);
+    assert.equal(payload.scope, "project");
+    assert.match(payload.error.message, /project directory does not exist/i);
+});
+
+void test("validate project rejects a directory without a .yyp manifest", async () => {
+    await withTempDir(async (projectRoot) => {
+        const result = runValidateCli(["validate", "project", "--path", projectRoot, "--json"]);
+
+        assert.equal(result.exitCode, 1);
+        assert.equal(result.stderr, "");
+        const payload = JSON.parse(result.stdout) as {
+            error: { message: string };
+            ok: boolean;
+            scope: string;
+        };
+        assert.equal(payload.ok, false);
+        assert.equal(payload.scope, "project");
+        assert.match(payload.error.message, /\.yyp manifest/i);
+    });
+});
+
+void test("validate project accepts a directory with a .yyp manifest", async () => {
+    await withTempDir(async (projectRoot) => {
+        await writeFile(path.join(projectRoot, "Example.yyp"), JSON.stringify({ resources: [] }), "utf8");
+        const result = await runCliTestCommand({
+            argv: ["validate", "project", "--path", projectRoot, "--json"]
+        });
+
+        assert.equal(result.exitCode, 0);
+        const payload = JSON.parse(result.stdout) as { ok: boolean; scope: string };
+        assert.equal(payload.ok, true);
+        assert.equal(payload.scope, "project");
+    });
+});
+
+void test("validate file emits JSON failures when --json is requested", async () => {
+    const missingFile = path.join(os.tmpdir(), `gmloop-missing-file-${String(process.pid)}-${String(Date.now())}.gml`);
+    const result = runValidateCli(["validate", "file", missingFile, "--json"]);
+
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stderr, "");
+    const payload = JSON.parse(result.stdout) as {
+        error: { message: string };
+        ok: boolean;
+        scope: string;
+    };
+    assert.equal(payload.ok, false);
+    assert.equal(payload.scope, "file");
+    assert.match(payload.error.message, /ENOENT|no such file/i);
 });


### PR DESCRIPTION
## What changed

- reject missing or non-GameMaker roots in `validate project`
- require a `.yyp` manifest at the validated project root
- emit parseable `{ ok: false, error, scope }` JSON with exit code 1 when `validate ... --json` fails
- preserve the existing human-readable error path when `--json` is not requested

## Why

`gmloop validate project --path <missing-path> --json` previously exited 0 and reported `ok: true` with a synthetic project graph. Integrations could therefore claim that a nonexistent GameMaker project passed verification. Thrown failures also escaped through the human CLI error renderer even when callers requested JSON.

## Validation

- TypeScript CLI build
- focused validate command suite: 7/7 passing
- Prettier check
- ESLint quiet check

The complete CLI suite was also attempted on Windows. It reaches unrelated existing failures involving POSIX path assertions, symlink privileges, performance thresholds, and agent-pack resource lookup; the focused suite covering this change is green.
