### PR TITLE
Harden auto-merge control-plane handoff and recovery

### DIFF
--- a/.github/workflows/automerge-finalize.yml
+++ b/.github/workflows/automerge-finalize.yml
@@ -1,11 +1,19 @@
 name: "Finalize auto-merge"
+run-name: "Finalize auto-merge validation run ${{ inputs.validation_run_id }}"
 
 on:
-  workflow_run:
-    workflows: ["Auto-merge PRs"]
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      validation_run_id:
+        description: "Completed Auto-merge PRs workflow run to finalize."
+        required: true
+        type: string
 
 permissions: {}
+
+concurrency:
+  group: automerge-finalize-${{ inputs.validation_run_id }}
+  cancel-in-progress: false
 
 jobs:
   analyze:
@@ -16,7 +24,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
@@ -45,22 +53,60 @@ jobs:
         with:
           name: validation-target
           path: target
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: resolve
-        name: Resolve current PR and trust boundary
+        name: Resolve validation run, current PR, and trust boundary
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          VALIDATION_RUN_ID: ${{ inputs.validation_run_id }}
         with:
           script: |
             const fs = require('node:fs');
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
             const { owner, repo } = context.repo;
+            const runId = Number(process.env.VALIDATION_RUN_ID || 0);
+            core.setOutput('validation_conclusion', '');
+            core.setOutput('validation_url', '');
+            core.setOutput('pr_number', '');
+            core.setOutput('head_sha', '');
+            core.setOutput('base_sha', '');
+            core.setOutput('merge_sha', '');
+            core.setOutput('retry', '0');
+            core.setOutput('blocked_reason', 'infrastructure');
+            core.setOutput('max_retries', '1');
+            core.setOutput('current', 'false');
+            core.setOutput('trusted', 'false');
+            if (!Number.isInteger(runId) || runId <= 0) {
+              core.setFailed('Finalization requires a positive validation workflow run ID.');
+              return;
+            }
+
+            const { data: validationRun } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+            if (validationRun.path !== '.github/workflows/automerge-prs.yml'
+                || validationRun.event !== 'workflow_dispatch'
+                || validationRun.status !== 'completed') {
+              core.setFailed(`Run ${runId} is not a completed trusted Auto-merge PRs workflow_dispatch run.`);
+              return;
+            }
+            core.setOutput('validation_conclusion', String(validationRun.conclusion || ''));
+            core.setOutput('validation_url', String(validationRun.html_url || ''));
+
             let target = null;
             try { target = JSON.parse(fs.readFileSync('target/validation-target.json', 'utf8')); } catch {}
             if (!target) {
-              const match = String(process.env.RUN_TITLE || '').match(/PR #(\d+) @ ([0-9a-f]{40})/u);
-              if (match) target = { prNumber: Number(match[1]), headSha: match[2], baseSha: '', mergeSha: '', retry: 0, blockedReason: 'infrastructure' };
+              const match = String(validationRun.display_title || '').match(/PR #(\d+) @ ([0-9a-f]{40})/u);
+              if (match) {
+                target = {
+                  prNumber: Number(match[1]),
+                  headSha: match[2],
+                  baseSha: '',
+                  mergeSha: '',
+                  retry: 0,
+                  blockedReason: 'infrastructure',
+                };
+              }
             }
             const number = Number(target?.prNumber || 0);
             const head = String(target?.headSha || '');
@@ -73,15 +119,25 @@ jobs:
             core.setOutput('merge_sha', merge);
             core.setOutput('retry', Number.isInteger(retry) ? String(retry) : '0');
             core.setOutput('blocked_reason', String(target?.blockedReason || ''));
-            core.setOutput('max_retries', '1');
-            core.setOutput('current', 'false');
-            core.setOutput('trusted', 'false');
             if (!Number.isInteger(number) || number <= 0 || !/^[0-9a-f]{40}$/u.test(head)) return;
 
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
             if (pr.state !== 'open' || pr.draft || pr.base.ref !== 'main' || pr.head.sha !== head) return;
-            const runId = Number(context.payload.workflow_run?.id || 0);
-            const runCreatedAt = new Date(context.payload.workflow_run?.created_at || 0).getTime();
+
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const latest = stateModule.findLatestBotAutoMergeState(comments);
+            if (!stateModule.validationRunNeedsFinalization(latest, runId, head)) {
+              core.notice(`Validation run ${runId} for PR #${number} is already finalized or superseded.`);
+              return;
+            }
+
+            const runCreatedAt = new Date(validationRun.created_at || 0).getTime();
             const recentRuns = await github.rest.actions.listWorkflowRuns({
               owner, repo, workflow_id: 'automerge-prs.yml', per_page: 50,
             });
@@ -108,7 +164,7 @@ jobs:
               typeof filename === 'string' && trustedPatterns.some((pattern) => pattern.test(filename));
             const trustedChange = files.some((file) => matches(file.filename) || matches(file.previous_filename));
             core.setOutput('trusted', trustedChange ? 'false' : 'true');
-            core.notice(`Finalizer resolved PR #${number} at ${head}; trusted=${!trustedChange}, base=${base || 'missing'}.`);
+            core.notice(`Finalizer resolved validation run ${runId} for PR #${number} at ${head}; trusted=${!trustedChange}, base=${base || 'missing'}.`);
       - name: Revalidate stale trusted product PR without mutating its branch
         id: freshness
         if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.resolve.outputs.base_sha != '' && steps.resolve.outputs.blocked_reason == '' }}
