### PR TITLE
Add hierarchical semantic zoom to graph visualization

### DIFF
--- a/src/ui/src/app/components/gm-graph-panel.ts
+++ b/src/ui/src/app/components/gm-graph-panel.ts
@@ -12,6 +12,7 @@ import {
     listGraphNodeKinds,
     resolveEffectiveGraphNodeKinds
 } from "../../graph/graph-layout.js";
+import { projectGraphLayoutForSemanticZoom } from "../../graph/graph-semantic-zoom.js";
 import { EDGE_LINE_VISUAL_STYLES, NODE_VISUAL_STYLES } from "../../graph/graph-visualization-style-metadata.js";
 import type { GraphVisualizationEdgeType, GraphVisualizationNodeKind } from "../../graph/types.js";
 import {
@@ -34,6 +35,8 @@ const DEFAULT_DISABLED_NODE_KINDS = new Set<GraphLegendNodeKind>([
     "note",
     "room_layer"
 ]);
+const FOCUSED_NODE_ZOOM_SCALE = 2.4;
+const FOCUS_CLEAR_ZOOM_SCALE = 0.55;
 
 function formatNodeKindLabel(kind: string): string {
     return kind
@@ -111,6 +114,7 @@ export class GmGraphPanel extends LightDomLitElement {
     #enabledNodeKinds = new Set<GraphLegendNodeKind>();
     #enabledEdgeTypes = new Set<GraphVisualizationEdgeType>();
     #selectedNodeId: string | null = null;
+    #focusedNodeId: string | null = null;
     #lastModelReference: GraphVisualizationUiModel | null = null;
     #initializedFiltersForModel = false;
 
@@ -135,6 +139,7 @@ export class GmGraphPanel extends LightDomLitElement {
         this.#panY = 0;
         this.#zoomScale = 1;
         this.#selectedNodeId = null;
+        this.#focusedNodeId = null;
         this.#cachedVisibleLayout = null;
         this.requestUpdate();
     };
@@ -249,6 +254,9 @@ export class GmGraphPanel extends LightDomLitElement {
         this.#panX = mouseX - (mouseX - this.#panX) * (finalScale / this.#zoomScale);
         this.#panY = mouseY - (mouseY - this.#panY) * (finalScale / this.#zoomScale);
         this.#zoomScale = finalScale;
+        if (finalScale <= FOCUS_CLEAR_ZOOM_SCALE) {
+            this.#focusedNodeId = null;
+        }
 
         this.requestUpdate();
     };
@@ -297,6 +305,26 @@ export class GmGraphPanel extends LightDomLitElement {
         this.#selectedNodeId = nodeId;
         this.requestUpdate();
     }
+
+    protected focusNode(nodeId: string): void {
+        const node = this.#cachedLayout?.nodes.find((candidate) => candidate.id === nodeId);
+        if (!node) {
+            return;
+        }
+
+        const targetScale = Math.max(this.#zoomScale, FOCUSED_NODE_ZOOM_SCALE);
+        this.#selectedNodeId = nodeId;
+        this.#focusedNodeId = nodeId;
+        this.#panX = -node.x * targetScale;
+        this.#panY = -node.y * targetScale;
+        this.#zoomScale = targetScale;
+        this.requestUpdate();
+    }
+
+    #clearFocus = (): void => {
+        this.#focusedNodeId = null;
+        this.requestUpdate();
+    };
 
     #matchesSearch(node: GraphLayoutNode): boolean {
         const query = this.state?.searchQuery.trim().toLowerCase() ?? "";
@@ -453,6 +481,7 @@ export class GmGraphPanel extends LightDomLitElement {
 
         const pathLabel = readGraphNodePathLabel(node);
         const locationLabel = readGraphNodeLocationLabel(node);
+        const isFocused = this.#focusedNodeId === node.id;
         return html`
             <div id="tooltip" class="visible" role="dialog" aria-live="polite" data-selected-node-id=${node.id}>
                 <h3>${node.displayName}</h3>
@@ -463,6 +492,11 @@ export class GmGraphPanel extends LightDomLitElement {
                 ${locationLabel ? html`<div>${locationLabel}</div>` : null}
                 ${node.summary ? html`<p>${node.summary}</p>` : null}
                 ${node.snippet ? html`<pre>${node.snippet}</pre>` : null}
+                ${
+                    isFocused
+                        ? html`<button type="button" @click=${this.#clearFocus}>Exit focused view</button>`
+                        : html`<div>Double-click the node to zoom into its semantic hierarchy.</div>`
+                }
             </div>
         `;
     }
@@ -484,6 +518,9 @@ export class GmGraphPanel extends LightDomLitElement {
             this.#cachedNodeItems = listGraphNodeKindLegendItems(graphNodes);
             this.#cachedEdgeTypes = listGraphEdgeTypes(graphEdges);
             this.#cachedVisibleLayout = null;
+            if (this.#focusedNodeId && !this.#cachedLayout.nodes.some((node) => node.id === this.#focusedNodeId)) {
+                this.#focusedNodeId = null;
+            }
         }
 
         const query = this.state.searchQuery.trim().toLowerCase();
@@ -507,11 +544,22 @@ export class GmGraphPanel extends LightDomLitElement {
         const layout = this.#cachedLayout;
         const nodeItems = this.#cachedNodeItems;
         const edgeTypes = this.#cachedEdgeTypes;
-        const { edges: visibleEdges, nodes: visibleNodes } = this.#cachedVisibleLayout;
+        const filteredLayout = this.#cachedVisibleLayout;
+        const semanticLayout = projectGraphLayoutForSemanticZoom({
+            displayLayout: filteredLayout,
+            focusNodeId: this.#focusedNodeId,
+            sourceLayout: layout,
+            zoomScale: this.#zoomScale
+        });
+        const { edges: visibleEdges, nodes: visibleNodes } = semanticLayout;
         const selectedNode = layout.nodes.find((node) => node.id === this.#selectedNodeId) ?? null;
 
         if (this.#cachedJsonValue === null) {
-            this.#cachedJsonValue = JSON.stringify({ edges: visibleEdges, nodes: visibleNodes }, null, 2);
+            this.#cachedJsonValue = JSON.stringify(
+                { edges: filteredLayout.edges, nodes: filteredLayout.nodes },
+                null,
+                2
+            );
         }
         const jsonValue = this.#cachedJsonValue;
 
@@ -574,11 +622,13 @@ export class GmGraphPanel extends LightDomLitElement {
                             return svg`
                                 <line
                                     class="link"
+                                    data-aggregate-count=${String(edge.aggregateCount)}
                                     x1=${String(geom.x1)}
                                     y1=${String(geom.y1)}
                                     x2=${String(geom.x2)}
                                     y2=${String(geom.y2)}
                                     stroke=${getEdgeColor(edge.type)}
+                                    stroke-width=${String(Math.min(6, 1 + Math.log2(edge.aggregateCount)))}
                                     stroke-dasharray=${getEdgeDashArray(edge.type)}
                                     marker-end=${`url(#${readEdgeArrowMarkerId(edge.type)})`}
                                 ></line>
@@ -598,6 +648,10 @@ export class GmGraphPanel extends LightDomLitElement {
                                             event.stopPropagation();
                                         }}
                                         @click=${() => this.selectNode(node.id)}
+                                        @dblclick=${(event: MouseEvent) => {
+                                            event.stopPropagation();
+                                            this.focusNode(node.id);
+                                        }}
                                         @keydown=${(event: KeyboardEvent) => {
                                             if (event.key === "Enter" || event.key === " ") {
                                                 event.preventDefault();

--- a/src/ui/src/graph/graph-semantic-zoom.ts
+++ b/src/ui/src/graph/graph-semantic-zoom.ts
@@ -1,0 +1,283 @@
+import { buildGraphHierarchy } from "./graph-layout-hierarchy.js";
+import type { GraphLayout, GraphLayoutEdge, GraphLayoutNode } from "./graph-layout.js";
+
+export type GraphSemanticZoomLevel = "overview" | "resource" | "symbol" | "detail";
+
+export type GraphSemanticZoomEdge = GraphLayoutEdge &
+    Readonly<{
+        aggregateCount: number;
+    }>;
+
+export type GraphSemanticZoomLayout = Readonly<{
+    edges: ReadonlyArray<GraphSemanticZoomEdge>;
+    nodes: ReadonlyArray<GraphLayoutNode>;
+}>;
+
+const OVERVIEW_MAX_DEPTH = 1;
+const RESOURCE_MAX_DEPTH = 2;
+const SYMBOL_MAX_DEPTH = 3;
+const OVERVIEW_MAX_SCALE = 0.55;
+const RESOURCE_MAX_SCALE = 1.2;
+const SYMBOL_MAX_SCALE = 3.5;
+
+/**
+ * Map camera scale to a stable semantic level. The thresholds deliberately keep
+ * project/resources visible first, then progressively reveal owned symbols.
+ */
+export function resolveGraphSemanticZoomLevel(zoomScale: number): GraphSemanticZoomLevel {
+    if (zoomScale <= OVERVIEW_MAX_SCALE) {
+        return "overview";
+    }
+    if (zoomScale <= RESOURCE_MAX_SCALE) {
+        return "resource";
+    }
+    if (zoomScale <= SYMBOL_MAX_SCALE) {
+        return "symbol";
+    }
+
+    return "detail";
+}
+
+function readMaxHierarchyDepth(level: GraphSemanticZoomLevel): number {
+    switch (level) {
+        case "overview": {
+            return OVERVIEW_MAX_DEPTH;
+        }
+        case "resource": {
+            return RESOURCE_MAX_DEPTH;
+        }
+        case "symbol": {
+            return SYMBOL_MAX_DEPTH;
+        }
+        case "detail": {
+            return Number.POSITIVE_INFINITY;
+        }
+    }
+}
+
+function readFocusDescendantDepth(level: GraphSemanticZoomLevel): number {
+    switch (level) {
+        case "overview": {
+            return 1;
+        }
+        case "resource": {
+            return 2;
+        }
+        case "symbol": {
+            return 3;
+        }
+        case "detail": {
+            return Number.POSITIVE_INFINITY;
+        }
+    }
+}
+
+function readHierarchyDepth(
+    nodeId: string,
+    parentMap: ReadonlyMap<string, string>,
+    depthByNodeId: Map<string, number>,
+    visitingNodeIds: Set<string>
+): number {
+    const cachedDepth = depthByNodeId.get(nodeId);
+    if (cachedDepth !== undefined) {
+        return cachedDepth;
+    }
+
+    const parentId = parentMap.get(nodeId);
+    if (!parentId || visitingNodeIds.has(nodeId)) {
+        depthByNodeId.set(nodeId, 0);
+        return 0;
+    }
+
+    visitingNodeIds.add(nodeId);
+    const depth = readHierarchyDepth(parentId, parentMap, depthByNodeId, visitingNodeIds) + 1;
+    visitingNodeIds.delete(nodeId);
+    depthByNodeId.set(nodeId, depth);
+    return depth;
+}
+
+function buildHierarchyDepths(
+    nodes: ReadonlyArray<GraphLayoutNode>,
+    parentMap: ReadonlyMap<string, string>
+): Map<string, number> {
+    const depthByNodeId = new Map<string, number>();
+    for (const node of nodes) {
+        readHierarchyDepth(node.id, parentMap, depthByNodeId, new Set<string>());
+    }
+
+    return depthByNodeId;
+}
+
+function isHierarchyDescendantOrSelf(
+    nodeId: string,
+    ancestorId: string,
+    parentMap: ReadonlyMap<string, string>
+): boolean {
+    let currentNodeId: string | undefined = nodeId;
+    const visitedNodeIds = new Set<string>();
+
+    while (currentNodeId && !visitedNodeIds.has(currentNodeId)) {
+        if (currentNodeId === ancestorId) {
+            return true;
+        }
+
+        visitedNodeIds.add(currentNodeId);
+        currentNodeId = parentMap.get(currentNodeId);
+    }
+
+    return false;
+}
+
+function addVisibleAncestors(
+    nodeId: string,
+    parentMap: ReadonlyMap<string, string>,
+    displayNodeIds: ReadonlySet<string>,
+    projectedNodeIds: Set<string>
+): void {
+    let currentNodeId: string | undefined = nodeId;
+    const visitedNodeIds = new Set<string>();
+
+    while (currentNodeId && !visitedNodeIds.has(currentNodeId)) {
+        visitedNodeIds.add(currentNodeId);
+        if (displayNodeIds.has(currentNodeId)) {
+            projectedNodeIds.add(currentNodeId);
+        }
+        currentNodeId = parentMap.get(currentNodeId);
+    }
+}
+
+function collectProjectedNodeIds(parameters: {
+    depthByNodeId: ReadonlyMap<string, number>;
+    displayLayout: GraphLayout;
+    focusNodeId: string | null;
+    level: GraphSemanticZoomLevel;
+    parentMap: ReadonlyMap<string, string>;
+}): Set<string> {
+    const { depthByNodeId, displayLayout, focusNodeId, level, parentMap } = parameters;
+    const displayNodeIds = new Set(displayLayout.nodes.map((node) => node.id));
+    const projectedNodeIds = new Set<string>();
+    const usableFocusNodeId = focusNodeId && displayNodeIds.has(focusNodeId) ? focusNodeId : null;
+
+    if (!usableFocusNodeId) {
+        const maxDepth = readMaxHierarchyDepth(level);
+        for (const node of displayLayout.nodes) {
+            if (node.kind === "project" || (depthByNodeId.get(node.id) ?? 0) <= maxDepth) {
+                projectedNodeIds.add(node.id);
+            }
+        }
+        return projectedNodeIds;
+    }
+
+    const focusDepth = depthByNodeId.get(usableFocusNodeId) ?? 0;
+    const descendantDepth = readFocusDescendantDepth(level);
+
+    for (const node of displayLayout.nodes) {
+        const nodeDepth = depthByNodeId.get(node.id) ?? 0;
+        if (node.kind === "project" || nodeDepth <= OVERVIEW_MAX_DEPTH) {
+            projectedNodeIds.add(node.id);
+            continue;
+        }
+
+        if (
+            isHierarchyDescendantOrSelf(node.id, usableFocusNodeId, parentMap) &&
+            nodeDepth - focusDepth <= descendantDepth
+        ) {
+            projectedNodeIds.add(node.id);
+        }
+    }
+
+    addVisibleAncestors(usableFocusNodeId, parentMap, displayNodeIds, projectedNodeIds);
+    return projectedNodeIds;
+}
+
+function findProjectedRepresentativeId(
+    nodeId: string,
+    parentMap: ReadonlyMap<string, string>,
+    projectedNodeIds: ReadonlySet<string>
+): string | null {
+    let currentNodeId: string | undefined = nodeId;
+    const visitedNodeIds = new Set<string>();
+
+    while (currentNodeId && !visitedNodeIds.has(currentNodeId)) {
+        if (projectedNodeIds.has(currentNodeId)) {
+            return currentNodeId;
+        }
+
+        visitedNodeIds.add(currentNodeId);
+        currentNodeId = parentMap.get(currentNodeId);
+    }
+
+    return null;
+}
+
+function aggregateProjectedEdges(
+    displayLayout: GraphLayout,
+    parentMap: ReadonlyMap<string, string>,
+    projectedNodes: ReadonlyArray<GraphLayoutNode>,
+    projectedNodeIds: ReadonlySet<string>
+): ReadonlyArray<GraphSemanticZoomEdge> {
+    const projectedNodeById = new Map(projectedNodes.map((node) => [node.id, node]));
+    const edgeByKey = new Map<string, GraphSemanticZoomEdge>();
+
+    for (const edge of displayLayout.edges) {
+        const sourceId = findProjectedRepresentativeId(edge.sourceNode.id, parentMap, projectedNodeIds);
+        const targetId = findProjectedRepresentativeId(edge.targetNode.id, parentMap, projectedNodeIds);
+        if (!sourceId || !targetId || sourceId === targetId) {
+            continue;
+        }
+
+        const sourceNode = projectedNodeById.get(sourceId);
+        const targetNode = projectedNodeById.get(targetId);
+        if (!sourceNode || !targetNode) {
+            continue;
+        }
+
+        const edgeKey = `${sourceId}\u0000${targetId}\u0000${edge.type}`;
+        const existingEdge = edgeByKey.get(edgeKey);
+        if (existingEdge) {
+            edgeByKey.set(edgeKey, { ...existingEdge, aggregateCount: existingEdge.aggregateCount + 1 });
+            continue;
+        }
+
+        edgeByKey.set(edgeKey, {
+            ...edge,
+            aggregateCount: 1,
+            source: sourceId,
+            sourceNode,
+            target: targetId,
+            targetNode
+        });
+    }
+
+    return [...edgeByKey.values()];
+}
+
+/**
+ * Project the filtered graph into a semantic level-of-detail view. Hidden
+ * descendants collapse into their nearest visible hierarchy ancestor and
+ * duplicate relationships are bundled into one edge with an aggregate count.
+ */
+export function projectGraphLayoutForSemanticZoom(parameters: {
+    displayLayout: GraphLayout;
+    focusNodeId: string | null;
+    sourceLayout: GraphLayout;
+    zoomScale: number;
+}): GraphSemanticZoomLayout {
+    const { displayLayout, focusNodeId, sourceLayout, zoomScale } = parameters;
+    const hierarchy = buildGraphHierarchy(sourceLayout.nodes, sourceLayout.edges);
+    const depthByNodeId = buildHierarchyDepths(sourceLayout.nodes, hierarchy.parentMap);
+    const level = resolveGraphSemanticZoomLevel(zoomScale);
+    const projectedNodeIds = collectProjectedNodeIds({
+        depthByNodeId,
+        displayLayout,
+        focusNodeId,
+        level,
+        parentMap: hierarchy.parentMap
+    });
+    const projectedNodes = displayLayout.nodes.filter((node) => projectedNodeIds.has(node.id));
+
+    return Object.freeze({
+        edges: aggregateProjectedEdges(displayLayout, hierarchy.parentMap, projectedNodes, projectedNodeIds),
+        nodes: projectedNodes
+    });
+}

--- a/src/ui/test/graph-semantic-zoom.test.ts
+++ b/src/ui/test/graph-semantic-zoom.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createGraphLayout } from "../src/graph/graph-layout.js";
+import {
+    projectGraphLayoutForSemanticZoom,
+    resolveGraphSemanticZoomLevel
+} from "../src/graph/graph-semantic-zoom.js";
+import type { GraphVisualizationNodeKind, GraphVisualizationNodeRecord } from "../src/graph/types.js";
+
+function createNode(id: string, kind: GraphVisualizationNodeKind, name: string): GraphVisualizationNodeRecord {
+    return {
+        displayName: name,
+        filePath: null,
+        graphId: "project",
+        id,
+        kind,
+        lineEnd: null,
+        lineStart: null,
+        name,
+        resourcePath: null,
+        scopeId: null,
+        scipSymbol: null,
+        snippet: "",
+        summary: ""
+    };
+}
+
+void test("resolveGraphSemanticZoomLevel progressively reveals hierarchy detail", () => {
+    assert.equal(resolveGraphSemanticZoomLevel(0.4), "overview");
+    assert.equal(resolveGraphSemanticZoomLevel(1), "resource");
+    assert.equal(resolveGraphSemanticZoomLevel(2), "symbol");
+    assert.equal(resolveGraphSemanticZoomLevel(4), "detail");
+});
+
+void test("semantic overview collapses deep symbols and bundles their relationships", () => {
+    const layout = createGraphLayout(
+        [
+            createNode("project", "project", "Game"),
+            createNode("script-a", "script", "player"),
+            createNode("fn-a", "function", "update_player"),
+            createNode("local-a", "local_variable", "speed"),
+            createNode("script-b", "script", "combat"),
+            createNode("fn-b", "function", "apply_damage")
+        ],
+        [
+            { source: "project", target: "script-a", type: "contains" },
+            { source: "script-a", target: "fn-a", type: "defines" },
+            { source: "fn-a", target: "local-a", type: "defines" },
+            { source: "project", target: "script-b", type: "contains" },
+            { source: "script-b", target: "fn-b", type: "defines" },
+            { source: "fn-a", target: "fn-b", type: "calls" }
+        ]
+    );
+
+    const projected = projectGraphLayoutForSemanticZoom({
+        displayLayout: layout,
+        focusNodeId: null,
+        sourceLayout: layout,
+        zoomScale: 0.4
+    });
+
+    assert.deepEqual(
+        projected.nodes.map((node) => node.id),
+        ["project", "script-a", "script-b"]
+    );
+    assert.ok(
+        projected.edges.some(
+            (edge) =>
+                edge.source === "script-a" &&
+                edge.target === "script-b" &&
+                edge.type === "calls" &&
+                edge.aggregateCount === 1
+        )
+    );
+});
+
+void test("semantic overview combines duplicate descendant relationships into one weighted edge", () => {
+    const layout = createGraphLayout(
+        [
+            createNode("project", "project", "Game"),
+            createNode("script-a", "script", "player"),
+            createNode("fn-a-1", "function", "update_player"),
+            createNode("fn-a-2", "function", "update_weapon"),
+            createNode("script-b", "script", "combat"),
+            createNode("fn-b", "function", "apply_damage")
+        ],
+        [
+            { source: "project", target: "script-a", type: "contains" },
+            { source: "script-a", target: "fn-a-1", type: "defines" },
+            { source: "script-a", target: "fn-a-2", type: "defines" },
+            { source: "project", target: "script-b", type: "contains" },
+            { source: "script-b", target: "fn-b", type: "defines" },
+            { source: "fn-a-1", target: "fn-b", type: "calls" },
+            { source: "fn-a-2", target: "fn-b", type: "calls" }
+        ]
+    );
+
+    const projected = projectGraphLayoutForSemanticZoom({
+        displayLayout: layout,
+        focusNodeId: null,
+        sourceLayout: layout,
+        zoomScale: 0.4
+    });
+    const callsEdges = projected.edges.filter((edge) => edge.type === "calls");
+
+    assert.equal(callsEdges.length, 1);
+    assert.equal(callsEdges[0]?.source, "script-a");
+    assert.equal(callsEdges[0]?.target, "script-b");
+    assert.equal(callsEdges[0]?.aggregateCount, 2);
+});
+
+void test("focused semantic zoom reveals one hierarchy branch while preserving project context", () => {
+    const layout = createGraphLayout(
+        [
+            createNode("project", "project", "Game"),
+            createNode("script-a", "script", "player"),
+            createNode("fn-a", "function", "update_player"),
+            createNode("local-a", "local_variable", "speed"),
+            createNode("script-b", "script", "combat"),
+            createNode("fn-b", "function", "apply_damage")
+        ],
+        [
+            { source: "project", target: "script-a", type: "contains" },
+            { source: "script-a", target: "fn-a", type: "defines" },
+            { source: "fn-a", target: "local-a", type: "defines" },
+            { source: "project", target: "script-b", type: "contains" },
+            { source: "script-b", target: "fn-b", type: "defines" }
+        ]
+    );
+
+    const projected = projectGraphLayoutForSemanticZoom({
+        displayLayout: layout,
+        focusNodeId: "script-a",
+        sourceLayout: layout,
+        zoomScale: 2.4
+    });
+    const visibleNodeIds = new Set(projected.nodes.map((node) => node.id));
+
+    assert.ok(visibleNodeIds.has("project"));
+    assert.ok(visibleNodeIds.has("script-a"));
+    assert.ok(visibleNodeIds.has("fn-a"));
+    assert.ok(visibleNodeIds.has("local-a"));
+    assert.ok(visibleNodeIds.has("script-b"));
+    assert.ok(!visibleNodeIds.has("fn-b"));
+});
+
+void test("detail semantic zoom exposes the complete filtered graph", () => {
+    const layout = createGraphLayout(
+        [
+            createNode("project", "project", "Game"),
+            createNode("script", "script", "player"),
+            createNode("function", "function", "update_player"),
+            createNode("local", "local_variable", "speed")
+        ],
+        [
+            { source: "project", target: "script", type: "contains" },
+            { source: "script", target: "function", type: "defines" },
+            { source: "function", target: "local", type: "defines" }
+        ]
+    );
+
+    const projected = projectGraphLayoutForSemanticZoom({
+        displayLayout: layout,
+        focusNodeId: null,
+        sourceLayout: layout,
+        zoomScale: 4
+    });
+
+    assert.deepEqual(
+        projected.nodes.map((node) => node.id),
+        ["project", "script", "function", "local"]
+    );
+});


### PR DESCRIPTION
## Summary

- add a semantic level-of-detail projection for the graph visualization so zoom level controls how much of the project hierarchy is rendered
- collapse hidden descendants into their nearest visible hierarchy ancestor and bundle duplicate relationships with aggregate counts
- render bundled relationships with weighted edge widths to reduce overlapping line noise
- let users double-click a node to center and zoom into its semantic subtree while keeping top-level project context visible
- clear focused navigation when sufficiently zoomed back out and expose an explicit Exit focused view action
- keep the JSON graph view based on the full filtered graph rather than the visual level-of-detail projection

## Why

The graph currently lays out the complete enabled semantic graph at once. Even with hierarchical seeding and overlap resolution, large GameMaker projects produce dense clusters of symbols and crossing relationships that are difficult to read. This change treats the visualization as a semantic map: project/resources are visible at broad zoom levels, deeper owned symbols are progressively disclosed, and relationships from hidden descendants are represented by bundled ancestor-level edges rather than disappearing or producing a large edge tangle.

The implementation stays within the existing Lit/SVG graph renderer on `main`; it adds a projection layer instead of replacing the renderer or changing semantic index ownership.

## Tests

Added focused unit coverage for:

- semantic zoom level selection
- collapsing deep symbols in overview mode
- bundling duplicate descendant relationships and retaining aggregate counts
- focused subtree disclosure while preserving project-level context
- exposing the complete filtered graph at the deepest zoom level

I was unable to execute the repository build/lint/test commands from the connector environment because the local checkout is not available there; CI should provide the authoritative validation for the branch.