### PR TITLE
Center graph layout and reduce edge overlap

### DIFF
--- a/src/ui/src/graph/graph-layout-hierarchy.ts
+++ b/src/ui/src/graph/graph-layout-hierarchy.ts
@@ -7,6 +7,7 @@ import type {
 const ROOT_HIERARCHY_RADIUS = 320;
 const SECOND_LEVEL_HIERARCHY_RADIUS = 150;
 const DEEP_HIERARCHY_RADIUS = 95;
+const AUXILIARY_ROOT_RADIUS = 720;
 
 export const PROMOTABLE_HIERARCHY_EDGE_TYPES = new Set<GraphVisualizationEdgeType>(["contains", "defines"]);
 
@@ -34,7 +35,15 @@ export function buildGraphHierarchy(
         }
     }
 
-    const projectNodes = nodes.filter((node) => node.kind === "project");
+    // Keep the actual game/project root first. The graph can also contain a toolset
+    // project node, and downstream centering intentionally anchors to projectNodes[0].
+    const projectNodes = nodes
+        .filter((node) => node.kind === "project")
+        .toSorted((left, right) => {
+            const leftPriority = left.graphId === "project" ? 0 : 1;
+            const rightPriority = right.graphId === "project" ? 0 : 1;
+            return leftPriority - rightPriority || left.id.localeCompare(right.id);
+        });
     const defaultParentId = projectNodes.length > 0 ? projectNodes[0].id : null;
     for (const node of nodes) {
         if (node.kind !== "project" && !parentMap.has(node.id) && defaultParentId && node.id !== defaultParentId) {
@@ -63,9 +72,26 @@ export function seedInitialGraphPositions(
 ): Map<string, InitialGraphPosition> {
     const initialPositions = new Map<string, InitialGraphPosition>();
     const visitedNodeIds = new Set<string>();
+    const primaryProjectNode = hierarchy.projectNodes[0];
 
-    for (const projectNode of hierarchy.projectNodes) {
-        layoutHierarchyBranch(projectNode.id, 0, 0, null, 0, hierarchy, initialPositions, visitedNodeIds);
+    if (primaryProjectNode) {
+        layoutHierarchyBranch(primaryProjectNode.id, 0, 0, null, 0, hierarchy, initialPositions, visitedNodeIds);
+    }
+
+    const auxiliaryProjectNodes = hierarchy.projectNodes.slice(1);
+    for (let index = 0; index < auxiliaryProjectNodes.length; index++) {
+        const projectNode = auxiliaryProjectNodes[index];
+        const theta = Math.PI + (index / Math.max(1, auxiliaryProjectNodes.length)) * Math.PI * 2;
+        layoutHierarchyBranch(
+            projectNode.id,
+            Math.cos(theta) * AUXILIARY_ROOT_RADIUS,
+            Math.sin(theta) * AUXILIARY_ROOT_RADIUS,
+            theta,
+            0,
+            hierarchy,
+            initialPositions,
+            visitedNodeIds
+        );
     }
 
     for (const node of nodes) {
@@ -139,6 +165,18 @@ function getInitialHierarchyPosition(
     const siblings = parentId ? (hierarchy.childrenMap.get(parentId) ?? []) : [];
     const index = siblings.indexOf(nodeId);
     const count = siblings.length;
+
+    // Direct children of the game/project root should surround it instead of
+    // occupying a narrow forward arc. This keeps the root visually central and
+    // gives top-level branches distinct radial lanes before force refinement.
+    if (depth === 1) {
+        const theta = count > 1 ? (index / count) * Math.PI * 2 : parentActualAngle;
+        return {
+            angle: theta,
+            x: parentX + Math.cos(theta) * radius,
+            y: parentY + Math.sin(theta) * radius
+        };
+    }
 
     if (parentAngle === null) {
         const theta = count > 1 ? (index / count) * Math.PI * 2 : 0;

--- a/src/ui/src/graph/graph-render-viewport.ts
+++ b/src/ui/src/graph/graph-render-viewport.ts
@@ -10,6 +10,8 @@ const AUTO_LABEL_MIN_SCALE = 0.8;
 const EDGE_BATCH_OVERVIEW_MAX_SCALE = 0.75;
 const EDGE_BATCH_OVERVIEW_COUNT_THRESHOLD = 150;
 const EDGE_BATCH_COUNT_THRESHOLD = 750;
+const PARALLEL_EDGE_LANE_SPACING = 24;
+const MAX_PARALLEL_EDGE_LANE_OFFSET = 96;
 
 export type GraphViewportTransform = Readonly<{
     panX: number;
@@ -166,18 +168,81 @@ function getEdgeIntersection(edge: GraphLayoutEdge): Readonly<{ x1: number; x2: 
     };
 }
 
+function readCanonicalEdgePairKey(edge: GraphLayoutEdge): string {
+    return edge.source <= edge.target ? `${edge.source}\u0000${edge.target}` : `${edge.target}\u0000${edge.source}`;
+}
+
+function readEdgeRouteSortKey(edge: GraphLayoutEdge): string {
+    return `${edge.source}\u0000${edge.target}\u0000${edge.type}`;
+}
+
+/**
+ * Assign deterministic curved lanes to relationships that connect the same pair of nodes. This
+ * prevents reciprocal and multi-type relationships from being painted directly on top of one
+ * another in dense batched views while keeping single relationships straight.
+ */
+function buildParallelEdgeLaneOffsets(edges: ReadonlyArray<GraphLayoutEdge>): Map<GraphLayoutEdge, number> {
+    const edgesByPair = new Map<string, Array<GraphLayoutEdge>>();
+    for (const edge of edges) {
+        const pairKey = readCanonicalEdgePairKey(edge);
+        const pairEdges = edgesByPair.get(pairKey) ?? [];
+        pairEdges.push(edge);
+        edgesByPair.set(pairKey, pairEdges);
+    }
+
+    const offsetByEdge = new Map<GraphLayoutEdge, number>();
+    for (const pairEdges of edgesByPair.values()) {
+        if (pairEdges.length < 2) {
+            continue;
+        }
+
+        const sortedEdges = pairEdges.toSorted((left, right) =>
+            readEdgeRouteSortKey(left).localeCompare(readEdgeRouteSortKey(right))
+        );
+        const centerIndex = (sortedEdges.length - 1) / 2;
+        for (let index = 0; index < sortedEdges.length; index++) {
+            const edge = sortedEdges[index];
+            const canonicalOffset = Math.max(
+                -MAX_PARALLEL_EDGE_LANE_OFFSET,
+                Math.min(MAX_PARALLEL_EDGE_LANE_OFFSET, (index - centerIndex) * PARALLEL_EDGE_LANE_SPACING)
+            );
+            const directionMultiplier = edge.source <= edge.target ? 1 : -1;
+            offsetByEdge.set(edge, canonicalOffset * directionMultiplier);
+        }
+    }
+
+    return offsetByEdge;
+}
+
+function createRoutedEdgePathPart(edge: GraphLayoutEdge, laneOffset: number): string {
+    const geometry = getEdgeIntersection(edge);
+    if (laneOffset === 0) {
+        return `M${String(geometry.x1)},${String(geometry.y1)}L${String(geometry.x2)},${String(geometry.y2)}`;
+    }
+
+    const dx = geometry.x2 - geometry.x1;
+    const dy = geometry.y2 - geometry.y1;
+    const distance = Math.hypot(dx, dy) || 1;
+    const perpendicularX = -dy / distance;
+    const perpendicularY = dx / distance;
+    const controlX = (geometry.x1 + geometry.x2) / 2 + perpendicularX * laneOffset;
+    const controlY = (geometry.y1 + geometry.y2) / 2 + perpendicularY * laneOffset;
+    return `M${String(geometry.x1)},${String(geometry.y1)}Q${String(controlX)},${String(controlY)},${String(geometry.x2)},${String(geometry.y2)}`;
+}
+
 /**
  * Collapse many line elements into style-compatible path batches. Directional arrowheads are omitted
  * in batch mode; they return automatically when zoom/detail and graph size permit per-edge rendering.
+ * Parallel relationships are routed through separate curved lanes so distinct semantics remain legible.
  */
 export function buildGraphEdgeBatches(edges: ReadonlyArray<GraphLayoutEdge>): ReadonlyArray<GraphEdgeBatch> {
     const pathPartsByType = new Map<GraphVisualizationEdgeType, Array<string>>();
     const edgeCountByType = new Map<GraphVisualizationEdgeType, number>();
+    const laneOffsetByEdge = buildParallelEdgeLaneOffsets(edges);
 
     for (const edge of edges) {
-        const geometry = getEdgeIntersection(edge);
         const pathParts = pathPartsByType.get(edge.type) ?? [];
-        pathParts.push(`M${String(geometry.x1)},${String(geometry.y1)}L${String(geometry.x2)},${String(geometry.y2)}`);
+        pathParts.push(createRoutedEdgePathPart(edge, laneOffsetByEdge.get(edge) ?? 0));
         pathPartsByType.set(edge.type, pathParts);
         edgeCountByType.set(edge.type, (edgeCountByType.get(edge.type) ?? 0) + 1);
     }

--- a/src/ui/test/graph-edge-routing.test.ts
+++ b/src/ui/test/graph-edge-routing.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { GraphLayoutEdge, GraphLayoutNode } from "../src/graph/graph-layout.js";
+import { buildGraphEdgeBatches } from "../src/graph/graph-render-viewport.js";
+
+function createNode(id: string, x: number, y: number): GraphLayoutNode {
+    return {
+        displayName: id,
+        filePath: null,
+        graphId: "project",
+        id,
+        kind: "script",
+        lineEnd: null,
+        lineStart: null,
+        name: id,
+        radius: 10,
+        resourcePath: null,
+        scopeId: null,
+        scipSymbol: null,
+        snippet: "",
+        summary: "",
+        x,
+        y
+    };
+}
+
+function createEdge(
+    sourceNode: GraphLayoutNode,
+    targetNode: GraphLayoutNode,
+    type: GraphLayoutEdge["type"]
+): GraphLayoutEdge {
+    return {
+        source: sourceNode.id,
+        sourceNode,
+        target: targetNode.id,
+        targetNode,
+        type
+    };
+}
+
+void test("batched relationships sharing endpoints are routed into distinct curved lanes", () => {
+    const left = createNode("left", 0, 0);
+    const right = createNode("right", 200, 0);
+    const batches = buildGraphEdgeBatches([
+        createEdge(left, right, "calls"),
+        createEdge(left, right, "references")
+    ]).toSorted((leftBatch, rightBatch) => leftBatch.type.localeCompare(rightBatch.type));
+
+    assert.equal(batches.length, 2);
+    assert.ok(batches.every((batch) => batch.pathData.includes("Q")));
+    assert.notEqual(batches[0]?.pathData, batches[1]?.pathData);
+});
+
+void test("reciprocal relationships are routed onto opposite sides instead of overlapping", () => {
+    const left = createNode("left", 0, 0);
+    const right = createNode("right", 200, 0);
+    const batches = buildGraphEdgeBatches([
+        createEdge(left, right, "references"),
+        createEdge(right, left, "calls")
+    ]);
+
+    assert.equal(batches.length, 2);
+    assert.ok(batches.every((batch) => batch.pathData.includes("Q")));
+    assert.notEqual(batches[0]?.pathData, batches[1]?.pathData);
+});
+
+void test("single batched relationships remain straight", () => {
+    const left = createNode("left", 0, 0);
+    const right = createNode("right", 200, 0);
+    const [batch] = buildGraphEdgeBatches([createEdge(left, right, "calls")]);
+
+    assert.ok(batch);
+    assert.ok(batch.pathData.includes("L"));
+    assert.ok(!batch.pathData.includes("Q"));
+});

--- a/src/ui/test/graph-layout-hierarchy-centering.test.ts
+++ b/src/ui/test/graph-layout-hierarchy-centering.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildGraphHierarchy, seedInitialGraphPositions } from "../src/graph/graph-layout-hierarchy.js";
+import type { GraphVisualizationNodeRecord } from "../src/graph/types.js";
+
+function createNode(
+    id: string,
+    kind: GraphVisualizationNodeRecord["kind"],
+    graphId: GraphVisualizationNodeRecord["graphId"] = "project"
+): GraphVisualizationNodeRecord {
+    return {
+        displayName: id,
+        filePath: null,
+        graphId,
+        id,
+        kind,
+        lineEnd: null,
+        lineStart: null,
+        name: id,
+        resourcePath: null,
+        scopeId: null,
+        scipSymbol: null,
+        snippet: "",
+        summary: ""
+    };
+}
+
+void test("graph hierarchy prefers and centers the game project root ahead of toolset roots", () => {
+    const toolsetRoot = createNode("toolset-root", "project", "toolset");
+    const gameRoot = createNode("game-root", "project", "project");
+    const script = createNode("script", "script");
+    const nodes = [toolsetRoot, gameRoot, script];
+    const hierarchy = buildGraphHierarchy(nodes, [{ source: gameRoot.id, target: script.id, type: "contains" }]);
+    const positions = seedInitialGraphPositions(nodes, hierarchy);
+
+    assert.deepEqual(
+        hierarchy.projectNodes.map((node) => node.id),
+        [gameRoot.id, toolsetRoot.id]
+    );
+    assert.deepEqual(positions.get(gameRoot.id), { angle: 0, x: 0, y: 0 });
+    assert.notDeepEqual(positions.get(toolsetRoot.id), { angle: 0, x: 0, y: 0 });
+});
+
+void test("top-level game branches surround the project root instead of occupying one side", () => {
+    const gameRoot = createNode("game-root", "project");
+    const children = Array.from({ length: 8 }, (_, index) => createNode(`script-${String(index)}`, "script"));
+    const nodes = [gameRoot, ...children];
+    const hierarchy = buildGraphHierarchy(
+        nodes,
+        children.map((node) => ({ source: gameRoot.id, target: node.id, type: "contains" as const }))
+    );
+    const positions = seedInitialGraphPositions(nodes, hierarchy);
+    const childPositions = children.map((node) => positions.get(node.id));
+
+    assert.ok(childPositions.every((position) => position !== undefined));
+    const xValues = childPositions.map((position) => position?.x ?? 0);
+    const yValues = childPositions.map((position) => position?.y ?? 0);
+    const averageX = xValues.reduce((sum, value) => sum + value, 0) / xValues.length;
+    const averageY = yValues.reduce((sum, value) => sum + value, 0) / yValues.length;
+
+    assert.ok(Math.min(...xValues) < 0);
+    assert.ok(Math.max(...xValues) > 0);
+    assert.ok(Math.min(...yValues) < 0);
+    assert.ok(Math.max(...yValues) > 0);
+    assert.ok(Math.abs(averageX) < 1e-9);
+    assert.ok(Math.abs(averageY) < 1e-9);
+});


### PR DESCRIPTION
## Summary

- prioritize the actual game/project root over the optional toolset root when building the graph hierarchy
- seed top-level game branches around the project root across a full 360° instead of a narrow forward arc
- place auxiliary project/toolset roots away from the game root so they no longer begin stacked at the same origin
- keep downstream centering anchored to the game root by ordering it first in `projectNodes`
- route dense batched relationships that share the same endpoints through deterministic curved lanes so reciprocal and multi-type edges do not paint directly on top of one another
- keep single relationships straight and preserve the existing batching/performance behavior
- add focused regression tests for root centering, radial branch distribution, and edge-lane routing

## Why

The graph layout could look visibly off-center even though the root was later translated to `(0, 0)`, because first-level children were seeded into only a 144° arc. That made nearly the entire graph grow to one side of the game/project node. When both project and toolset roots were present, both were also initially seeded at the origin and the first `project` node depended on input ordering.

Dense batched graph views also drew multiple relationships between the same two nodes along exactly the same segment, hiding distinct edge types and reciprocal relationships.

## Impact

The game/project node remains the visual anchor, with its primary branches distributed around it rather than predominantly to one side. Auxiliary roots stay spatially separate. Dense relationship bundles become easier to distinguish without introducing an expensive global edge-crossing solver or regressing the existing large-graph rendering optimizations.

## Validation

Added focused tests covering:

- game/project root precedence when a toolset root is also present
- project root placement at the origin
- full-circle distribution of top-level branches around the root
- distinct curved lanes for same-endpoint and reciprocal batched relationships
- straight routing for single relationships

Local test execution was not available in the connector-only environment used for these changes; GitHub CI should be treated as the authoritative validation for this draft.