@@ -125,31 +181,31 @@ jobs:
         run: node src/cli/src/commands/ci-automerge-evidence.ts fingerprint --github-output "$GITHUB_OUTPUT"
       - name: Download exact base evidence
         id: base_download
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-base
           path: report-base
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download exact synthetic-merge evidence
         id: merge_download
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-merge
           path: report-merge
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download optional complete ancestor evidence
         id: ancestor_download
         continue-on-error: true
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-ancestor
           path: report-ancestor
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: provenance
         name: Verify exact evidence provenance
@@ -259,10 +315,11 @@ jobs:
           TRUSTED: ${{ steps.resolve.outputs.trusted }}
           BLOCKED: ${{ steps.resolve.outputs.blocked_reason }}
           FRESHNESS: ${{ steps.freshness.outputs.status }}
-          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_CONCLUSION: ${{ steps.resolve.outputs.validation_conclusion }}
           EVAL_GREEN: ${{ steps.evaluate.outputs.green }}
           EVAL_REASON: ${{ steps.evaluate.outputs.reason }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ inputs.validation_run_id }}
+          TARGET_URL: ${{ steps.resolve.outputs.validation_url }}
         with:
           script: |
             const fs = require('node:fs');
@@ -305,7 +362,10 @@ jobs:
               summary = '### Trusted auto-merge evaluation\n\n⚠️ Expected trusted evaluation output was unavailable.';
             }
 
-            const stateModule = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'src/cli/src/commands/ci-automerge-state.ts')).href);
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
             const state = {
               pr: number,
               head: process.env.HEAD_SHA,
@@ -316,13 +376,12 @@ jobs:
               retry: Number(process.env.RETRY || 0),
               runId: Number(process.env.RUN_ID || 0),
             };
-            const stateMarker = stateModule.serializeAutoMergeState(state);
-            const marker = '<!-- automerge-pr-test-summary -->';
-            const body = `${marker}\n${stateMarker}\n${summary}`;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: number, per_page: 100 });
-            const existing = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-            if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const existing = stateModule.findBotAutoMergeSummaryComment(comments);
+            const body = stateModule.renderAutoMergeStateComment(state, summary);
+            if (existing?.id) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             else await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
 
             let status = 'failure';
@@ -351,7 +410,7 @@ jobs:
               owner, repo, sha: process.env.HEAD_SHA, state: status,
               context: 'automerge/trusted-validation',
               description: description.slice(0, 140),
-              target_url: context.payload.workflow_run?.html_url,
+              target_url: process.env.TARGET_URL || undefined,
             });
             core.setOutput('green', green ? 'true' : 'false');
             core.setOutput('reason', reason);
@@ -467,7 +526,7 @@ jobs:
         with:
           name: report-merge
           path: report-merge
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Retarget validated evidence to the identical landed tree
         if: ${{ steps.provenance.outputs.valid == 'true' }}

--- a/.github/workflows/automerge-reconcile.yml
+++ b/.github/workflows/automerge-reconcile.yml
@@ -4,8 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
+  # This accelerates human-dispatched workers. Bot-dispatched workers are still
+  # recovered deterministically by the periodic coordinator below.
   workflow_run:
-    workflows: ["Finalize auto-merge"]
+    workflows: ["Auto-merge PRs"]
     types: [completed]
   schedule:
     - cron: "*/5 * * * *"
@@ -19,14 +21,14 @@ concurrency:
 
 jobs:
   discover:
-    name: Admit validation and trusted merge candidates
+    name: Coordinate validation and trusted merge candidates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       matrix: ${{ steps.queue.outputs.matrix }}
@@ -55,25 +57,65 @@ jobs:
               core.setFailed('Invalid auto-merge admission policy.');
               return;
             }
-            const stateModule = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'src/cli/src/commands/ci-automerge-state.ts')).href);
+
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
             const { data: branch } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
             const liveBase = branch.commit.sha;
             const pulls = await github.paginate(github.rest.pulls.list, {
               owner, repo, state: 'open', base: 'main', sort: 'created', direction: 'asc', per_page: 100,
             });
 
