### PR TITLE
Fix live-reload session registry cleanup

### DIFF
--- a/src/cli/src/commands/watch.ts
+++ b/src/cli/src/commands/watch.ts
@@ -27,6 +27,7 @@ import { createStatusUrl, createWebSocketUrl, DEFAULT_GM_TEMP_ROOT } from "../mo
 import { prepareLiveReload } from "../modules/live-reload/session.js";
 import {
     type LiveReloadRegisteredSession,
+    removeLiveReloadSessionRegistry,
     writeLiveReloadSessionRegistry
 } from "../modules/live-reload/session-registry.js";
 import {
@@ -784,9 +785,9 @@ async function writeLiveReloadSessionAfterStartup(
         statusServerController: StatusServerHandle | null;
         websocketServerController: PatchWebSocketServer | null;
     }>
-): Promise<void> {
+): Promise<LiveReloadRegisteredSession | null> {
     if (parameters.liveReloadSession === undefined || parameters.statusServerController === null) {
-        return;
+        return null;
     }
 
     const websocketUrl = parameters.websocketServerController?.url ?? "";
@@ -794,7 +795,7 @@ async function writeLiveReloadSessionAfterStartup(
     const websocketEndpoint = websocketUrl.length > 0 ? new URL(websocketUrl) : null;
     const statusEndpoint = new URL(statusUrl);
 
-    await writeLiveReloadSessionRegistry({
+    const session: LiveReloadRegisteredSession = {
         lastHeartbeatAt: Date.now(),
         processId: process.pid,
         projectRoot: parameters.liveReloadSession.projectRoot,
@@ -809,7 +810,9 @@ async function writeLiveReloadSessionAfterStartup(
         websocketPort: websocketEndpoint === null ? 0 : Number(websocketEndpoint.port),
         websocketUrl,
         yypPath: parameters.liveReloadSession.yypPath
-    });
+    };
+    await writeLiveReloadSessionRegistry(session);
+    return session;
 }
 
 /**
@@ -1082,7 +1085,7 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
         websocketServerController
     });
 
-    await writeLiveReloadSessionAfterStartup({
+    const registeredLiveReloadSession = await writeLiveReloadSessionAfterStartup({
         liveReloadSession,
         normalizedPath,
         runtimeServerController,
@@ -1152,6 +1155,20 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
             runtimeContext.debouncedHandlers.clear();
 
             displayTranspilationStatistics(runtimeContext, verbose, quiet);
+
+            if (registeredLiveReloadSession !== null) {
+                try {
+                    await removeLiveReloadSessionRegistry(
+                        registeredLiveReloadSession.projectRoot,
+                        registeredLiveReloadSession
+                    );
+                } catch (error) {
+                    const message = getErrorMessage(error, {
+                        fallback: "Unknown live-reload registry cleanup error"
+                    });
+                    console.error(`Failed to remove live-reload session registry: ${message}`);
+                }
+            }
 
             if (runtimeServerController) {
                 try {

--- a/src/cli/src/modules/live-reload/session-registry.ts
+++ b/src/cli/src/modules/live-reload/session-registry.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -129,12 +130,40 @@ export async function readLiveReloadSessionRegistry(registryPath: string): Promi
 
 export async function writeLiveReloadSessionRegistry(session: LiveReloadRegisteredSession): Promise<void> {
     const registryPath = path.join(session.projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH);
+    const temporaryPath = `${registryPath}.${process.pid}.${randomUUID()}.tmp`;
     await fs.mkdir(path.dirname(registryPath), { recursive: true });
-    await fs.writeFile(registryPath, `${JSON.stringify(session, null, 2)}\n`, "utf8");
+    try {
+        await fs.writeFile(temporaryPath, `${JSON.stringify(session, null, 2)}\n`, {
+            encoding: "utf8",
+            flag: "wx"
+        });
+        await fs.rename(temporaryPath, registryPath);
+    } finally {
+        await fs.rm(temporaryPath, { force: true });
+    }
 }
 
-export async function removeLiveReloadSessionRegistry(projectRoot: string): Promise<void> {
-    await fs.rm(path.join(projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH), { force: true });
+function isSameRegisteredSession(current: LiveReloadRegisteredSession, expected: LiveReloadRegisteredSession): boolean {
+    return (
+        current.processId === expected.processId &&
+        current.statusUrl === expected.statusUrl &&
+        current.watchedRoot === expected.watchedRoot
+    );
+}
+
+export async function removeLiveReloadSessionRegistry(
+    projectRoot: string,
+    expected?: LiveReloadRegisteredSession
+): Promise<boolean> {
+    const registryPath = path.join(projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH);
+    if (expected !== undefined) {
+        const current = await readLiveReloadSessionRegistry(registryPath);
+        if (current === null || !isSameRegisteredSession(current, expected)) {
+            return false;
+        }
+    }
+    await fs.rm(registryPath, { force: true });
+    return true;
 }
 
 async function fetchJsonWithTimeout(url: string): Promise<unknown> {
@@ -185,7 +214,7 @@ export async function discoverLiveReloadSessionByPath(
 
     const alive = await isLiveReloadRegisteredSessionAlive(session, options.fetchStatus);
     if (!alive) {
-        await removeLiveReloadSessionRegistry(identity.projectRoot);
+        await removeLiveReloadSessionRegistry(identity.projectRoot, session);
         return Object.freeze({ alive: false, registryPath: identity.registryPath, session: null });
     }
 

--- a/src/cli/test/live-reload-session-registry.test.ts
+++ b/src/cli/test/live-reload-session-registry.test.ts
@@ -1,14 +1,18 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
+import { runWatchCommand } from "../src/commands/watch.js";
 import { createStatusUrl, createWebSocketUrl } from "../src/modules/live-reload/config.js";
 import {
     discoverLiveReloadSessionByPath,
     LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH,
+    type LiveReloadRegisteredSession,
     readLiveReloadSessionRegistry,
+    removeLiveReloadSessionRegistry,
     resolveLiveReloadProjectIdentity,
     writeLiveReloadSessionRegistry
 } from "../src/modules/live-reload/session-registry.js";
@@ -72,7 +76,88 @@ void test("live-reload session registry round-trips endpoint metadata", async ()
         assert.equal(session?.statusUrl, "http://127.0.0.1:50001/status");
         assert.equal(session?.websocketUrl, "ws://127.0.0.1:50002");
         assert.equal(session?.startSource, "ui");
+        assert.deepEqual(await readdir(path.join(projectRoot, ".gmloop")), ["live-reload-session.json"]);
     } finally {
+        await rm(projectRoot, { recursive: true, force: true });
+    }
+});
+
+void test("live-reload registry cleanup does not remove a replacement session", async () => {
+    const projectRoot = await createTemporaryGameMakerProject();
+    const baseSession = {
+        lastHeartbeatAt: 123,
+        processId: 456,
+        projectRoot,
+        runtimeUrl: null,
+        startSource: "ui" as const,
+        status: "running" as const,
+        statusHost: "127.0.0.1",
+        statusPort: 50_001,
+        statusUrl: createStatusUrl("127.0.0.1", 50_001),
+        watchedRoot: projectRoot,
+        websocketHost: "127.0.0.1",
+        websocketPort: 50_002,
+        websocketUrl: createWebSocketUrl("127.0.0.1", 50_002),
+        yypPath: path.join(projectRoot, "Game.yyp")
+    };
+
+    try {
+        await writeLiveReloadSessionRegistry(baseSession);
+        const replacement = {
+            ...baseSession,
+            lastHeartbeatAt: 789,
+            processId: 999,
+            statusPort: 50_003,
+            statusUrl: createStatusUrl("127.0.0.1", 50_003)
+        };
+        await writeLiveReloadSessionRegistry(replacement);
+
+        assert.equal(await removeLiveReloadSessionRegistry(projectRoot, baseSession), false);
+        const retainedSession = await readLiveReloadSessionRegistry(
+            path.join(projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH)
+        );
+        assert.equal(retainedSession?.processId, 999);
+        assert.equal(await removeLiveReloadSessionRegistry(projectRoot, replacement), true);
+        assert.equal(
+            await readLiveReloadSessionRegistry(path.join(projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH)),
+            null
+        );
+    } finally {
+        await rm(projectRoot, { recursive: true, force: true });
+    }
+});
+
+void test("live-reload watcher cleanup removes its own registry entry", async () => {
+    const projectRoot = await createTemporaryGameMakerProject();
+    const abortController = new AbortController();
+    const registryPath = path.join(projectRoot, LIVE_RELOAD_SESSION_REGISTRY_RELATIVE_PATH);
+    const watchPromise = runWatchCommand(projectRoot, {
+        abortSignal: abortController.signal,
+        liveReloadSession: {
+            projectRoot,
+            startSource: "ui",
+            yypPath: path.join(projectRoot, "Game.yyp")
+        },
+        quiet: true,
+        runtimeServer: false,
+        statusPort: 0,
+        websocketPort: 0
+    });
+
+    try {
+        let session: LiveReloadRegisteredSession | null = null;
+        for (let attempt = 0; attempt < 100 && session === null; attempt += 1) {
+            session = await readLiveReloadSessionRegistry(registryPath);
+            if (session === null) await delay(20);
+        }
+        assert.notEqual(session, null, "watcher should register its live-reload session");
+
+        abortController.abort();
+        await watchPromise;
+        assert.equal(await readLiveReloadSessionRegistry(registryPath), null);
+    } finally {
+        abortController.abort();
+        await watchPromise.catch(() => undefined);
         await rm(projectRoot, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
## Summary

- write live-reload session registries through an atomic temporary-file rename
- remove stale entries only when they still match the session that was inspected
- remove a watcher's own registry entry during normal abort/signal cleanup
- preserve a replacement session owned by a newer process

## Why

The project-local registry could be observed while partially written, and clean watcher shutdown left a stale entry behind. Discovery or cleanup could also remove a newer replacement session after reading an older one.

## Validation

- CLI TypeScript project build: `tsc -b src/cli/tsconfig.json`
- focused registry tests: 6 passed, including a real loopback watcher cleanup
- focused ESLint with `--quiet`
- Prettier check