### PR TITLE
Emit valid JSON for empty lint targets

### DIFF
--- a/src/cli/src/commands/lint.ts
+++ b/src/cli/src/commands/lint.ts
@@ -1497,6 +1497,9 @@ export async function runLintCommand(command: CommanderCommandLike): Promise<voi
         await warnOverlayWithoutLanguageWiringIfNeeded({ eslint, results, quiet: options.quiet });
 
         if (results.length === 0) {
+            if (options.formatter === "json") {
+                process.stdout.write("[]\n");
+            }
             emitNoLintableFilesMessage(targets);
             setProcessExitCode(0);
             return;

--- a/src/cli/test/lint-command-definition.test.ts
+++ b/src/cli/test/lint-command-definition.test.ts
@@ -66,6 +66,24 @@ void test("lint reports when no .gml files are found in the provided path", asyn
     }
 });
 
+void test("lint emits an empty JSON array when no .gml files are found", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-empty-json-"));
+
+    try {
+        await writeFile(path.join(temporaryDirectory, "readme.txt"), "not gml\n", "utf8");
+
+        const result = await runCliTestCommand({
+            argv: ["lint", "--formatter", "json", "--no-default-config", temporaryDirectory]
+        });
+
+        assert.equal(result.exitCode, 0);
+        assert.deepEqual(JSON.parse(result.stdout), []);
+        assert.match(result.stderr, /No \.gml files were linted in/);
+    } finally {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+});
+
 void test("lint prints a clean-run summary when all files pass with no diagnostics", async () => {
     const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "gmloop-cli-lint-clean-"));
 


### PR DESCRIPTION
## What changed

When `lint --formatter json` finds no GML files, emit `[]` on stdout before returning successfully. Existing human guidance remains on stderr.

## Why

The empty-target path returned before loading the requested formatter, so JSON consumers received an empty string despite exit code 0. Integrations then had to treat a successful lint run as malformed output.

## Validation

- TypeScript CLI build
- lint command suite: 18/18 passing
- Prettier
- ESLint quiet check