-            const runs = await github.rest.actions.listWorkflowRuns({
+            const { data: validationRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner, repo, workflow_id: 'automerge-prs.yml', per_page: 100,
             });
-            const active = new Map();
-            for (const run of runs.data.workflow_runs) {
-              if (!['queued', 'in_progress'].includes(run.status)) continue;
-              const match = String(run.display_title || '').match(/PR #(\d+) @ ([0-9a-f]{40})/u);
-              if (match) active.set(Number(match[1]), match[2]);
+            const validationRuns = validationRunsResponse.workflow_runs;
+            const activeValidations = new Map();
+            const completedValidations = new Map();
+            for (const run of validationRuns) {
+              const identity = stateModule.parseAutoMergeValidationRunTitle(run.display_title);
+              if (!identity) continue;
+              const key = `${identity.pr}:${identity.head}`;
+              if (['queued', 'in_progress'].includes(run.status)) {
+                // Workflow runs are returned newest-first; retain the newest active
+                // head for each PR so an older cancelling run cannot trigger a duplicate.
+                if (!activeValidations.has(identity.pr)) activeValidations.set(identity.pr, identity.head);
+                continue;
+              }
+              if (run.status !== 'completed' || completedValidations.has(key)) continue;
+              completedValidations.set(key, run);
             }
+
+            const { data: finalizerRunsResponse } = await github.rest.actions.listWorkflowRuns({
+              owner, repo, workflow_id: 'automerge-finalize.yml', per_page: 100,
+            });
+            const activeFinalizers = new Set();
+            const finalizerAttempts = new Map();
+            for (const run of finalizerRunsResponse.workflow_runs) {
+              const validationRunId = stateModule.parseAutoMergeFinalizerRunTitle(run.display_title);
+              if (!validationRunId) continue;
+              finalizerAttempts.set(validationRunId, (finalizerAttempts.get(validationRunId) || 0) + 1);
+              if (['queued', 'in_progress'].includes(run.status)) activeFinalizers.add(validationRunId);
+            }
+
+            const upsertState = async (pr, state, summary, knownComments = null) => {
+              const comments = knownComments || await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const existing = stateModule.findBotAutoMergeSummaryComment(comments);
+              const body = stateModule.renderAutoMergeStateComment(state, summary);
+              if (existing?.id) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+              }
+            };
 
             const eventPr = Number(process.env.EVENT_PR || 0);
             const validations = [];
+            const finalizations = [];
             const reconcile = [];
             for (const pr of pulls) {
               if (pr.draft) continue;
@@ -81,20 +123,62 @@ jobs:
                 core.notice(`PR #${pr.number} comes from an external repository; unattended validation/merge is disabled.`);
                 continue;
               }
+
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: pr.number, per_page: 100,
               });
               const latest = stateModule.findLatestBotAutoMergeState(comments);
+              const key = `${pr.number}:${pr.head.sha}`;
+              const completed = completedValidations.get(key);
+              if (completed && stateModule.validationRunNeedsFinalization(latest, completed.id, pr.head.sha)) {
+                if (activeFinalizers.has(completed.id)) continue;
+                const attempts = finalizerAttempts.get(completed.id) || 0;
+                const handoffRetry = latest?.head === pr.head.sha
+                  && latest.reason === 'infrastructure'
+                  && latest.runId === 0
+                  ? latest.retry
+                  : 0;
+                if (attempts >= maxRetries + 1 || handoffRetry > maxRetries) {
+                  await upsertState(pr, {
+                    pr: pr.number,
+                    head: pr.head.sha,
+                    base: liveBase,
+                    green: false,
+                    trusted: false,
+                    reason: 'infrastructure',
+                    retry: maxRetries,
+                    runId: completed.id,
+                  }, `### Trusted auto-merge evaluation\n\n⚠️ Finalization failed after ${Math.max(attempts, handoffRetry)} retry attempt(s). The trusted validation worker completed, but its durable handoff could not be finalized.`, comments);
+                  await github.rest.repos.createCommitStatus({
+                    owner, repo, sha: pr.head.sha,
+                    state: 'failure',
+                    context: 'automerge/trusted-validation',
+                    description: 'Trusted validation finalizer retry exhausted',
+                  });
+                  continue;
+                }
+                finalizations.push({
+                  pr,
+                  run: completed,
+                  handoffRetry,
+                  priority: pr.number === eventPr ? 0 : 1,
+                });
+                continue;
+              }
+
               if (latest && latest.head === pr.head.sha && latest.green && latest.trusted && latest.base === liveBase) {
                 if (reconcile.length === 0) reconcile.push({ pr_number: pr.number, head_sha: pr.head.sha, base_sha: liveBase });
                 continue;
               }
 
