### PR TITLE
Fix LSP semantic lease build contract

### DIFF
--- a/src/lsp/src/intelligence/identifier-index.ts
+++ b/src/lsp/src/intelligence/identifier-index.ts
@@ -42,13 +42,6 @@ type GmlSymbolDocumentation = ReturnType<typeof Semantic.createEmptyGmlSymbolDoc
 type SemanticFileManifest = Awaited<ReturnType<typeof Semantic.buildSemanticFileManifest>>;
 type SemanticSnapshot = ReturnType<typeof Semantic.createSemanticSnapshotFromProjectIndex>;
 type SemanticIndexStore = ReturnType<typeof Semantic.openSemanticIndexStore>;
-/**
- * Narrow snapshot-lease-acquisition role, mirroring the
- * `SemanticSnapshotLeaseAcquirer` role type exported by `@gmloop/semantic`.
- * `withPinnedSemanticQueries` only ever leases a snapshot, so it depends on
- * this slice of `SemanticIndexStore` rather than the full store contract.
- */
-type SemanticSnapshotLeaseAcquirer = Pick<SemanticIndexStore, "acquireSemanticSnapshot">;
 type SemanticSnapshotAcquireResult = Awaited<ReturnType<SemanticIndexStore["acquireSemanticSnapshot"]>>;
 type SemanticSnapshotLease = Extract<SemanticSnapshotAcquireResult, Readonly<{ kind: "lease" }>>["lease"];
 type SemanticSnapshotQueries = SemanticSnapshotLease["queries"];
@@ -158,7 +151,7 @@ function createNavigationSnapshotRequirements(
 }
 
 async function withPinnedSemanticQueries<Result>(
-    store: SemanticSnapshotLeaseAcquirer,
+    store: SemanticIndexStore,
     state: NavigationState,
     document: GmlTextDocument,
     capability: RequiredSemanticCapability,


### PR DESCRIPTION
## Summary

Fix the current repository-wide TypeScript build failure in `src/lsp/src/intelligence/identifier-index.ts`.

## Root cause

PR #10087 was merged from an older branch after the Law-of-Demeter snapshot helper had already landed on `main`. Each change built independently, but Git combined them into an incompatible type contract without a textual merge conflict:

- #10087 narrowed `withPinnedSemanticQueries` from the full semantic store to an acquisition-only local type.
- Later `main` had refactored that path through `withSemanticLeaseQueries`, whose parameter still requires the full `SemanticIndexStore`.
- The merged source therefore passes the narrow acquisition-only value into the full-store helper, producing TS2345 (`SemanticSnapshotLeaseAcquirer` is not assignable to `SemanticIndexStore`).

## Fix

Restore only the stale #10087 narrowing hunk in `identifier-index.ts`, returning `withPinnedSemanticQueries` to the full `SemanticIndexStore` contract expected by `withSemanticLeaseQueries`.

This is deliberately a minimal integration repair: it keeps the newer Law-of-Demeter helper and the semantic-store role split intact, while removing the incompatible caller narrowing that was merged later from the stale branch.

## Scope

- 1 file changed
- 1 insertion / 8 deletions
- No runtime behavior changes; this repairs the TypeScript dependency contract only.

## Validation

The branch is based directly on current `main` at `f3461209f56069f7d0fcf49e2433814de3803841`. The repository's auto-merge validation will exercise both the PR head and exact synthetic merge; this PR is expected to exercise the broken-base recovery path introduced by #10298.