### PR TITLE
Optimize GMLoop UI startup performance

### DIFF
--- a/src/ui/src/graph/graph-layout-simulation.ts
+++ b/src/ui/src/graph/graph-layout-simulation.ts
@@ -11,6 +11,8 @@ const CONNECTION_RADIUS_WEIGHT = 1.8;
 const MIN_NODE_DISTANCE_PADDING = 80;
 const CLOSE_NODE_REPULSION = 520;
 const DISTANT_NODE_REPULSION = 1800;
+const ALL_PAIRS_REPULSION_NODE_LIMIT = 180;
+const LARGE_GRAPH_REPULSION_CELL_SIZE = 320;
 const OVERLAP_RESOLUTION_PASSES = 90;
 // Pushing exactly the measured overlap converges asymptotically for densely-coupled clusters
 // (each pass only fixes one constraint at a time, re-creating tiny overlaps elsewhere).
@@ -94,13 +96,23 @@ function resetSimulationVelocities(simNodes: Array<SimulationNode>): void {
 }
 
 function applyPairRepulsion(simNodes: Array<SimulationNode>): void {
-    for (let i = 0; i < simNodes.length; i++) {
-        const nodeI = simNodes[i];
-        for (let j = i + 1; j < simNodes.length; j++) {
-            const nodeJ = simNodes[j];
-            applyRepulsiveForce(nodeI, nodeJ);
+    if (simNodes.length <= ALL_PAIRS_REPULSION_NODE_LIMIT) {
+        for (let i = 0; i < simNodes.length; i++) {
+            const nodeI = simNodes[i];
+            for (let j = i + 1; j < simNodes.length; j++) {
+                const nodeJ = simNodes[j];
+                applyRepulsiveForce(nodeI, nodeJ);
+            }
         }
+        return;
     }
+
+    // Large semantic graphs can contain thousands of symbols. Applying distant
+    // repulsion to every pair for every simulation iteration dominates startup
+    // time while contributing only a tiny force between already-separated nodes.
+    // Reuse the deterministic spatial grid so large layouts only evaluate local
+    // neighborhoods; edge attraction and gravity continue to provide global shape.
+    forEachNearbySimulationNodePair(simNodes, LARGE_GRAPH_REPULSION_CELL_SIZE, applyRepulsiveForce);
 }
 
 function applyRepulsiveForce(nodeA: SimulationNode, nodeB: SimulationNode): void {

--- a/src/ui/src/graph/graph-layout.ts
+++ b/src/ui/src/graph/graph-layout.ts
@@ -130,6 +130,28 @@ function getSimulationNodeForLayout(nodeId: string, simNodeById: Map<string, Sim
     return simNode;
 }
 
+/**
+ * Attach renderer-only node references without making them part of serialized graph data.
+ *
+ * The visual graph needs direct node references for fast edge geometry, but enumerating those
+ * references causes JSON.stringify() to duplicate both endpoint nodes for every edge. Large
+ * semantic graphs can therefore spend substantial startup time and memory serializing data that
+ * is already present in the top-level node list. Non-enumerable references keep runtime access
+ * unchanged while the JSON view remains the compact source/target/type graph representation.
+ */
+function createLayoutEdge(
+    edge: GraphVisualizationEdgeRecord,
+    sourceNode: GraphLayoutNode,
+    targetNode: GraphLayoutNode
+): GraphLayoutEdge {
+    const layoutEdge = { ...edge } as GraphLayoutEdge;
+    Object.defineProperties(layoutEdge, {
+        sourceNode: { value: sourceNode },
+        targetNode: { value: targetNode }
+    });
+    return layoutEdge;
+}
+
 function createLayoutEdges(
     layoutNodes: ReadonlyArray<GraphLayoutNode>,
     edges: ReadonlyArray<GraphVisualizationEdgeRecord>
@@ -142,7 +164,7 @@ function createLayoutEdges(
             return [];
         }
 
-        return [{ ...edge, sourceNode, targetNode }];
+        return [createLayoutEdge(edge, sourceNode, targetNode)];
     });
 }
 
@@ -257,13 +279,17 @@ export function filterGraphLayoutForDisplay(parameters: {
         }
 
         visibleEdgeKeys.add(edgeKey);
-        visibleEdges.push({
-            source: sourceNode.id,
-            sourceNode,
-            target: targetNode.id,
-            targetNode,
-            type: edge.type
-        });
+        visibleEdges.push(
+            createLayoutEdge(
+                {
+                    source: sourceNode.id,
+                    target: targetNode.id,
+                    type: edge.type
+                },
+                sourceNode,
+                targetNode
+            )
+        );
     }
 
     return Object.freeze({

--- a/src/ui/src/graph/graph-visualization-bundle.ts
+++ b/src/ui/src/graph/graph-visualization-bundle.ts
@@ -371,6 +371,11 @@ function getGraphVisualizationWebBundleFiles(
     staticWebBundleFilesPromise ??= createGraphVisualizationWebBundleFiles({
         allowStalePrebuilt: options?.isServerMode === true
     });
+    if (options?.isServerMode === true) {
+        void refreshGraphVisualizationBundleCache().catch((error: unknown) => {
+            console.error("Failed to refresh graph visualization web bundle in background:", error);
+        });
+    }
     return staticWebBundleFilesPromise;
 }
 
@@ -379,7 +384,7 @@ function getGraphVisualizationWebBundleFiles(
  *
  * Server mode is allowed to serve the last prebuilt shell immediately. This method checks that shell
  * against the workspace sources in the background and replaces the in-memory asset cache only after
- * a fresh build is ready. The caller can bump its UI revision when `true` is returned.
+ * a fresh build is ready.
  */
 export function refreshGraphVisualizationBundleCache(): Promise<boolean> {
     if (isGraphVisualizationBundleTestEnvironment()) {
@@ -391,6 +396,10 @@ export function refreshGraphVisualizationBundleCache(): Promise<boolean> {
         const hasPrebuiltEntry =
             prebuiltWebDirectory !== null &&
             existsSync(path.join(prebuiltWebDirectory.path, GRAPH_VISUALIZATION_ENTRY_HTML_PATH));
+        if (!hasPrebuiltEntry && staticWebBundleFilesPromise !== null) {
+            await staticWebBundleFilesPromise;
+            return false;
+        }
         if (
             hasPrebuiltEntry &&
             prebuiltWebDirectory !== null &&

--- a/src/ui/src/graph/graph-visualization-bundle.ts
+++ b/src/ui/src/graph/graph-visualization-bundle.ts
@@ -20,7 +20,6 @@ const GRAPH_VISUALIZATION_ENTRY_HTML_PATH = "index.html";
 const GRAPH_VISUALIZATION_WEB_ENTRY_RELATIVE_PATH = path.join("src", "web", GRAPH_VISUALIZATION_ENTRY_HTML_PATH);
 const UTF8_CONTENT_TYPE_SUFFIX = "; charset=utf-8";
 let staticWebBundleFilesPromise: Promise<ReadonlyArray<GraphVisualizationBundleFile>> | null = null;
-let staticWebBundleRefreshPromise: Promise<boolean> | null = null;
 
 function resolveUiWorkspaceRoot(): string {
     const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -371,55 +370,7 @@ function getGraphVisualizationWebBundleFiles(
     staticWebBundleFilesPromise ??= createGraphVisualizationWebBundleFiles({
         allowStalePrebuilt: options?.isServerMode === true
     });
-    if (options?.isServerMode === true) {
-        void refreshGraphVisualizationBundleCache().catch((error: unknown) => {
-            console.error("Failed to refresh graph visualization web bundle in background:", error);
-        });
-    }
     return staticWebBundleFilesPromise;
-}
-
-/**
- * Refresh the cached web assets without making an existing server-mode bundle wait for a Vite build.
- *
- * Server mode is allowed to serve the last prebuilt shell immediately. This method checks that shell
- * against the workspace sources in the background and replaces the in-memory asset cache only after
- * a fresh build is ready.
- */
-export function refreshGraphVisualizationBundleCache(): Promise<boolean> {
-    if (isGraphVisualizationBundleTestEnvironment()) {
-        return Promise.resolve(false);
-    }
-
-    staticWebBundleRefreshPromise ??= (async () => {
-        const prebuiltWebDirectory = resolvePrebuiltWebDirectory();
-        const hasPrebuiltEntry =
-            prebuiltWebDirectory !== null &&
-            existsSync(path.join(prebuiltWebDirectory.path, GRAPH_VISUALIZATION_ENTRY_HTML_PATH));
-        if (!hasPrebuiltEntry && staticWebBundleFilesPromise !== null) {
-            await staticWebBundleFilesPromise;
-            return false;
-        }
-        if (
-            hasPrebuiltEntry &&
-            prebuiltWebDirectory !== null &&
-            (prebuiltWebDirectory.workspaceRoot === null ||
-                (await isWorkspaceWebBundleFresh(prebuiltWebDirectory.workspaceRoot, prebuiltWebDirectory.path)))
-        ) {
-            if (staticWebBundleFilesPromise === null) {
-                staticWebBundleFilesPromise = loadPrebuiltWebBundleFiles(prebuiltWebDirectory.path);
-            }
-            return false;
-        }
-
-        const freshBundleFiles = await createGraphVisualizationWebBundleFiles();
-        staticWebBundleFilesPromise = Promise.resolve(freshBundleFiles);
-        return true;
-    })().finally(() => {
-        staticWebBundleRefreshPromise = null;
-    });
-
-    return staticWebBundleRefreshPromise;
 }
 
 /**

--- a/src/ui/src/graph/graph-visualization-bundle.ts
+++ b/src/ui/src/graph/graph-visualization-bundle.ts
@@ -20,6 +20,7 @@ const GRAPH_VISUALIZATION_ENTRY_HTML_PATH = "index.html";
 const GRAPH_VISUALIZATION_WEB_ENTRY_RELATIVE_PATH = path.join("src", "web", GRAPH_VISUALIZATION_ENTRY_HTML_PATH);
 const UTF8_CONTENT_TYPE_SUFFIX = "; charset=utf-8";
 let staticWebBundleFilesPromise: Promise<ReadonlyArray<GraphVisualizationBundleFile>> | null = null;
+let staticWebBundleRefreshPromise: Promise<boolean> | null = null;
 
 function resolveUiWorkspaceRoot(): string {
     const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -256,24 +257,34 @@ async function loadPrebuiltWebBundleFiles(webDir: string): Promise<ReadonlyArray
     return Object.freeze(files);
 }
 
-async function createGraphVisualizationWebBundleFiles(): Promise<ReadonlyArray<GraphVisualizationBundleFile>> {
+function isGraphVisualizationBundleTestEnvironment(): boolean {
+    return Boolean(
+        process.env.CI ||
+        process.env.NODE_ENV === "test" ||
+        process.env.GMLOOP_TEST === "1" ||
+        process.execArgv.some((argument) => argument.includes("test")) ||
+        process.argv.some((argument) => argument.includes("test"))
+    );
+}
+
+async function createGraphVisualizationWebBundleFiles(options: {
+    allowStalePrebuilt?: boolean;
+} = {}): Promise<ReadonlyArray<GraphVisualizationBundleFile>> {
     const prebuiltWebDirectory = resolvePrebuiltWebDirectory();
-    if (
+    const hasPrebuiltEntry =
         prebuiltWebDirectory !== null &&
-        (prebuiltWebDirectory.workspaceRoot === null ||
+        existsSync(path.join(prebuiltWebDirectory.path, GRAPH_VISUALIZATION_ENTRY_HTML_PATH));
+    if (
+        hasPrebuiltEntry &&
+        prebuiltWebDirectory !== null &&
+        (options.allowStalePrebuilt === true ||
+            prebuiltWebDirectory.workspaceRoot === null ||
             (await isWorkspaceWebBundleFresh(prebuiltWebDirectory.workspaceRoot, prebuiltWebDirectory.path)))
     ) {
         return loadPrebuiltWebBundleFiles(prebuiltWebDirectory.path);
     }
 
-    const isTest =
-        process.env.CI ||
-        process.env.NODE_ENV === "test" ||
-        process.env.GMLOOP_TEST === "1" ||
-        process.execArgv.some((a) => a.includes("test")) ||
-        process.argv.some((a) => a.includes("test"));
-
-    if (isTest) {
+    if (isGraphVisualizationBundleTestEnvironment()) {
         const mockHtml = [
             "<!DOCTYPE html>",
             "<html>",
@@ -355,10 +366,51 @@ async function createGraphVisualizationWebBundleFiles(): Promise<ReadonlyArray<G
 }
 
 function getGraphVisualizationWebBundleFiles(
-    _options?: GraphVisualizationRenderOptions
+    options?: GraphVisualizationRenderOptions
 ): Promise<ReadonlyArray<GraphVisualizationBundleFile>> {
-    staticWebBundleFilesPromise ??= createGraphVisualizationWebBundleFiles();
+    staticWebBundleFilesPromise ??= createGraphVisualizationWebBundleFiles({
+        allowStalePrebuilt: options?.isServerMode === true
+    });
     return staticWebBundleFilesPromise;
+}
+
+/**
+ * Refresh the cached web assets without making an existing server-mode bundle wait for a Vite build.
+ *
+ * Server mode is allowed to serve the last prebuilt shell immediately. This method checks that shell
+ * against the workspace sources in the background and replaces the in-memory asset cache only after
+ * a fresh build is ready. The caller can bump its UI revision when `true` is returned.
+ */
+export function refreshGraphVisualizationBundleCache(): Promise<boolean> {
+    if (isGraphVisualizationBundleTestEnvironment()) {
+        return Promise.resolve(false);
+    }
+
+    staticWebBundleRefreshPromise ??= (async () => {
+        const prebuiltWebDirectory = resolvePrebuiltWebDirectory();
+        const hasPrebuiltEntry =
+            prebuiltWebDirectory !== null &&
+            existsSync(path.join(prebuiltWebDirectory.path, GRAPH_VISUALIZATION_ENTRY_HTML_PATH));
+        if (
+            hasPrebuiltEntry &&
+            prebuiltWebDirectory !== null &&
+            (prebuiltWebDirectory.workspaceRoot === null ||
+                (await isWorkspaceWebBundleFresh(prebuiltWebDirectory.workspaceRoot, prebuiltWebDirectory.path)))
+        ) {
+            if (staticWebBundleFilesPromise === null) {
+                staticWebBundleFilesPromise = loadPrebuiltWebBundleFiles(prebuiltWebDirectory.path);
+            }
+            return false;
+        }
+
+        const freshBundleFiles = await createGraphVisualizationWebBundleFiles();
+        staticWebBundleFilesPromise = Promise.resolve(freshBundleFiles);
+        return true;
+    })().finally(() => {
+        staticWebBundleRefreshPromise = null;
+    });
+
+    return staticWebBundleRefreshPromise;
 }
 
 /**

--- a/src/ui/src/web/register-components.ts
+++ b/src/ui/src/web/register-components.ts
@@ -2,14 +2,12 @@ import { GmAppHeader } from "../app/components/gm-app-header.js";
 import { GmAppShell } from "../app/components/gm-app-shell.js";
 import { GmGraphPanel } from "../app/components/gm-graph-panel.js";
 import { GmGraphToolbar } from "../app/components/gm-graph-toolbar.js";
-import {
-    GmBadge,
-    GmButton,
-    GmCard,
-    GmCopyButton,
-    GmErrorBanner,
-    GmStatusChip
-} from "../app/components/primitives/index.js";
+import { GmBadge } from "../app/components/primitives/gm-badge.js";
+import { GmButton } from "../app/components/primitives/gm-button.js";
+import { GmCard } from "../app/components/primitives/gm-card.js";
+import { GmCopyButton } from "../app/components/primitives/gm-copy-button.js";
+import { GmErrorBanner } from "../app/components/primitives/gm-error-banner.js";
+import { GmStatusChip } from "../app/components/primitives/gm-status-chip.js";
 
 function defineCustomElementOnce(name: string, constructorValue: CustomElementConstructor): void {
     if (!customElements.get(name)) {

--- a/src/ui/src/web/register-components.ts
+++ b/src/ui/src/web/register-components.ts
@@ -1,22 +1,15 @@
+import { GmAppHeader } from "../app/components/gm-app-header.js";
+import { GmAppShell } from "../app/components/gm-app-shell.js";
+import { GmGraphPanel } from "../app/components/gm-graph-panel.js";
+import { GmGraphToolbar } from "../app/components/gm-graph-toolbar.js";
 import {
-    GmAppHeader,
-    GmAppShell,
-    GmAutoGamePanel,
     GmBadge,
     GmButton,
     GmCard,
-    GmConfigPanel,
     GmCopyButton,
-    GmDocsPanel,
     GmErrorBanner,
-    GmFixPanel,
-    GmGraphPanel,
-    GmGraphToolbar,
-    GmJsonViewer,
-    GmLiveReloadPanel,
-    GmPlaygroundPanel,
     GmStatusChip
-} from "../app/components/index.js";
+} from "../app/components/primitives/index.js";
 
 function defineCustomElementOnce(name: string, constructorValue: CustomElementConstructor): void {
     if (!customElements.get(name)) {
@@ -24,8 +17,39 @@ function defineCustomElementOnce(name: string, constructorValue: CustomElementCo
     }
 }
 
+async function registerDeferredGraphVisualizationCustomElements(): Promise<void> {
+    const [
+        { GmAutoGamePanel },
+        { GmConfigPanel },
+        { GmDocsPanel },
+        { GmFixPanel },
+        { GmLiveReloadPanel },
+        { GmPlaygroundPanel },
+        { GmJsonViewer }
+    ] = await Promise.all([
+        import("../app/components/gm-auto-game-panel.js"),
+        import("../app/components/gm-config-panel.js"),
+        import("../app/components/gm-docs-panel.js"),
+        import("../app/components/gm-fix-panel.js"),
+        import("../app/components/gm-live-reload-panel.js"),
+        import("../app/components/gm-playground-panel.js"),
+        import("../app/components/primitives/gm-json-viewer.js")
+    ]);
+
+    defineCustomElementOnce("gm-json-viewer", GmJsonViewer);
+    defineCustomElementOnce("gm-live-reload-panel", GmLiveReloadPanel);
+    defineCustomElementOnce("gm-playground-panel", GmPlaygroundPanel);
+    defineCustomElementOnce("gm-docs-panel", GmDocsPanel);
+    defineCustomElementOnce("gm-fix-panel", GmFixPanel);
+    defineCustomElementOnce("gm-config-panel", GmConfigPanel);
+    defineCustomElementOnce("gm-auto-game-panel", GmAutoGamePanel);
+}
+
 /**
- * Register all graph visualization custom elements.
+ * Register the graph visualization shell and startup-critical custom elements.
+ *
+ * Inactive page surfaces are loaded asynchronously so their modules do not
+ * inflate the startup chunk or delay the initial Graph Index render.
  */
 export function registerGraphVisualizationCustomElements(): void {
     defineCustomElementOnce("gm-button", GmButton);
@@ -33,16 +57,13 @@ export function registerGraphVisualizationCustomElements(): void {
     defineCustomElementOnce("gm-badge", GmBadge);
     defineCustomElementOnce("gm-copy-button", GmCopyButton);
     defineCustomElementOnce("gm-error-banner", GmErrorBanner);
-    defineCustomElementOnce("gm-json-viewer", GmJsonViewer);
     defineCustomElementOnce("gm-status-chip", GmStatusChip);
     defineCustomElementOnce("gm-app-header", GmAppHeader);
     defineCustomElementOnce("gm-page-toolbar", GmGraphToolbar);
     defineCustomElementOnce("gm-graph-panel", GmGraphPanel);
-    defineCustomElementOnce("gm-live-reload-panel", GmLiveReloadPanel);
-    defineCustomElementOnce("gm-playground-panel", GmPlaygroundPanel);
-    defineCustomElementOnce("gm-docs-panel", GmDocsPanel);
-    defineCustomElementOnce("gm-fix-panel", GmFixPanel);
-    defineCustomElementOnce("gm-config-panel", GmConfigPanel);
-    defineCustomElementOnce("gm-auto-game-panel", GmAutoGamePanel);
     defineCustomElementOnce("gm-app-shell", GmAppShell);
+
+    void registerDeferredGraphVisualizationCustomElements().catch((error: unknown) => {
+        console.error("Failed to load deferred graph visualization UI components:", error);
+    });
 }

--- a/src/ui/test/graph-layout-serialization.test.ts
+++ b/src/ui/test/graph-layout-serialization.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createGraphLayout, filterGraphLayoutForDisplay } from "../src/graph/graph-layout.js";
+import type {
+    GraphVisualizationEdgeType,
+    GraphVisualizationNodeKind,
+    GraphVisualizationNodeRecord
+} from "../src/graph/types.js";
+
+function createNode(id: string, kind: GraphVisualizationNodeKind): GraphVisualizationNodeRecord {
+    return {
+        displayName: id,
+        filePath: null,
+        graphId: "project",
+        id,
+        kind,
+        lineEnd: null,
+        lineStart: null,
+        name: id,
+        resourcePath: null,
+        scopeId: null,
+        scipSymbol: null,
+        snippet: "",
+        summary: ""
+    };
+}
+
+void test("graph layout JSON does not duplicate renderer-only edge endpoint nodes", () => {
+    const layout = createGraphLayout(
+        [createNode("project", "project"), createNode("script", "script")],
+        [{ source: "project", target: "script", type: "contains" }]
+    );
+    const edge = layout.edges[0];
+
+    assert.ok(edge);
+    assert.equal(edge.sourceNode.id, "project");
+    assert.equal(edge.targetNode.id, "script");
+    assert.deepEqual(JSON.parse(JSON.stringify(edge)), {
+        source: "project",
+        target: "script",
+        type: "contains"
+    });
+});
+
+void test("filtered promoted edges keep endpoint references non-enumerable", () => {
+    const layout = createGraphLayout(
+        [
+            createNode("project", "project"),
+            createNode("script", "script"),
+            createNode("function", "function")
+        ],
+        [
+            { source: "project", target: "script", type: "contains" },
+            { source: "script", target: "function", type: "defines" }
+        ]
+    );
+    const filtered = filterGraphLayoutForDisplay({
+        enabledEdgeTypes: new Set<GraphVisualizationEdgeType>(["contains", "defines"]),
+        enabledNodeKinds: new Set<GraphVisualizationNodeKind>(["project", "function"]),
+        layout,
+        matchesNode: () => true
+    });
+    const edge = filtered.edges[0];
+
+    assert.ok(edge);
+    assert.equal(edge.sourceNode.id, "project");
+    assert.equal(edge.targetNode.id, "function");
+    assert.deepEqual(JSON.parse(JSON.stringify(edge)), {
+        source: "project",
+        target: "function",
+        type: "defines"
+    });
+});


### PR DESCRIPTION
## Summary

Optimize the graph visualization UI startup path so the browser can become usable much sooner on large semantic indexes and local server launches.

## Root causes

- Large graph layouts ran 80 full all-pairs repulsion passes, making the force-refinement phase quadratic in the number of graph nodes.
- Layout edges stored enumerable `sourceNode` and `targetNode` objects, so the graph panel's JSON serialization duplicated full endpoint node payloads for every visible edge.
- In server mode, a stale local `dist/web` bundle forced a source-tree freshness scan and synchronous Vite rebuild before the first HTML document could be served.
- The web entry eagerly imported and registered every UI page surface, so Docs, Config, Fix, Auto-Game, Playground, Live Reload, and the JSON viewer all inflated the startup module graph even though Graph Index is the initial page.

## Changes

- Preserve the existing exact all-pairs force simulation for small graphs, but switch large graphs to the existing deterministic spatial-grid neighborhood traversal for repulsion.
- Keep direct `sourceNode` / `targetNode` references for rendering while making them non-enumerable, so JSON serialization emits only the compact edge record.
- In server mode, use an existing prebuilt UI shell immediately instead of freshness-scanning and rebuilding it on the first request. Normal non-server/static export behavior retains the existing freshness checks.
- Register only the shell, header, toolbar, graph panel, and graph-critical primitives synchronously. Load inactive page surfaces and the JSON viewer through dynamic imports so Vite can split them out of the initial startup chunk.
- Use direct primitive imports instead of the primitives barrel so the JSON viewer remains outside the eager module graph.
- Add regression coverage proving layout edge endpoint references remain available at runtime without being duplicated into serialized JSON.

## Impact

This removes the largest known main-thread scaling bottleneck for large semantic graphs, removes local UI compilation from the first-response critical path when a prebuilt server shell is available, and reduces the amount of UI code that must be loaded and evaluated before the initial Graph Index render. Small graph layout behavior remains on the existing algorithm.

## Validation

- Added focused graph-layout serialization regression tests.
- Existing large/deep graph layout tests exercise the new large-graph spatial-repulsion path and continue to enforce minimum node spacing and a performance ceiling when run in CI.
- Local test execution was not available from the connector-only environment used to make these changes; GitHub CI should be treated as the authoritative validation for this draft.