-              if (active.get(pr.number) === pr.head.sha) continue;
+              if (activeValidations.get(pr.number) === pr.head.sha) continue;
               let retry = 0;
               let eligible = false;
               if (!latest || latest.head !== pr.head.sha) {
                 eligible = true;
+              } else if (['infrastructure', 'baseline-unavailable'].includes(latest.reason) && latest.base !== liveBase) {
+                eligible = true;
+                retry = 0;
               } else if (['infrastructure', 'baseline-unavailable'].includes(latest.reason) && latest.retry < maxRetries) {
                 eligible = true;
                 retry = latest.retry + 1;
@@ -103,57 +187,124 @@ jobs:
               } else if (latest.reason === 'pending' && latest.base !== liveBase) {
                 eligible = true;
               }
-              if (eligible) {
-                validations.push({
-                  pr,
-                  retry,
-                  priority: pr.number === eventPr ? 0 : 1,
+              if (!eligible) continue;
+
+              const { data: changedFiles } = await github.rest.pulls.listFiles({
+                owner, repo, pull_number: pr.number, per_page: 1,
+              });
+              if (changedFiles.length === 0) {
+                core.notice(`PR #${pr.number} has no changed files yet; waiting for its first substantive synchronize event.`);
+                continue;
+              }
+              validations.push({
+                pr,
+                retry,
+                comments,
+                priority: pr.number === eventPr ? 0 : 1,
+              });
+            }
+
+            finalizations.sort((a, b) => a.priority - b.priority
+              || new Date(a.run.created_at || 0).getTime() - new Date(b.run.created_at || 0).getTime());
+            const finalizationFailures = [];
+            let finalizersDispatched = 0;
+            for (const candidate of finalizations.slice(0, maxParallel)) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'automerge-finalize.yml',
+                  ref: 'main',
+                  inputs: { validation_run_id: String(candidate.run.id) },
                 });
+                finalizersDispatched += 1;
+                core.notice(`Dispatched trusted finalizer for validation run ${candidate.run.id} (PR #${candidate.pr.number}).`);
+              } catch (error) {
+                const nextRetry = candidate.handoffRetry + 1;
+                const canRetry = nextRetry <= maxRetries;
+                await upsertState(candidate.pr, {
+                  pr: candidate.pr.number,
+                  head: candidate.pr.head.sha,
+                  base: liveBase,
+                  green: false,
+                  trusted: false,
+                  reason: 'infrastructure',
+                  retry: nextRetry,
+                  runId: 0,
+                }, `### Trusted auto-merge evaluation\n\n⚠️ Finalizer dispatch failed before the finalizer started: ${error.message}`);
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: candidate.pr.head.sha,
+                  state: canRetry ? 'pending' : 'failure',
+                  context: 'automerge/trusted-validation',
+                  description: canRetry ? 'Finalizer dispatch failed; retry pending' : 'Finalizer dispatch retry exhausted',
+                });
+                finalizationFailures.push(`run ${candidate.run.id}: ${error.message}`);
+                core.warning(`Could not dispatch finalizer for validation run ${candidate.run.id}: ${error.message}`);
               }
             }
 
             validations.sort((a, b) => a.priority - b.priority
               || new Date(a.pr.created_at).getTime() - new Date(b.pr.created_at).getTime());
-            const slots = Math.max(0, maxParallel - active.size);
+            const slots = Math.max(0, maxParallel - activeValidations.size);
             const admitted = validations.slice(0, slots);
-            const publishPendingState = async (pr, retry) => {
-              const marker = '<!-- automerge-pr-test-summary -->';
-              const stateMarker = stateModule.serializeAutoMergeState({
-                pr: pr.number, head: pr.head.sha, base: liveBase, green: false, trusted: false,
-                reason: 'pending', retry, runId: 0,
-              });
-              const body = `${marker}\n${stateMarker}\n### Trusted auto-merge evaluation\n\n⏳ Validation admitted for the exact current PR head and live main.`;
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: pr.number, per_page: 100,
-              });
-              const existing = comments.find((comment) =>
-                comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-              if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-              else await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
-            };
+            const admissionFailures = [];
             for (const candidate of admitted) {
               const pr = candidate.pr;
-              await github.rest.actions.createWorkflowDispatch({
-                owner, repo, workflow_id: 'automerge-prs.yml', ref: 'main',
-                inputs: {
-                  pr_number: String(pr.number),
-                  expected_head: pr.head.sha,
-                  retry: String(candidate.retry),
-                  reason: candidate.retry ? 'queue-infrastructure-retry' : 'admission-queue',
-                },
-              });
+              const state = {
+                pr: pr.number,
+                head: pr.head.sha,
+                base: liveBase,
+                green: false,
+                trusted: false,
+                reason: 'pending',
+                retry: candidate.retry,
+                runId: 0,
+              };
+
+              // Both prerequisite state surfaces must be writable before launching
+              // work. A failure here leaves no orphan worker and remains retryable.
               await github.rest.repos.createCommitStatus({
                 owner, repo, sha: pr.head.sha,
                 state: 'pending',
                 context: 'automerge/trusted-validation',
                 description: candidate.retry ? 'Trusted validation retry queued' : 'Trusted validation queued',
               });
-              await publishPendingState(pr, candidate.retry);
-              core.notice(`Admitted PR #${pr.number} @ ${pr.head.sha} (retry=${candidate.retry}).`);
+              await upsertState(pr, state,
+                '### Trusted auto-merge evaluation\n\n⏳ Validation admitted for the exact current PR head and live main.',
+                candidate.comments);
+
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: 'automerge-prs.yml', ref: 'main',
+                  inputs: {
+                    pr_number: String(pr.number),
+                    expected_head: pr.head.sha,
+                    retry: String(candidate.retry),
+                    reason: candidate.retry ? 'queue-infrastructure-retry' : 'admission-queue',
+                  },
+                });
+                core.notice(`Admitted PR #${pr.number} @ ${pr.head.sha} (retry=${candidate.retry}).`);
+              } catch (error) {
+                const canRetry = candidate.retry < maxRetries;
+                await upsertState(pr, {
+                  ...state,
+                  reason: 'infrastructure',
+                }, `### Trusted auto-merge evaluation\n\n⚠️ Validation dispatch failed before a worker started: ${error.message}`);
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: pr.head.sha,
+                  state: canRetry ? 'pending' : 'failure',
+                  context: 'automerge/trusted-validation',
+                  description: canRetry ? 'Validation dispatch failed; retry pending' : 'Validation dispatch retry exhausted',
+                });
+                admissionFailures.push(`PR #${pr.number}: ${error.message}`);
+              }
             }
