### PR TITLE
Add HTML5 live patch acknowledgements

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -757,6 +757,8 @@ pnpm run cli -- live-reload status --status-host 127.0.0.1 --status-port 18000
 
 Agents can also use `live-reload status` (for discovery/health checks) and `live-reload wait-for-patch` by project path. Through MCP these appear as `gmloop_live_reload_status` and `gmloop_live_reload_wait_for_patch`.
 
+For injected HTML5 runtimes, `live-reload wait-for-patch --require-applied` waits until the runtime wrapper acknowledges the exact new streamed revision. Pass `--since-revision <revision>` from a previous status snapshot to establish the baseline. The status payload exposes `lastPatchRevision`, `lastAppliedPatch`, and `appliedPatchClients`; an acknowledgement confirms that the wrapper committed the patch, not that a particular gameplay outcome occurred. Native runners and clients without the injected wrapper do not provide applied acknowledgements.
+
 **Example Output:**
 
 ```
@@ -1220,4 +1222,5 @@ Provides ANTLR-based GML parsing used by the transpiler.
     - Stores patches in runtime context for future streaming
 
 ## TODO
+
 - **FEAT**: If/when the UI is running and at the same time a "fix" command (e.g. refactor/format/lint-fix/etc.) is run via the CLI for that same, currently-opened-project (ex. `pnpm run cli -- refactor codemod --path /Users/henrykirk/Desktop/CannonFatherSource/cannonfather --only namingConvention`), the UI's "Fix" page/tab should show the progress of that command in real-time, the same way as if it were started via the UI. Similarly, running a "fix" workflow on a GameMaker project should lock/reserve it so that the user cannot start a new "fix" workflow in parallel until the current one is finished (should work across the UI & CLI, since the CLI can also start a fix workflow). This is to prevent multiple fix workflows from running in parallel and potentially conflicting with each other.

--- a/src/cli/src/commands/live-reload.ts
+++ b/src/cli/src/commands/live-reload.ts
@@ -110,7 +110,9 @@ interface LiveReloadPathCommandOptions {
 
 interface LiveReloadWaitForPatchCommandOptions extends LiveReloadPathCommandOptions {
     pollIntervalMs?: number;
+    requireApplied?: boolean;
     sincePatchId?: string;
+    sinceRevision?: string;
     timeoutMs?: number;
 }
 
@@ -313,12 +315,34 @@ function readLastPatchId(statusPayload: unknown): string | null {
     return typeof lastPatchId === "string" && lastPatchId.length > 0 ? lastPatchId : null;
 }
 
+function readLastPatchRevision(statusPayload: unknown): string | null {
+    if (!Core.isObjectLike(statusPayload)) {
+        return null;
+    }
+
+    const revision = (statusPayload as Record<string, unknown>).lastPatchRevision;
+    return typeof revision === "string" && revision.length > 0 ? revision : null;
+}
+
+function hasAppliedRevision(statusPayload: unknown, revision: string): boolean {
+    if (!Core.isObjectLike(statusPayload)) {
+        return false;
+    }
+    const status = statusPayload as Record<string, unknown>;
+    const appliedPatches = Core.toArray(status.appliedPatchClients);
+    return appliedPatches.some(
+        (patch) => Core.isObjectLike(patch) && (patch as Record<string, unknown>).revision === revision
+    );
+}
+
 async function pollLiveReloadStatusForPatch(
     parameters: Readonly<{
         deadline: number;
         pollIntervalMs: number;
+        requireApplied: boolean;
         session: LiveReloadRegisteredSession;
         sincePatchId: string | undefined;
+        sinceRevision: string | undefined;
     }>
 ): Promise<Record<string, unknown> | null> {
     if (Date.now() > parameters.deadline) {
@@ -336,9 +360,23 @@ async function pollLiveReloadStatusForPatch(
         // resolves the wait deterministically.
     }
 
-    const lastPatchId = statusPayload === null ? null : readLastPatchId(statusPayload);
-    if (lastPatchId !== null && lastPatchId !== parameters.sincePatchId) {
-        return statusPayload ?? {};
+    if (parameters.requireApplied && statusPayload !== null) {
+        if (!Object.hasOwn(statusPayload, "lastPatchRevision")) {
+            throw new Error("The active live-reload session does not support runtime-applied patch acknowledgements.");
+        }
+        const streamedRevision = readLastPatchRevision(statusPayload);
+        if (
+            streamedRevision !== null &&
+            streamedRevision !== parameters.sinceRevision &&
+            hasAppliedRevision(statusPayload, streamedRevision)
+        ) {
+            return statusPayload;
+        }
+    } else {
+        const latestPatchId = statusPayload === null ? null : readLastPatchId(statusPayload);
+        if (latestPatchId !== null && latestPatchId !== parameters.sincePatchId) {
+            return statusPayload ?? {};
+        }
     }
 
     const remainingMs = parameters.deadline - Date.now();
@@ -391,26 +429,38 @@ export async function runLiveReloadWaitForPatchCommand(
     }
 
     let sincePatchId = options.sincePatchId;
-    if (!sincePatchId) {
-        try {
-            const initialPayload = await fetchLiveReloadStatusPayload(discovery.session);
-            sincePatchId = readLastPatchId(initialPayload) ?? undefined;
-        } catch {
-            // Ignore baseline fetch error; will wait for any patch
-        }
-    }
-
-    const timeoutMs = options.timeoutMs ?? 10_000;
-    const pollIntervalMs = options.pollIntervalMs ?? 250;
-    const deadline = Date.now() + timeoutMs;
-
+    let sinceRevision = options.sinceRevision;
+    const requireApplied = options.requireApplied ?? false;
     let latestPayload: Record<string, unknown> | null = null;
     try {
+        if ((requireApplied && !sinceRevision) || (!requireApplied && !sincePatchId)) {
+            const initialPayload = await fetchLiveReloadStatusPayload(discovery.session);
+            if (requireApplied) {
+                if (
+                    !Core.isObjectLike(initialPayload) ||
+                    !Object.hasOwn(initialPayload as object, "lastPatchRevision")
+                ) {
+                    throw new Error(
+                        "The active live-reload session does not support runtime-applied patch acknowledgements."
+                    );
+                }
+                sinceRevision = readLastPatchRevision(initialPayload) ?? undefined;
+            } else {
+                sincePatchId = readLastPatchId(initialPayload) ?? undefined;
+            }
+        }
+
+        const timeoutMs = options.timeoutMs ?? 10_000;
+        const pollIntervalMs = options.pollIntervalMs ?? 250;
+        const deadline = Date.now() + timeoutMs;
+
         latestPayload = await pollLiveReloadStatusForPatch({
             deadline,
             pollIntervalMs,
+            requireApplied,
             session: discovery.session,
-            sincePatchId
+            sincePatchId,
+            sinceRevision
         });
     } catch (error) {
         const errorMessage = Core.getErrorMessage(error, {
@@ -427,6 +477,7 @@ export async function runLiveReloadWaitForPatchCommand(
         process.exit(1);
     }
 
+    const timeoutMs = options.timeoutMs ?? 10_000;
     if (latestPayload !== null) {
         console.log(
             JSON.stringify(
@@ -445,7 +496,7 @@ export async function runLiveReloadWaitForPatchCommand(
     const payload = {
         command: LIVE_RELOAD_WAIT_FOR_PATCH_COMMAND,
         ok: false,
-        error: `Timed out waiting for a live-reload patch after ${String(timeoutMs)}ms.`,
+        error: `Timed out waiting for a live-reload ${requireApplied ? "applied patch acknowledgement" : "patch"} after ${String(timeoutMs)}ms.`,
         code: "timeout"
     };
     console.log(JSON.stringify(payload, null, 2));
@@ -647,6 +698,8 @@ function createLiveReloadWaitForPatchSubcommand(): Command {
         .description("Wait until the registered live-reload session reports a new patch.")
         .addOption(new Option(PROJECT_PATH_OPTION_FLAG, PROJECT_PATH_OPTION_DESCRIPTION).default(process.cwd()))
         .addOption(new Option("--since-patch-id <id>", "Existing patch id to wait past."))
+        .addOption(new Option("--require-applied", "Wait for an HTML5 runtime-applied acknowledgement."))
+        .addOption(new Option("--since-revision <revision>", "Existing streamed revision to wait past."))
         .addOption(
             new Option("--timeout-ms <ms>", "Maximum wait time in milliseconds.")
                 .argParser(createMinimumValueValidator(1, "Timeout must be a positive integer."))

--- a/src/cli/src/commands/watch.ts
+++ b/src/cli/src/commands/watch.ts
@@ -65,7 +65,11 @@ import {
     resolveScriptFileNameFromSegments
 } from "../modules/transpilation/runtime-identifiers.js";
 import { extractReferencesFromAst, extractSymbolsFromAst } from "../modules/transpilation/symbol-extraction.js";
-import { type PatchWebSocketServer, startPatchWebSocketServer } from "../modules/websocket/server.js";
+import {
+    type PatchWebSocketServer,
+    startPatchWebSocketServer,
+    type StreamedPatchAcknowledgement
+} from "../modules/websocket/server.js";
 import {
     DEFAULT_TRANSIENT_EMPTY_FILE_READ_RETRY_COUNT,
     DEFAULT_TRANSIENT_EMPTY_FILE_READ_RETRY_DELAY_MS,
@@ -98,6 +102,11 @@ const { debounce, getErrorMessage, isErrorWithCode } = Core;
 const IGNORED_WATCH_DIRECTORY_NAMES = new Set(DEFAULT_WATCH_IGNORED_DIRECTORY_NAMES);
 
 type RuntimeDescriptorFormatter = (source: RuntimeSourceDescriptor) => string;
+
+interface AppliedPatchStatus extends StreamedPatchAcknowledgement {
+    clientId: string;
+    acknowledgedAt: number;
+}
 
 type WatchFactory = (
     path: string,
@@ -933,6 +942,8 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
     let websocketServerController: PatchWebSocketServer | null = null;
     let statusServerController: StatusServerHandle | null = null;
     let runtimeServerController: RuntimeStaticServerInstance | null = null;
+    const appliedPatchByClient = new Map<string, AppliedPatchStatus>();
+    let lastAppliedPatch: AppliedPatchStatus | null = null;
 
     const watchedFiles = await collectWatchedFilePaths(normalizedPath, extensionMatcher, maxConcurrentDirs);
     await Core.runInParallelWithLimit(
@@ -978,8 +989,30 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
                     ];
                 },
                 onClientDisconnect: (clientId) => {
+                    appliedPatchByClient.delete(clientId);
                     if (verbose) {
                         console.log(`Patch streaming client disconnected: ${clientId}`);
+                    }
+                },
+                onPatchAcknowledgement: (clientId, acknowledgement) => {
+                    const expectedPatch =
+                        runtimeContext.lastSuccessfulPatches.get(acknowledgement.id) ??
+                        runtimeContext.resourcePatches.get(acknowledgement.id);
+                    if (expectedPatch?.revision !== acknowledgement.revision) {
+                        return;
+                    }
+                    const previous = appliedPatchByClient.get(clientId);
+                    if (previous && previous.sequence >= acknowledgement.sequence) {
+                        return;
+                    }
+                    const appliedPatch = {
+                        ...acknowledgement,
+                        clientId,
+                        acknowledgedAt: Date.now()
+                    };
+                    appliedPatchByClient.set(clientId, appliedPatch);
+                    if (!lastAppliedPatch || lastAppliedPatch.sequence < appliedPatch.sequence) {
+                        lastAppliedPatch = appliedPatch;
                     }
                 }
             });
@@ -1012,6 +1045,7 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
                         error: e.error
                     }));
                     const lastMetric = runtimeContext.metrics.at(-1) ?? null;
+                    const lastStreamedPatch = websocketServerController?.getLastStreamedPatch() ?? null;
                     return {
                         uptime: Date.now() - runtimeContext.startTime,
                         patchCount: runtimeContext.metrics.length,
@@ -1037,8 +1071,11 @@ export async function runWatchCommand(targetPath: string, options: WatchCommandO
                         watchedRoot: normalizedPath,
                         lastChangedFile:
                             lastMetric === null ? null : path.relative(normalizedPath, lastMetric.filePath),
-                        lastPatchId: lastMetric?.patchId ?? null,
+                        lastPatchId: lastStreamedPatch?.id ?? lastMetric?.patchId ?? null,
+                        lastPatchRevision: lastStreamedPatch?.revision ?? null,
                         lastPatchResult: lastMetric?.patchResult ?? null,
+                        lastAppliedPatch,
+                        appliedPatchClients: Array.from(appliedPatchByClient.values()),
                         transpileErrors: recentErrors,
                         runtimeErrors: [],
                         avgHotReloadLatencyMs: latencyStats?.avg,

--- a/src/cli/src/modules/status/server.ts
+++ b/src/cli/src/modules/status/server.ts
@@ -16,6 +16,17 @@ import {
     evaluateTranspilationHealth
 } from "./status-health-policy.js";
 
+interface AppliedPatchSnapshot {
+    id: string;
+    revision: string;
+    sequence: number;
+    status: "applied";
+    type: "patch_ack";
+    clientId: string;
+    acknowledgedAt: number;
+    runtimeVersion?: number;
+}
+
 export interface StatusSnapshot {
     uptime: number;
     /** Number of patches in the bounded metrics window (capped at maxPatchHistory). */
@@ -57,6 +68,9 @@ export interface StatusSnapshot {
     websocketUrl?: string;
     lastChangedFile?: string | null;
     lastPatchId?: string | null;
+    lastPatchRevision?: string | null;
+    lastAppliedPatch?: AppliedPatchSnapshot | null;
+    appliedPatchClients?: Array<AppliedPatchSnapshot>;
     lastPatchResult?: {
         delivered: boolean;
         failureCount: number;

--- a/src/cli/src/modules/transpilation/coordinator.ts
+++ b/src/cli/src/modules/transpilation/coordinator.ts
@@ -6,6 +6,7 @@
  * file change detection and WebSocket patch streaming.
  */
 
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import { Core } from "@gmloop/core";
@@ -34,9 +35,10 @@ const defaultParserAdapter: GmlParserAdapter = createGmlParserAdapter();
 
 type RuntimeTranspiler = GmlTranspilerInstance;
 type GmlTranspilerInstance = ReturnType<typeof createGmlTranspilerAdapter>;
-export type RuntimeTranspilerPatch =
+export type RuntimeTranspilerPatch = (
     | ReturnType<GmlTranspilerInstance["transpileScript"]>
-    | ReturnType<GmlTranspilerInstance["transpileEvent"]>;
+    | ReturnType<GmlTranspilerInstance["transpileEvent"]>
+) & { revision?: string };
 
 export interface ResourceLayerUpdate {
     layerName: string;
@@ -47,6 +49,7 @@ export interface ResourceLayerUpdate {
 export interface ResourcePatch {
     kind: "resource";
     id: string;
+    revision: string;
     resourceType: "GMRoom";
     resourceName: string;
     layerUpdates: Array<ResourceLayerUpdate>;
@@ -63,6 +66,7 @@ export function createResourcePatch(
     return {
         kind: "resource",
         id: `resource/room/${resourceName}`,
+        revision: randomUUID(),
         resourceType: "GMRoom",
         resourceName,
         layerUpdates,
@@ -774,8 +778,10 @@ export function transpileFile(
         );
         const previousPatch = context.lastSuccessfulPatches.get(patchPayload.id);
         const runtimePatchChanged = hasRuntimePatchChanged(previousPatch, patchPayload);
+        const revision = runtimePatchChanged || !previousPatch?.revision ? randomUUID() : previousPatch.revision;
+        const identifiedPatchPayload: RuntimeTranspilerPatch = { ...patchPayload, revision };
 
-        context.lastSuccessfulPatches.set(patchPayload.id, patchPayload);
+        context.lastSuccessfulPatches.set(patchPayload.id, identifiedPatchPayload);
 
         let patchIdsForSource = context.sourcePathToPatchIds.get(filePath);
         if (!patchIdsForSource) {
@@ -784,10 +790,14 @@ export function transpileFile(
         }
         patchIdsForSource.add(patchPayload.id);
         if (runtimePatchChanged) {
-            addToBoundedCollection(context.patches, createPatchSummary(patchPayload), context.bounds.maxEntries);
+            addToBoundedCollection(
+                context.patches,
+                createPatchSummary(identifiedPatchPayload),
+                context.bounds.maxEntries
+            );
             context.totalPatchCount += 1;
 
-            const broadcastResult = context.websocketServer?.broadcast(patchPayload);
+            const broadcastResult = context.websocketServer?.broadcast(identifiedPatchPayload);
 
             // Record end-to-end hot-reload latency after the patch has been broadcast.
             // This captures the full pipeline delay (file-change detection → broadcast)
@@ -845,7 +855,7 @@ export function transpileFile(
 
         return {
             success: true,
-            patch: patchPayload,
+            patch: identifiedPatchPayload,
             metrics,
             symbols: parsedSymbols,
             references: parsedReferences

--- a/src/cli/src/modules/websocket/server.ts
+++ b/src/cli/src/modules/websocket/server.ts
@@ -18,13 +18,37 @@ const DEFAULT_PORT = 17_890;
 
 const describeWebSocketError = Core.getErrorMessage;
 
+function acknowledgementKey(id: string, revision: string): string {
+    return `${id}\u0000${revision}`;
+}
+
 export interface PatchWebSocketServerOptions {
     host?: string;
     port?: number;
     verbose?: boolean;
     onClientConnect?: (clientId: string, socket: WebSocket) => void;
     onClientDisconnect?: (clientId: string) => void;
+    onPatchAcknowledgement?: (clientId: string, acknowledgement: StreamedPatchAcknowledgement) => void;
     prepareInitialMessages?: () => Iterable<unknown>;
+}
+
+/** Validated browser-runtime confirmation for one applied patch revision. */
+export interface PatchAppliedAcknowledgement {
+    type: "patch_ack";
+    id: string;
+    revision: string;
+    status: "applied";
+    runtimeVersion?: number;
+}
+
+export interface StreamedPatchRevision {
+    id: string;
+    revision: string;
+    sequence: number;
+}
+
+export interface StreamedPatchAcknowledgement extends PatchAppliedAcknowledgement {
+    sequence: number;
 }
 
 export interface PatchBroadcastResult {
@@ -42,6 +66,7 @@ export interface PatchBroadcastResult {
 export interface PatchBroadcaster {
     broadcast(patch: unknown): PatchBroadcastResult;
     getClientCount(): number;
+    getLastStreamedPatch(): StreamedPatchRevision | null;
 }
 
 /**
@@ -80,10 +105,15 @@ export async function startPatchWebSocketServer({
     verbose = false,
     onClientConnect,
     onClientDisconnect,
+    onPatchAcknowledgement,
     prepareInitialMessages
 }: PatchWebSocketServerOptions = {}): Promise<PatchWebSocketServer> {
     const clients = new Set<WebSocket>();
     const clientIds = new Map<WebSocket, string>();
+    const pendingAcknowledgements = new Map<WebSocket, Map<string, StreamedPatchRevision>>();
+    const streamedPatchById = new Map<string, StreamedPatchRevision>();
+    let patchSequence = 0;
+    let lastStreamedPatch: StreamedPatchRevision | null = null;
 
     const wss = new WebSocketServer({
         host,
@@ -99,6 +129,57 @@ export async function startPatchWebSocketServer({
     });
 
     const READY_STATE_OPEN = 1;
+
+    function streamedPatchRevisions(payload: unknown): Array<Omit<StreamedPatchRevision, "sequence">> {
+        const revisions: Array<Omit<StreamedPatchRevision, "sequence">> = [];
+        for (const item of Core.toArray(payload)) {
+            if (!Core.isObjectLike(item)) {
+                continue;
+            }
+            const patch = item as Record<string, unknown>;
+            if (Core.isNonEmptyString(patch.id) && Core.isNonEmptyString(patch.revision)) {
+                revisions.push({ id: patch.id, revision: patch.revision });
+            }
+        }
+        return revisions;
+    }
+
+    function recordDeliveredPatches(ws: WebSocket, patches: Array<StreamedPatchRevision>): void {
+        const pending = pendingAcknowledgements.get(ws);
+        if (!pending) {
+            return;
+        }
+        for (const patch of patches) {
+            pending.set(acknowledgementKey(patch.id, patch.revision), patch);
+        }
+        while (pending.size > 1000) {
+            const oldestKey = pending.keys().next().value;
+            if (typeof oldestKey !== "string") {
+                break;
+            }
+            pending.delete(oldestKey);
+        }
+    }
+
+    function identifyStreamedPatches(payload: unknown): Array<StreamedPatchRevision> {
+        return streamedPatchRevisions(payload).map((patch) => {
+            const current = streamedPatchById.get(patch.id);
+            if (current?.revision === patch.revision) {
+                return current;
+            }
+            const streamedPatch = { ...patch, sequence: ++patchSequence };
+            streamedPatchById.set(patch.id, streamedPatch);
+            return streamedPatch;
+        });
+    }
+
+    function recordLatestStreamedPatch(patches: Array<StreamedPatchRevision>): void {
+        for (const patch of patches) {
+            if (!lastStreamedPatch || lastStreamedPatch.sequence < patch.sequence) {
+                lastStreamedPatch = patch;
+            }
+        }
+    }
 
     function sendJsonMessage(ws: WebSocket, payload: unknown, clientId: string): boolean {
         try {
@@ -123,6 +204,7 @@ export async function startPatchWebSocketServer({
 
         clients.add(ws);
         clientIds.set(ws, clientId);
+        pendingAcknowledgements.set(ws, new Map());
 
         if (verbose) {
             console.log(`[WebSocket] Client connected: ${clientId}`);
@@ -136,10 +218,16 @@ export async function startPatchWebSocketServer({
             try {
                 const replayPayloads = Array.from(prepareInitialMessages());
                 const replayPayload = replayPayloads.length === 1 ? replayPayloads[0] : replayPayloads;
+                const replayPatches = identifyStreamedPatches(replayPayload);
                 const replayedCount =
                     replayPayloads.length > 0 && sendJsonMessage(ws, replayPayload, clientId)
                         ? replayPayloads.length
                         : 0;
+
+                if (replayedCount > 0) {
+                    recordDeliveredPatches(ws, replayPatches);
+                    recordLatestStreamedPatch(replayPatches);
+                }
 
                 if (verbose && replayedCount > 0) {
                     console.log(`[WebSocket] Sent ${replayedCount} queued message(s) to ${clientId}`);
@@ -153,6 +241,39 @@ export async function startPatchWebSocketServer({
             }
         }
 
+        ws.on("message", (data) => {
+            let payload: unknown;
+            try {
+                payload = JSON.parse(data.toString());
+            } catch (error) {
+                if (verbose) {
+                    console.error(
+                        `[WebSocket] Ignored malformed client message (${clientId}): ${describeWebSocketError(error)}`
+                    );
+                }
+                return;
+            }
+
+            const acknowledgement = parsePatchAppliedAcknowledgement(payload);
+            if (acknowledgement) {
+                const deliveredPatch = pendingAcknowledgements
+                    .get(ws)
+                    ?.get(acknowledgementKey(acknowledgement.id, acknowledgement.revision));
+                if (!deliveredPatch) {
+                    if (verbose) {
+                        console.error(`[WebSocket] Ignored acknowledgement for an undelivered patch (${clientId})`);
+                    }
+                    return;
+                }
+                pendingAcknowledgements
+                    .get(ws)
+                    ?.delete(acknowledgementKey(acknowledgement.id, acknowledgement.revision));
+                onPatchAcknowledgement?.(clientId, { ...acknowledgement, sequence: deliveredPatch.sequence });
+            } else if (verbose) {
+                console.error(`[WebSocket] Ignored unsupported client message (${clientId})`);
+            }
+        });
+
         let cleanedUp = false;
         const cleanupClient = (reason: "close" | "error", error?: unknown) => {
             if (cleanedUp) {
@@ -162,6 +283,7 @@ export async function startPatchWebSocketServer({
 
             clients.delete(ws);
             clientIds.delete(ws);
+            pendingAcknowledgements.delete(ws);
 
             if (verbose) {
                 if (reason === "error") {
@@ -234,6 +356,9 @@ export async function startPatchWebSocketServer({
             return { successCount: 0, failureCount: clients.size, totalClients: clients.size };
         }
 
+        const streamedPatches = identifyStreamedPatches(patch);
+        recordLatestStreamedPatch(streamedPatches);
+
         for (const ws of clients) {
             try {
                 if (ws.readyState !== READY_STATE_OPEN) {
@@ -242,6 +367,7 @@ export async function startPatchWebSocketServer({
                 }
 
                 ws.send(serializedMessage);
+                recordDeliveredPatches(ws, streamedPatches);
                 successCount += 1;
             } catch (error) {
                 failureCount += 1;
@@ -312,6 +438,46 @@ export async function startPatchWebSocketServer({
         port: resolvedPort,
         broadcast,
         stop,
-        getClientCount: () => clients.size
+        getClientCount: () => clients.size,
+        getLastStreamedPatch: () => lastStreamedPatch
+    };
+}
+
+function parsePatchAppliedAcknowledgement(payload: unknown): PatchAppliedAcknowledgement | null {
+    if (!Core.isObjectLike(payload)) {
+        return null;
+    }
+
+    const message = payload as Record<string, unknown>;
+    if (
+        message.type !== "patch_ack" ||
+        message.status !== "applied" ||
+        !Core.isNonEmptyString(message.id) ||
+        message.id.length > 512 ||
+        !Core.isNonEmptyString(message.revision) ||
+        message.revision.length > 512
+    ) {
+        return null;
+    }
+
+    const runtimeVersion = message.runtimeVersion;
+    if (runtimeVersion === undefined) {
+        return {
+            type: "patch_ack",
+            id: message.id,
+            revision: message.revision,
+            status: "applied"
+        };
+    }
+    if (typeof runtimeVersion !== "number" || !Number.isFinite(runtimeVersion) || runtimeVersion < 0) {
+        return null;
+    }
+
+    return {
+        type: "patch_ack",
+        id: message.id,
+        revision: message.revision,
+        status: "applied",
+        runtimeVersion
     };
 }

--- a/src/cli/test/live-reload-wait-for-patch.test.ts
+++ b/src/cli/test/live-reload-wait-for-patch.test.ts
@@ -42,6 +42,9 @@ function startStatusServer(
 ) {
     let statusRequestCount = 0;
     const state = {
+        lastAppliedPatch: null as { id: string; revision: string } | null,
+        appliedPatchClients: [] as Array<{ id: string; revision: string }>,
+        lastPatchRevision: null as string | null,
         patches: [...initialPatches],
         scanComplete: true,
         uptimeMs: 100,
@@ -101,6 +104,51 @@ void test("live-reload wait-for-patch succeeds instantly if a new patch exists",
         assert.equal(payload.payload.patches.length, 1);
         assert.equal(payload.payload.patches[0]?.patchId, "patch-1");
     } finally {
+        await server.close();
+        await rm(projectRoot, { recursive: true, force: true });
+    }
+});
+
+void test("live-reload wait-for-patch can require a new runtime-applied revision", async () => {
+    const port = 60_997;
+    const projectRoot = await createTempSessionProject(port);
+    const server = startStatusServer(port, [{ patchId: "gml/script/player" }]);
+    server.state.lastPatchRevision = "revision-1";
+    server.state.lastAppliedPatch = { id: "gml/script/player", revision: "revision-1" };
+    server.state.appliedPatchClients = [{ id: "gml/script/player", revision: "revision-1" }];
+    await server.listen();
+
+    const timer = setTimeout(() => {
+        server.state.lastPatchRevision = "revision-2";
+        server.state.lastAppliedPatch = { id: "gml/script/player", revision: "revision-2" };
+        server.state.appliedPatchClients = [{ id: "gml/script/player", revision: "revision-2" }];
+    }, 100);
+
+    try {
+        const result = await runCliTestCommand({
+            argv: [
+                "live-reload",
+                "wait-for-patch",
+                "--require-applied",
+                "--since-revision",
+                "revision-1",
+                "--path",
+                projectRoot,
+                "--poll-interval-ms",
+                "25",
+                "--timeout-ms",
+                "1000"
+            ]
+        });
+        assert.equal(result.exitCode, 0);
+        const payload = JSON.parse(result.stdout) as {
+            ok: boolean;
+            payload: { lastAppliedPatch: { revision: string } };
+        };
+        assert.equal(payload.ok, true);
+        assert.equal(payload.payload.lastAppliedPatch.revision, "revision-2");
+    } finally {
+        clearTimeout(timer);
         await server.close();
         await rm(projectRoot, { recursive: true, force: true });
     }

--- a/src/cli/test/resource-change-handler.test.ts
+++ b/src/cli/test/resource-change-handler.test.ts
@@ -45,6 +45,9 @@ void describe("room resource changes", () => {
                 },
                 getClientCount() {
                     return 1;
+                },
+                getLastStreamedPatch() {
+                    return null;
                 }
             },
             transientEmptyFileReadRetryCount: 0,
@@ -70,6 +73,7 @@ void describe("room resource changes", () => {
                 {
                     kind: "resource",
                     id: "resource/room/Room1",
+                    revision: (patches[0] as { revision: string }).revision,
                     resourceType: "GMRoom",
                     resourceName: "Room1",
                     layerUpdates: [
@@ -86,6 +90,7 @@ void describe("room resource changes", () => {
                     }
                 }
             ]);
+            assert.ok((patches[0] as { revision?: string }).revision);
             assert.strictEqual(context.totalPatchCount, 1);
             assert.strictEqual(context.resourcePatches.size, 1);
         } finally {

--- a/src/cli/test/test-helpers/status-polling.ts
+++ b/src/cli/test/test-helpers/status-polling.ts
@@ -1,4 +1,19 @@
 export type StatusPayload = {
+    lastAppliedPatch?: {
+        id: string;
+        revision: string;
+        sequence: number;
+        clientId: string;
+        acknowledgedAt: number;
+    } | null;
+    lastPatchRevision?: string | null;
+    appliedPatchClients?: Array<{
+        id: string;
+        revision: string;
+        sequence: number;
+        clientId: string;
+        acknowledgedAt: number;
+    }>;
     patchCount?: number;
     patchHistorySize?: number;
     maxPatchHistory?: number;

--- a/src/cli/test/transpilation-error-classification.test.ts
+++ b/src/cli/test/transpilation-error-classification.test.ts
@@ -190,17 +190,20 @@ void describe("Transpilation error classification", () => {
         await writeFile(testFile, content, "utf8");
 
         let broadcastCount = 0;
+        const broadcastPatches: Array<unknown> = [];
         const context = createTranspilationContext();
         context.websocketServer = {
-            broadcast: () => {
+            broadcast: (patch) => {
                 broadcastCount += 1;
+                broadcastPatches.push(patch);
                 return {
                     successCount: 1,
                     failureCount: 0,
                     totalClients: 1
                 };
             },
-            getClientCount: () => 1
+            getClientCount: () => 1,
+            getLastStreamedPatch: () => null
         };
 
         const firstResult = transpileFile(context, testFile, content, 3, { verbose: false, quiet: true });
@@ -212,5 +215,12 @@ void describe("Transpilation error classification", () => {
         assert.strictEqual(context.totalPatchCount, 1, "duplicate runtime patch should not increase patch counter");
         assert.strictEqual(context.patches.length, 1, "duplicate runtime patch should not add history entries");
         assert.strictEqual(context.metrics.length, 2, "transpilation metrics should still capture both executions");
+        const firstBroadcast = broadcastPatches[0] as { revision?: string };
+        assert.ok(firstBroadcast.revision, "emitted runtime patch should carry a revision");
+        assert.strictEqual(
+            (secondResult.patch as { revision?: string }).revision,
+            firstBroadcast.revision,
+            "an unchanged patch body should retain its revision"
+        );
     });
 });

--- a/src/cli/test/watch-status-server.test.ts
+++ b/src/cli/test/watch-status-server.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 import { describe, it } from "node:test";
 
+import { findAvailablePort } from "./test-helpers/free-port.js";
+import { waitForScanComplete, waitForStatus } from "./test-helpers/status-polling.js";
 import { runWatchTest } from "./test-helpers/watch-runner.js";
+import { connectToHotReloadWebSocket } from "./test-helpers/websocket-client.js";
 
 void describe("watch command status server", () => {
     void it("should start status server by default and provide status endpoint", async () => {
@@ -42,6 +47,42 @@ void describe("watch command status server", () => {
                 assert.ok(error instanceof Error, "Expected an error when connecting to disabled server");
             }
         });
+    });
+
+    void it("reports only acknowledgements for patch revisions emitted by this watcher", async () => {
+        const websocketPort = await findAvailablePort();
+        await runWatchTest(
+            "watch-applied-patch-status",
+            { websocketServer: true, websocketPort },
+            async ({ baseUrl, testDir }) => {
+                const client = await connectToHotReloadWebSocket(`ws://127.0.0.1:${websocketPort}`);
+                try {
+                    await waitForScanComplete(baseUrl);
+                    await writeFile(path.join(testDir, "player.gml"), "var speed = 4;", "utf8");
+                    const [patch] = await client.waitForPatches({ timeoutMs: 4000 });
+                    assert.equal(typeof patch?.revision, "string");
+
+                    client.websocketClient.send(
+                        JSON.stringify({
+                            type: "patch_ack",
+                            id: patch?.id,
+                            revision: patch?.revision,
+                            status: "applied"
+                        })
+                    );
+
+                    const status = await waitForStatus(
+                        baseUrl,
+                        (payload) => payload.lastAppliedPatch?.revision === patch?.revision,
+                        4000
+                    );
+                    assert.equal(status.lastAppliedPatch?.id, patch?.id);
+                    assert.equal(status.appliedPatchClients?.length, 1);
+                } finally {
+                    await client.disconnect();
+                }
+            }
+        );
     });
 
     void it("should handle missing route with 404 error", async () => {

--- a/src/cli/test/websocket-server-cleanup.test.ts
+++ b/src/cli/test/websocket-server-cleanup.test.ts
@@ -143,6 +143,98 @@ void describe("patch websocket server client cleanup", () => {
         }
     });
 
+    void it("keeps the latest streamed revision stable when cached patches replay", async () => {
+        const patches = [
+            { kind: "script", id: "gml/script/first", revision: "revision-1", js_body: "return 1;" },
+            { kind: "script", id: "gml/script/second", revision: "revision-2", js_body: "return 2;" }
+        ];
+        const server = await startPatchWebSocketServer({
+            host: "127.0.0.1",
+            port: 0,
+            prepareInitialMessages: () => [patches[1], patches[0]]
+        });
+        server.broadcast(patches[0]);
+        server.broadcast(patches[1]);
+        const beforeReplay = server.getLastStreamedPatch();
+        const client = new WebSocket(server.url);
+
+        try {
+            const replayPayloadPromise = waitForMessage(client);
+            await waitForOpen(client);
+            await replayPayloadPromise;
+            assert.deepEqual(server.getLastStreamedPatch(), beforeReplay);
+            assert.equal(server.getLastStreamedPatch()?.revision, "revision-2");
+        } finally {
+            client.terminate();
+            await server.stop();
+        }
+    });
+
+    void it("validates and associates runtime patch acknowledgements with the client", async () => {
+        const acknowledgements: Array<{ clientId: string; id: string; revision: string }> = [];
+        let resolveAcknowledgement: () => void;
+        const acknowledgementReceived = new Promise<void>((resolve) => {
+            resolveAcknowledgement = resolve;
+        });
+        const server = await startPatchWebSocketServer({
+            host: "127.0.0.1",
+            port: 0,
+            onPatchAcknowledgement: (clientId, acknowledgement) => {
+                acknowledgements.push({ clientId, id: acknowledgement.id, revision: acknowledgement.revision });
+                resolveAcknowledgement();
+            }
+        });
+        const client = new WebSocket(server.url);
+
+        try {
+            await waitForOpen(client);
+            client.send("not json");
+            client.send(JSON.stringify({ type: "patch_ack", id: "missing-revision", status: "applied" }));
+            client.send(
+                JSON.stringify({
+                    type: "patch_ack",
+                    id: "gml/script/not_delivered",
+                    revision: "revision-forged",
+                    status: "applied"
+                })
+            );
+            server.broadcast({
+                kind: "script",
+                id: "gml/script/player_step",
+                revision: "revision-7",
+                js_body: "return 7;"
+            });
+            client.send(
+                JSON.stringify({
+                    type: "patch_ack",
+                    id: "gml/script/player_step",
+                    revision: "revision-7",
+                    status: "applied"
+                })
+            );
+
+            await acknowledgementReceived;
+            client.send(
+                JSON.stringify({
+                    type: "patch_ack",
+                    id: "gml/script/player_step",
+                    revision: "revision-7",
+                    status: "applied"
+                })
+            );
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            assert.equal(acknowledgements.length, 1);
+            assert.match(acknowledgements[0]?.clientId ?? "", /:/);
+            assert.deepEqual(
+                { id: acknowledgements[0]?.id, revision: acknowledgements[0]?.revision },
+                { id: "gml/script/player_step", revision: "revision-7" }
+            );
+        } finally {
+            client.terminate();
+            await server.stop();
+        }
+    });
+
     void it("logs structured close errors when client shutdown fails", async (testContext) => {
         let serverSocket: WebSocketType;
         const loggedErrors: Array<string> = [];

--- a/src/runtime-wrapper/index.ts
+++ b/src/runtime-wrapper/index.ts
@@ -8,6 +8,7 @@ export type {
     LogLevel,
     MessageEventLike,
     Patch,
+    PatchAppliedAcknowledgement,
     PatchErrorAnalytics,
     PatchErrorCategory,
     PatchErrorOccurrence,

--- a/src/runtime-wrapper/src/browser/runtime/types.ts
+++ b/src/runtime-wrapper/src/browser/runtime/types.ts
@@ -12,6 +12,8 @@ export interface PatchMetadata {
 export interface BasePatch {
     kind: PatchKind;
     id: string;
+    /** Unique identity for this emitted patch body on the live-reload wire. */
+    revision?: string;
     metadata?: PatchMetadata;
     /**
      * Optional GameMaker HTML5 runtime binding name for patches whose canonical

--- a/src/runtime-wrapper/src/browser/websocket/client.ts
+++ b/src/runtime-wrapper/src/browser/websocket/client.ts
@@ -22,6 +22,7 @@ import {
 import { ensureApplicationSurfaceAccessor, resolveRuntimeReadiness } from "./runtime-readiness.js";
 import type {
     MessageEventLike,
+    PatchAppliedAcknowledgement,
     PatchQueueMetrics,
     RuntimeWebSocketClient,
     RuntimeWebSocketConstructor,
@@ -82,7 +83,8 @@ function applyIncomingPatchInternal(
     wrapper: PatchApplicator | null,
     onError?: WebSocketClientOptions["onError"],
     logger?: Logger,
-    alreadyRecordedReceived = false
+    alreadyRecordedReceived = false,
+    onPatchApplied?: (patch: Patch) => void
 ): boolean {
     const receivedAt = alreadyRecordedReceived
         ? (state.connectionMetrics.lastPatchReceivedAt ?? Date.now())
@@ -120,6 +122,7 @@ function applyIncomingPatchInternal(
         if (logger) {
             logger.info(`Patch ${patch.id} applied in ${applyDuration}ms`);
         }
+        onPatchApplied?.(patch);
     };
 
     const recordFailure = () => {
@@ -191,6 +194,38 @@ export function createWebSocketClient({
     };
     let detachWebSocketListeners = noopListenerTeardown;
 
+    const sendPatchAcknowledgement = (patch: Patch, runtimeVersion?: number): void => {
+        if (!patch.revision || !state.ws || !state.isConnected) {
+            return;
+        }
+
+        const acknowledgement: PatchAppliedAcknowledgement = {
+            type: "patch_ack",
+            id: patch.id,
+            revision: patch.revision,
+            status: "applied",
+            ...(runtimeVersion === undefined ? {} : { runtimeVersion })
+        };
+
+        try {
+            state.ws.send(JSON.stringify(acknowledgement));
+        } catch (error) {
+            logger?.warn(`Failed to acknowledge applied patch ${patch.id}: ${String(error)}`);
+        }
+    };
+
+    const acknowledgeAppliedBatch = (patches: Array<unknown>, runtimeVersion?: number): void => {
+        for (const candidate of patches) {
+            if (!candidate || typeof candidate !== "object") {
+                continue;
+            }
+            const patch = candidate as Patch;
+            if (typeof patch.id === "string" && typeof patch.revision === "string") {
+                sendPatchAcknowledgement(patch, runtimeVersion);
+            }
+        }
+    };
+
     const clearReadinessTimer = (): void => {
         if (state.readinessTimer !== null) {
             clearInterval(state.readinessTimer);
@@ -222,7 +257,7 @@ export function createWebSocketClient({
                     recordPatchReceived(state);
                     enqueuePatch(patch);
                 } else {
-                    applyIncomingPatchInternal(patch, state, wrapper, onError, logger);
+                    applyIncomingPatchInternal(patch, state, wrapper, onError, logger, false, sendPatchAcknowledgement);
                 }
             }
         }
@@ -253,8 +288,10 @@ export function createWebSocketClient({
         return flushQueuedPatchBatch(
             state,
             wrapper,
-            (incoming) => applyIncomingPatchInternal(incoming, state, wrapper, onError, logger, true),
-            logger
+            (incoming) =>
+                applyIncomingPatchInternal(incoming, state, wrapper, onError, logger, true, sendPatchAcknowledgement),
+            logger,
+            acknowledgeAppliedBatch
         );
     };
 
@@ -294,7 +331,7 @@ export function createWebSocketClient({
             return true;
         }
 
-        return applyIncomingPatchInternal(incoming, state, wrapper, onError, logger);
+        return applyIncomingPatchInternal(incoming, state, wrapper, onError, logger, false, sendPatchAcknowledgement);
     };
 
     function connect() {

--- a/src/runtime-wrapper/src/browser/websocket/index.ts
+++ b/src/runtime-wrapper/src/browser/websocket/index.ts
@@ -2,6 +2,7 @@ export { createWebSocketClient, DEFAULT_READINESS_POLL_INTERVAL_MS } from "./cli
 export { ensureApplicationSurfaceAccessor, resolveRuntimeReadiness } from "./runtime-readiness.js";
 export type {
     MessageEventLike,
+    PatchAppliedAcknowledgement,
     PatchQueueMetrics,
     PatchQueueOptions,
     PatchQueueState,

--- a/src/runtime-wrapper/src/browser/websocket/patch-queue.ts
+++ b/src/runtime-wrapper/src/browser/websocket/patch-queue.ts
@@ -256,7 +256,8 @@ export function flushQueuedPatches(
     state: WebSocketClientState,
     wrapper: PatchApplicator | null,
     applyQueuedPatch: (incoming: unknown) => boolean,
-    logger?: Logger
+    logger?: Logger,
+    onBatchApplied?: (patches: Array<unknown>, runtimeVersion?: number) => void
 ): number {
     if (!state.patchQueue || !wrapper) {
         return 0;
@@ -304,8 +305,9 @@ export function flushQueuedPatches(
         }
         queueMetrics.totalFlushed += flushSize;
 
-        if (result.success && applied > 0) {
+        if (result.success && !result.rolledBack && applied === patchesToApply.length && applied > 0) {
             connectionMetrics.lastPatchAppliedAt = Date.now();
+            onBatchApplied?.(patchesToApply, result.version);
         }
     } else {
         for (const patch of patchesToApply) {

--- a/src/runtime-wrapper/src/browser/websocket/types.ts
+++ b/src/runtime-wrapper/src/browser/websocket/types.ts
@@ -34,6 +34,15 @@ export interface WebSocketClientOptions {
     logger?: Logger;
 }
 
+/** Browser-to-server confirmation that an identified patch revision committed. */
+export interface PatchAppliedAcknowledgement {
+    type: "patch_ack";
+    id: string;
+    revision: string;
+    status: "applied";
+    runtimeVersion?: number;
+}
+
 export interface PatchQueueState {
     queue: Array<unknown>;
     flushTimer: ReturnType<typeof setTimeout> | null;

--- a/src/runtime-wrapper/src/index.ts
+++ b/src/runtime-wrapper/src/index.ts
@@ -57,6 +57,7 @@ export type {
 export * as Runtime from "./browser/runtime/index.js";
 export type {
     MessageEventLike,
+    PatchAppliedAcknowledgement,
     PatchQueueMetrics,
     PatchQueueOptions,
     PatchQueueState,

--- a/src/runtime-wrapper/test/patch-queue.test.ts
+++ b/src/runtime-wrapper/test/patch-queue.test.ts
@@ -14,6 +14,7 @@ const { createWebSocketClient } = Clients;
 
 class MockWebSocket {
     public readyState = 0;
+    public readonly sentMessages: Array<string> = [];
     private listeners = new Map<string, Set<(event?: unknown) => void>>();
 
     constructor() {
@@ -38,12 +39,8 @@ class MockWebSocket {
         this.listeners.get(event)?.delete(handler);
     }
 
-    send(): void {
-        // No-op for testing: Mock WebSocket implementation doesn't transmit
-        // messages over the network. Tests verify client-side behavior
-        // (event handling, reconnection logic, state management) without
-        // requiring an actual WebSocket server. Real message transmission
-        // would add test flakiness and infrastructure dependencies.
+    send(data: string): void {
+        this.sentMessages.push(data);
     }
 
     close(): void {
@@ -960,6 +957,63 @@ void test("patch queue uses applyPatchBatch when available", async () => {
     } finally {
         client.disconnect();
         restoreRuntimeGlobals();
+    }
+});
+
+void test("patch queue acknowledges committed revisions and not rolled-back batches", async () => {
+    const success = await createConnectedPatchQueueClient({
+        patchQueue: { flushIntervalMs: 10, maxQueueSize: 10 }
+    });
+
+    try {
+        success.ws.simulateMessage(
+            JSON.stringify({
+                kind: "script",
+                id: "gml/script/queued_ack",
+                revision: "queued-revision-1",
+                js_body: "return 1;"
+            })
+        );
+        await waitForCondition("queued patch acknowledgement", () => success.ws.sentMessages.length === 1, {
+            timeoutMs: 200,
+            pollIntervalMs: 5
+        });
+        assert.equal(
+            (JSON.parse(success.ws.sentMessages[0] ?? "null") as { revision?: string }).revision,
+            "queued-revision-1"
+        );
+    } finally {
+        success.client.disconnect();
+        success.restoreRuntimeGlobals();
+    }
+
+    const rolledBack = await createConnectedPatchQueueClient({
+        patchQueue: { flushIntervalMs: 10, maxQueueSize: 10 },
+        wrapperMutator: (wrapper) => {
+            wrapper.applyPatchBatch = () => ({
+                success: false,
+                appliedCount: 0,
+                error: "synthetic rollback",
+                rolledBack: true
+            });
+            return wrapper;
+        }
+    });
+
+    try {
+        rolledBack.ws.simulateMessage(
+            JSON.stringify({
+                kind: "script",
+                id: "gml/script/rolled_back",
+                revision: "queued-revision-2",
+                js_body: "return 2;"
+            })
+        );
+        await wait(40);
+        assert.equal(rolledBack.ws.sentMessages.length, 0);
+    } finally {
+        rolledBack.client.disconnect();
+        rolledBack.restoreRuntimeGlobals();
     }
 });
 

--- a/src/runtime-wrapper/test/websocket.test.ts
+++ b/src/runtime-wrapper/test/websocket.test.ts
@@ -43,6 +43,7 @@ const flush = () =>
 
 class MockWebSocket implements RuntimeWebSocketInstance {
     public readyState = 0;
+    public readonly sentMessages: Array<string> = [];
     private readonly listeners: Record<WebSocketEvent, Array<(event?: unknown) => void>> = {
         open: [],
         message: [],
@@ -70,10 +71,10 @@ class MockWebSocket implements RuntimeWebSocketInstance {
     }
 
     send(data: string) {
-        void data;
         if (this.readyState !== 1) {
             throw new Error("WebSocket is not open");
         }
+        this.sentMessages.push(data);
     }
 
     close() {
@@ -194,9 +195,35 @@ void test("WebSocket client applies patches from messages", async () => {
     await wait(10);
 
     assert.ok(wrapper.hasScript("script:test"));
+    assert.equal(mockSocket.sentMessages.length, 0, "legacy patches without a revision are not acknowledged");
 
     client.disconnect();
     delete globalWithWebSocket.WebSocket;
+});
+
+void test("WebSocket client acknowledges an identified patch only after it applies", async () => {
+    const wrapper = RuntimeWrapper.createRuntimeWrapper();
+
+    await runWebSocketTest({ wrapper }, async (_client, mockSocket) => {
+        mockSocket.simulateMessage(
+            JSON.stringify({
+                kind: "script",
+                id: "gml/script/acknowledged",
+                revision: "revision-1",
+                js_body: "return 42;"
+            })
+        );
+
+        await wait(10);
+
+        assert.ok(wrapper.hasScript("gml/script/acknowledged"));
+        assert.deepEqual(JSON.parse(mockSocket.sentMessages[0] ?? "null"), {
+            type: "patch_ack",
+            id: "gml/script/acknowledged",
+            revision: "revision-1",
+            status: "applied"
+        });
+    });
 });
 
 void test("WebSocket client applies batch patches from messages", async () => {


### PR DESCRIPTION
## Summary
- add per-revision IDs to streamed script and room-resource patches
- acknowledge patches from the injected HTML5 runtime only after direct or queued application commits
- validate acknowledgements against patches delivered to that socket and ignore duplicate or stale replies
- expose streamed/applied revision state per runtime client
- add `live-reload wait-for-patch --require-applied --since-revision`

## Boundary
An acknowledgement proves that the injected HTML5 wrapper committed the patch. It does not prove a gameplay assertion, and native/non-injected runners remain broadcast-only.

## Verification
- TypeScript build: runtime-wrapper + CLI
- 106 focused runtime-wrapper/CLI tests
- ESLint on changed TypeScript files
- Prettier and `git diff --check`