+
             core.setOutput('matrix', JSON.stringify({ include: reconcile }));
             core.setOutput('count', String(reconcile.length));
-            core.notice(`Active validations=${active.size}; admitted=${admitted.length}; green merge candidates=${reconcile.length}.`);
+            core.notice(`Active validations=${activeValidations.size}; admitted=${admitted.length}; finalizers dispatched=${finalizersDispatched}; green merge candidates=${reconcile.length}.`);
+            const failures = [...finalizationFailures, ...admissionFailures];
+            if (failures.length) core.setFailed(`Auto-merge control-plane dispatch failure(s): ${failures.join('; ')}`);
 
   reconcile:
     name: Reconcile trusted green PR #${{ matrix.pr_number }}

--- a/src/cli/src/commands/ci-automerge-state.ts
+++ b/src/cli/src/commands/ci-automerge-state.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 export const AUTO_MERGE_STATE_MARKER = "automerge-state";
 export const AUTO_MERGE_STATE_SCHEMA_VERSION = 1;
+export const AUTO_MERGE_SUMMARY_COMMENT_MARKER = "<!-- automerge-pr-test-summary -->";
+export const AUTO_MERGE_FINALIZER_RUN_PREFIX = "Finalize auto-merge validation run ";
 export const AUTO_MERGE_STATE_REASONS = Object.freeze(new Set([
     "pending",
     "clean",
@@ -35,8 +38,14 @@ export type AutoMergeState = Readonly<{
     updatedAt: string;
 }>;
 
+export type AutoMergeValidationRunIdentity = Readonly<{
+    pr: number;
+    head: string;
+}>;
+
 type StateInput = Omit<AutoMergeState, "v" | "updatedAt"> & Readonly<{ updatedAt?: string }>;
-type IssueComment = Readonly<{
+export type AutoMergeIssueComment = Readonly<{
+    id?: number;
     body?: string | null;
     created_at?: string | null;
     updated_at?: string | null;
@@ -74,6 +83,12 @@ export function serializeAutoMergeState(value: StateInput | AutoMergeState): str
     return `<!-- ${AUTO_MERGE_STATE_MARKER} ${JSON.stringify(normalizeAutoMergeState(value))} -->`;
 }
 
+/** Render the canonical durable auto-merge summary comment. */
+export function renderAutoMergeStateComment(value: StateInput | AutoMergeState, summary: string): string {
+    const normalizedSummary = String(summary || "").trim();
+    return `${AUTO_MERGE_SUMMARY_COMMENT_MARKER}\n${serializeAutoMergeState(value)}\n${normalizedSummary}`;
+}
+
 /** Parse a durable auto-merge state marker from a PR comment body. */
 export function parseAutoMergeState(body: string | null | undefined): AutoMergeState | null {
     if (typeof body !== "string") return null;
@@ -89,14 +104,68 @@ export function parseAutoMergeState(body: string | null | undefined): AutoMergeS
 }
 
 /** Return the newest bot-authored comment containing valid auto-merge state. */
-export function findLatestBotAutoMergeState(comments: ReadonlyArray<IssueComment>, login = "github-actions[bot]"): AutoMergeState | null {
+export function findLatestBotAutoMergeState(comments: ReadonlyArray<AutoMergeIssueComment>, login = "github-actions[bot]"): AutoMergeState | null {
     const candidates = comments
         .filter((comment) => comment.user?.login === login)
         .map((comment) => ({ comment, state: parseAutoMergeState(comment.body) }))
-        .filter((entry): entry is { comment: IssueComment; state: AutoMergeState } => entry.state !== null)
+        .filter((entry): entry is { comment: AutoMergeIssueComment; state: AutoMergeState } => entry.state !== null)
         .sort((left, right) => new Date(right.comment.updated_at || right.comment.created_at || 0).getTime()
             - new Date(left.comment.updated_at || left.comment.created_at || 0).getTime());
     return candidates[0]?.state ?? null;
+}
+
+/** Find the single bot-owned summary comment used for durable auto-merge state. */
+export function findBotAutoMergeSummaryComment(comments: ReadonlyArray<AutoMergeIssueComment>, login = "github-actions[bot]"): AutoMergeIssueComment | null {
+    return comments.find((comment) => comment.user?.login === login
+        && comment.body?.includes(AUTO_MERGE_SUMMARY_COMMENT_MARKER)) ?? null;
+}
+
+/** Parse the exact PR/head identity encoded in a validation worker run title. */
+export function parseAutoMergeValidationRunTitle(title: string | null | undefined): AutoMergeValidationRunIdentity | null {
+    const match = String(title || "").match(/^Auto-merge PR #(\d+) @ ([0-9a-f]{40})$/u);
+    if (!match) return null;
+    const pr = Number(match[1]);
+    if (!Number.isInteger(pr) || pr <= 0) return null;
+    return Object.freeze({ pr, head: match[2] });
+}
+
+/** Parse the validation run ID encoded in a trusted finalizer run title. */
+export function parseAutoMergeFinalizerRunTitle(title: string | null | undefined): number | null {
+    const match = String(title || "").match(/^Finalize auto-merge validation run (\d+)$/u);
+    if (!match) return null;
+    const runId = Number(match[1]);
+    return Number.isInteger(runId) && runId > 0 ? runId : null;
+}
+
+/** Whether the newest completed worker run still needs its durable finalizer pass. */
+export function validationRunNeedsFinalization(state: AutoMergeState | null, runId: number, head: string): boolean {
+    if (!Number.isInteger(runId) || runId <= 0 || !isSha(head)) return false;
+    if (!state || state.head !== head || state.runId === 0) return true;
+    return state.runId < runId;
+}
+
+/** Assert the static trusted workflow contract that makes the control plane safe and recoverable. */
+export function assertAutoMergeControlPlaneContract(reconcile: string, finalizer: string): void {
+    assert.match(reconcile, /pull-requests: write/u);
+    assert.match(reconcile, /workflow_id: 'automerge-finalize\.yml'/u);
+    assert.match(reconcile, /has no changed files yet; waiting for its first substantive synchronize event/u);
+    assert.match(reconcile, /Finalizer dispatch failed before the finalizer started/u);
+    assert.match(reconcile, /handoffRetry > maxRetries/u);
+
+    const admissionAnchor = reconcile.indexOf("// Both prerequisite state surfaces must be writable before launching");
+    const statusAt = reconcile.indexOf("await github.rest.repos.createCommitStatus", admissionAnchor);
+    const persistedAt = reconcile.indexOf("await upsertState(pr, state", admissionAnchor);
+    const dispatchedAt = reconcile.indexOf("workflow_id: 'automerge-prs.yml'", admissionAnchor);
+    assert.ok(admissionAnchor >= 0 && statusAt > admissionAnchor && persistedAt > statusAt && dispatchedAt > persistedAt,
+        "commit status and durable pending state must both succeed before validation dispatch");
+
+    assert.match(finalizer, /workflow_dispatch:/u);
+    assert.doesNotMatch(finalizer, /workflows:\s*\["Auto-merge PRs"\]/u);
+    assert.match(finalizer, /run-id: \$\{\{ inputs\.validation_run_id \}\}/u);
+    assert.match(finalizer, /getWorkflowRun/u);
+    assert.match(finalizer, /validationRun\.path !== '\.github\/workflows\/automerge-prs\.yml'/u);
+    assert.match(finalizer, /validationRun\.event !== 'workflow_dispatch'/u);
+    assert.match(finalizer, /pull-requests: write/u);
 }
 
 function selfTest(): void {
@@ -113,6 +182,13 @@ function selfTest(): void {
     assert.equal(parseAutoMergeState(marker)?.pr, 42);
     assert.equal(parseAutoMergeState("<!-- automerge-state nope -->"), null);
     assert.equal(findLatestBotAutoMergeState([{ body: marker, updated_at: "2026-01-01", user: { login: "github-actions[bot]" } }])?.reason, "infrastructure");
+    assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${"a".repeat(40)}`), { pr: 42, head: "a".repeat(40) });
+    assert.equal(parseAutoMergeFinalizerRunTitle(`${AUTO_MERGE_FINALIZER_RUN_PREFIX}123`), 123);
+
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+    const reconcile = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-reconcile.yml"), "utf8");
+    const finalizer = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-finalize.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer);
     process.stdout.write("ci-automerge state self-test passed\n");
 }
 

--- a/src/cli/test/ci-automerge-state.test.ts
+++ b/src/cli/test/ci-automerge-state.test.ts
@@ -1,15 +1,27 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
+    AUTO_MERGE_FINALIZER_RUN_PREFIX,
+    AUTO_MERGE_SUMMARY_COMMENT_MARKER,
+    assertAutoMergeControlPlaneContract,
+    findBotAutoMergeSummaryComment,
     findLatestBotAutoMergeState,
     normalizeAutoMergeState,
+    parseAutoMergeFinalizerRunTitle,
     parseAutoMergeState,
-    serializeAutoMergeState
+    parseAutoMergeValidationRunTitle,
+    renderAutoMergeStateComment,
+    serializeAutoMergeState,
+    validationRunNeedsFinalization
 } from "../src/commands/ci-automerge-state.js";
 
 const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
 
 void test("auto-merge state round-trips through its durable comment marker", () => {
     const marker = serializeAutoMergeState({
@@ -34,6 +46,26 @@ void test("auto-merge state round-trips through its durable comment marker", () 
         runId: 123,
         updatedAt: parseAutoMergeState(marker)?.updatedAt
     }));
+});
+
+void test("canonical summary rendering and lookup share one durable marker", () => {
+    const body = renderAutoMergeStateComment({
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 0,
+        runId: 0
+    }, "### Trusted auto-merge evaluation\n\nWaiting for validation.");
+
+    assert.match(body, new RegExp(AUTO_MERGE_SUMMARY_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.equal(parseAutoMergeState(body)?.reason, "pending");
+    assert.equal(findBotAutoMergeSummaryComment([
+        { id: 7, body, user: { login: "github-actions[bot]" } },
+        { id: 8, body, user: { login: "someone-else" } }
+    ])?.id, 7);
 });
 
 void test("latest trusted state only considers valid bot-authored markers", () => {
@@ -66,6 +98,53 @@ void test("latest trusted state only considers valid bot-authored markers", () =
 
     assert.equal(state?.green, true);
     assert.equal(state?.runId, 456);
+});
+
+void test("validation and finalizer run titles have strict machine-readable identities", () => {
+    assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${HEAD_SHA}`), {
+        pr: 42,
+        head: HEAD_SHA
+    });
+    assert.equal(parseAutoMergeValidationRunTitle(`prefix Auto-merge PR #42 @ ${HEAD_SHA}`), null);
+    assert.equal(parseAutoMergeFinalizerRunTitle(`${AUTO_MERGE_FINALIZER_RUN_PREFIX}123456`), 123456);
+    assert.equal(parseAutoMergeFinalizerRunTitle("Finalize auto-merge"), null);
+});
+
+void test("completed validation finalization is idempotent and monotonic", () => {
+    const pending = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 0,
+        runId: 0
+    });
+    const finalized = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: true,
+        trusted: true,
+        reason: "clean",
+        retry: 0,
+        runId: 200
+    });
+
+    assert.equal(validationRunNeedsFinalization(null, 100, HEAD_SHA), true);
+    assert.equal(validationRunNeedsFinalization(pending, 100, HEAD_SHA), true);
+    assert.equal(validationRunNeedsFinalization(finalized, 200, HEAD_SHA), false);
+    assert.equal(validationRunNeedsFinalization(finalized, 199, HEAD_SHA), false);
+    assert.equal(validationRunNeedsFinalization(finalized, 201, HEAD_SHA), true);
+    assert.equal(validationRunNeedsFinalization(finalized, 201, "c".repeat(40)), true);
+    assert.equal(validationRunNeedsFinalization(finalized, 0, HEAD_SHA), false);
+});
+
+void test("control-plane workflow contract prevents orphan workers and implicit finalizer chaining", () => {
+    const reconcile = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-reconcile.yml"), "utf8");
+    const finalizer = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-finalize.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer);
 });
 
 void test("malformed or unsupported auto-merge state is rejected", () => {


### PR DESCRIPTION
## Summary

Fix the systemic auto-merge orchestration failures exposed by PR #10381 and harden the control plane so admission, validation finalization, and retry state are durable, idempotent, recoverable, and DRY.

## Root causes addressed

- `Reconcile auto-merge` attempted to create/update PR comments without the effective PR-write permission required by the live Actions token, producing `403 Resource not accessible by integration` after validation had already been dispatched.
- `Finalize auto-merge` relied on an implicit `workflow_run` hop after an `Auto-merge PRs` run dispatched by `GITHUB_TOKEN`; that bot-generated workflow chain was not reliably starting the finalizer.
- Admission wrote durable `pending` state after dispatch, so a publication failure could leave an orphan worker with no coherent queue state.
- Empty seed PRs could consume validation slots before their agent implementation arrived.
- Finalizer handoff had no durable dedupe/bounded-retry coordinator.
- Durable auto-merge summary rendering, state lookup, and workflow-contract checks were duplicated or insufficiently enforced.

## Changes

### Reconcile / coordinator

- Grants the coordinator `pull-requests: write` for durable PR-state publication.
- Requires both the pending commit status and canonical durable pending state to be writable **before** dispatching validation, preventing orphan workers.
- Converts validation-dispatch failures into explicit durable infrastructure state with bounded retry semantics.
- Skips PRs with no changed files until their first substantive synchronize event.
- Tracks active/completed validation workers by exact `PR # / head SHA` identity, retaining the newest active head when older cancelling runs coexist.
- Explicitly dispatches `automerge-finalize.yml` for completed workers instead of depending on an implicit workflow-to-workflow trigger.
- Tracks active finalizers and finalizer attempts, prevents duplicate finalization, bounds both finalizer-run failures and finalizer-dispatch failures, and publishes a terminal infrastructure state when retries are exhausted.
- Allows infrastructure-exhausted PRs to recover automatically when `main` advances to a newer trusted control-plane version.
- Keeps the periodic coordinator as the self-healing fallback; `workflow_run` is only an accelerator where GitHub emits it.

### Trusted finalizer

- Converts finalization to an explicit `workflow_dispatch` contract keyed by the completed validation run ID.
- Uses a deterministic run name and per-validation-run concurrency group.
- Independently fetches and verifies that the supplied run ID is a completed `.github/workflows/automerge-prs.yml` `workflow_dispatch` run before trusting artifacts or routing metadata.
- Uses the original validation run's conclusion and URL instead of finalizer-event context.
- Refuses duplicate or superseded finalization using durable state/run IDs.
- Grants the PR write permission required for durable state publication.
- Downloads validation, evidence, and promotion artifacts from the explicit validated run ID.

### DRY typed state helpers

- Centralizes the canonical auto-merge summary marker, rendering, and bot-owned comment lookup.
- Adds strict parsers for validation-worker and finalizer run identities.
- Adds the idempotent/monotonic `validationRunNeedsFinalization` predicate used by both coordinator and finalizer.
- Centralizes the static trusted workflow contract in `assertAutoMergeControlPlaneContract`, reused by both the unit test and the trusted source-level self-test.

### Tests / invariants

The shared trusted contract now enforces:

- required PR-write permissions;
- explicit finalizer dispatch rather than implicit finalizer chaining;
- validation-run provenance checks;
- exact explicit artifact run IDs;
- transactional admission ordering: status + durable state before worker dispatch;
- bounded finalizer-dispatch retry behavior;
- seed-PR suppression.

`ci-automerge-state.test.ts` also covers canonical comment round-tripping/lookup, strict run-title parsing, and monotonic finalization dedupe semantics without duplicating the workflow-contract assertions.

## Security / trust boundary

This PR changes trusted CI/control-plane files, so unattended merge should remain intentionally disabled for this PR itself. The finalizer continues to validate evidence using default-branch code and exact base/head/synthetic-merge provenance; the supplied validation run ID is routing metadata only and is independently verified before use.

## Validation

Final branch state is one cohesive commit (`810f105af80e52510c0c1b621ee6e5ab258aea54`) based directly on current `main` (`ceb923dae6d2383fb190539f92731455c050e29e`), with exactly four changed files and no base divergence.

GitHub-hosted `Validate GitHub workflows` run **#37** (`31345892201`) passed on the final squashed head. Its `actionlint` job passed every stage:

- workflow YAML and expression validation;
- local composite-action YAML parsing;
- trusted runtime Node setup;
- trusted auto-merge control-plane self-test, which now includes the shared orchestration/permission/transaction invariants above;
- existing trusted evidence and regression-gate self-tests invoked by the validator.

A local clone/test attempt from the execution environment was unavailable because that environment could not resolve `github.com`; the repository's GitHub-hosted trusted validator is therefore the executable validation source for this PR.

### Expected pre-fix red check on this PR

`Reconcile auto-merge` run **#102** (`31345891498`) is expected to fail on this PR because it is a `pull_request_target` workflow: GitHub executes the workflow definition from the trusted **base branch (`main`)**, not this PR's modified workflow. Its log confirms it checked out `main` at `ceb923dae6d2383fb190539f92731455c050e29e`, received `PullRequests: read`, then reproduced the exact pre-fix `403 Resource not accessible by integration` in `publishPendingState` after dispatching validation. That red run is direct evidence of the bug this PR fixes, not a failure of the patched branch. Once this trusted-CI PR is human-merged, subsequent coordinator runs will use the corrected permissions and control-plane implementation.