### PR TITLE
Harden auto-merge planning, provenance, and recovery

### DIFF
--- a/.github/actions/reconcile-automerge/action.yml
+++ b/.github/actions/reconcile-automerge/action.yml
@@ -1,5 +1,5 @@
 name: "Reconcile trusted auto-merge"
-description: "Retry a trusted merge or request fresh validation when main advances; never mutates the PR branch."
+description: "Retry a trusted merge or report that fresh validation is needed when main advances; never mutates the PR branch."
 
 inputs:
   pr-number:
@@ -21,7 +21,7 @@ inputs:
     default: "trusted-finalizer"
 outputs:
   status:
-    description: "current, revalidation-requested, merged, pending-mergeability, conflict, merge-failed, or not-current."
+    description: "current, revalidation-needed, merged, pending-mergeability, conflict, merge-failed, or not-current."
     value: ${{ steps.reconcile.outputs.status }}
   merged:
     description: "Whether this invocation merged the PR."
@@ -83,37 +83,17 @@ runs:
           const { data: branch } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
           const liveBase = branch.commit.sha;
           if (liveBase !== base) {
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner, repo, workflow_id: 'automerge-prs.yml', per_page: 50,
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: head,
+              state: 'pending',
+              context: 'automerge/trusted-validation',
+              description: 'main advanced; coordinator will queue fresh validation',
             });
-            const active = runs.data.workflow_runs.some((run) =>
-              ['queued', 'in_progress'].includes(run.status)
-              && String(run.display_title || '').includes(`PR #${number} @ ${head}`));
-            if (!active) {
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'automerge-prs.yml',
-                ref: 'main',
-                inputs: {
-                  pr_number: String(number),
-                  expected_head: head,
-                  retry: '0',
-                  reason: `${source}-stale-base`,
-                },
-              });
-              await github.rest.repos.createCommitStatus({
-                owner, repo, sha: head,
-                state: 'pending',
-                context: 'automerge/trusted-validation',
-                description: 'main advanced; fresh synthetic-merge validation requested',
-              });
-            }
-            await publish(`🔄 **Fresh validation requested without mutating the PR branch.** `
+            await publish(`🔄 **Fresh validation is required without mutating the PR branch.** `
               + `Trusted evidence covered main \`${base}\`, while live main is \`${liveBase}\`. `
-              + `The validation worker will test the exact current synthetic merge.`);
+              + `The central admission coordinator will queue the exact current synthetic merge when capacity is available.`);
             core.notice(`${source}: PR #${number} needs revalidation against ${liveBase}; branch was not modified.`);
-            set('revalidation-requested');
+            set('revalidation-needed');
             return;
           }
           if (!allowMerge) {
@@ -144,18 +124,22 @@ runs:
             }
           }
           if (!mergeable) {
-            await publish('⏳ **Trusted validation is green, but GitHub mergeability is still unresolved.** The periodic reconciler will retry without rerunning tests.');
+            await publish('⏳ **Trusted validation is green, but GitHub mergeability is still unresolved.** The periodic coordinator will retry without rerunning tests.');
             set('pending-mergeability');
             return;
           }
 
           const { data: lastBase } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
           if (lastBase.commit.sha !== base) {
-            await github.rest.actions.createWorkflowDispatch({
-              owner, repo, workflow_id: 'automerge-prs.yml', ref: 'main',
-              inputs: { pr_number: String(number), expected_head: head, retry: '0', reason: `${source}-premerge-race` },
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: head,
+              state: 'pending',
+              context: 'automerge/trusted-validation',
+              description: 'main changed before merge; coordinator will revalidate',
             });
-            set('revalidation-requested');
+            await publish(`🔄 **main changed during the final merge check.** `
+              + `The central admission coordinator will queue fresh validation against \`${lastBase.commit.sha}\`.`);
+            set('revalidation-needed');
             return;
           }
 

--- a/.github/ci/automerge-policy.json
+++ b/.github/ci/automerge-policy.json
@@ -3,6 +3,7 @@
   "testShardCount": 5,
   "maxParallelValidations": 2,
   "maxInfrastructureRetries": 1,
+  "pendingStateTimeoutMs": 900000,
   "maxRemovedTestCases": 3,
   "shardWatchdogMs": 1500000,
   "commandWatchdogMs": 1200000,
@@ -15,7 +16,7 @@
   ],
   "trustedCiPatterns": [
     "^\\.github/",
-    "^src/cli/(?:src/commands/ci-automerge-(?:evidence|gate|state)\\.ts|test/ci-automerge-state\\.test\\.ts)$",
+    "^src/cli/(?:src/commands/ci-automerge-(?:evidence|gate|state|plan)\\.ts|test/ci-automerge-(?:state|plan)\\.test\\.ts)$",
     "(?:^|/)package\\.json$",
     "^pnpm-lock\\.yaml$",
     "^pnpm-workspace\\.yaml$",

--- a/.github/workflows/automerge-finalize.yml
+++ b/.github/workflows/automerge-finalize.yml
@@ -1,11 +1,19 @@
 name: "Finalize auto-merge"
+run-name: "Finalize auto-merge validation run ${{ inputs.validation_run_id }}"
 
 on:
-  workflow_run:
-    workflows: ["Auto-merge PRs"]
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      validation_run_id:
+        description: "Completed Auto-merge PRs workflow run to finalize."
+        required: true
+        type: string
 
 permissions: {}
+
+concurrency:
+  group: automerge-finalize-${{ inputs.validation_run_id }}
+  cancel-in-progress: false
 
 jobs:
   analyze:
@@ -13,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      actions: write
+      actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
@@ -45,22 +53,68 @@ jobs:
         with:
           name: validation-target
           path: target
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: resolve
-        name: Resolve current PR and trust boundary
+        name: Resolve validation run, current PR, and trust boundary
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          VALIDATION_RUN_ID: ${{ inputs.validation_run_id }}
         with:
           script: |
             const fs = require('node:fs');
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
             const { owner, repo } = context.repo;
+            const runId = Number(process.env.VALIDATION_RUN_ID || 0);
+            core.setOutput('validation_conclusion', '');
+            core.setOutput('validation_url', '');
+            core.setOutput('pr_number', '');
+            core.setOutput('head_sha', '');
+            core.setOutput('base_sha', '');
+            core.setOutput('merge_sha', '');
+            core.setOutput('retry', '0');
+            core.setOutput('blocked_reason', 'infrastructure');
+            core.setOutput('max_retries', '1');
+            core.setOutput('current', 'false');
+            core.setOutput('trusted', 'false');
+            if (!Number.isInteger(runId) || runId <= 0) {
+              core.setFailed('Finalization requires a positive validation workflow run ID.');
+              return;
+            }
+
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
+            const planner = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-plan.ts',
+            )).href);
+            const { data: validationRun } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+            if (validationRun.path !== '.github/workflows/automerge-prs.yml'
+                || validationRun.event !== 'workflow_dispatch'
+                || validationRun.status !== 'completed'
+                || validationRun.head_branch !== 'main'
+                || Number(validationRun.run_attempt || 1) !== 1) {
+              core.setFailed(`Run ${runId} is not a first-attempt completed Auto-merge PRs workflow_dispatch from main.`);
+              return;
+            }
+            core.setOutput('validation_conclusion', String(validationRun.conclusion || ''));
+            core.setOutput('validation_url', String(validationRun.html_url || ''));
+
             let target = null;
             try { target = JSON.parse(fs.readFileSync('target/validation-target.json', 'utf8')); } catch {}
-            if (!target) {
-              const match = String(process.env.RUN_TITLE || '').match(/PR #(\d+) @ ([0-9a-f]{40})/u);
-              if (match) target = { prNumber: Number(match[1]), headSha: match[2], baseSha: '', mergeSha: '', retry: 0, blockedReason: 'infrastructure' };
+            const runIdentity = stateModule.parseAutoMergeValidationRunTitle(validationRun.display_title);
+            if (!target && runIdentity) {
+              target = {
+                prNumber: runIdentity.pr,
+                headSha: runIdentity.head,
+                baseSha: '',
+                mergeSha: '',
+                retry: 0,
+                blockedReason: 'infrastructure',
+              };
             }
             const number = Number(target?.prNumber || 0);
             const head = String(target?.headSha || '');
@@ -73,24 +127,42 @@ jobs:
             core.setOutput('merge_sha', merge);
             core.setOutput('retry', Number.isInteger(retry) ? String(retry) : '0');
             core.setOutput('blocked_reason', String(target?.blockedReason || ''));
-            core.setOutput('max_retries', '1');
-            core.setOutput('current', 'false');
-            core.setOutput('trusted', 'false');
-            if (!Number.isInteger(number) || number <= 0 || !/^[0-9a-f]{40}$/u.test(head)) return;
+            if (!runIdentity || runIdentity.pr !== number || runIdentity.head !== head) {
+              core.setFailed(`Validation run ${runId} title does not match its target artifact.`);
+              return;
+            }
+            if (!Number.isInteger(number) || number <= 0
+                || !/^[0-9a-f]{40}$/u.test(head)
+                || !/^[0-9a-f]{40}$/u.test(base)
+                || validationRun.head_sha !== base
+                || !planner.isTrustedValidationProducer(validationRun, base)) {
+              core.setFailed(`Validation run ${runId} did not execute from the exact trusted main SHA recorded as its base.`);
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
             if (pr.state !== 'open' || pr.draft || pr.base.ref !== 'main' || pr.head.sha !== head) return;
-            const runId = Number(context.payload.workflow_run?.id || 0);
-            const runCreatedAt = new Date(context.payload.workflow_run?.created_at || 0).getTime();
-            const recentRuns = await github.rest.actions.listWorkflowRuns({
-              owner, repo, workflow_id: 'automerge-prs.yml', per_page: 50,
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
             });
-            const superseded = recentRuns.data.workflow_runs.some((run) =>
-              run.id !== runId
-              && String(run.display_title || '').includes(`PR #${number} @ ${head}`)
-              && new Date(run.created_at || 0).getTime() > runCreatedAt);
-            if (superseded) {
-              core.notice(`Ignoring superseded validation run ${runId} for PR #${number} @ ${head}.`);
+            const latestState = stateModule.findLatestBotAutoMergeState(comments);
+            if (latestState?.head === head && latestState.runId >= runId) {
+              core.notice(`Validation run ${runId} for PR #${number} is already finalized or superseded by durable state.`);
+              return;
+            }
+
+            const recentRuns = [];
+            for (let page = 1; page <= 5; page += 1) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'automerge-prs.yml', per_page: 100, page,
+              });
+              recentRuns.push(...data.workflow_runs);
+              if (data.workflow_runs.length < 100) break;
+            }
+            const newest = planner.selectNewestValidationRuns(recentRuns).get(`${number}:${head}`);
+            if (newest && newest.id !== runId) {
+              core.notice(`Ignoring superseded validation run ${runId}; newest generation for PR #${number} @ ${head} is ${newest.id}.`);
               return;
             }
             core.setOutput('current', 'true');
@@ -108,8 +180,8 @@ jobs:
               typeof filename === 'string' && trustedPatterns.some((pattern) => pattern.test(filename));
             const trustedChange = files.some((file) => matches(file.filename) || matches(file.previous_filename));
             core.setOutput('trusted', trustedChange ? 'false' : 'true');
-            core.notice(`Finalizer resolved PR #${number} at ${head}; trusted=${!trustedChange}, base=${base || 'missing'}.`);
-      - name: Revalidate stale trusted product PR without mutating its branch
+            core.notice(`Finalizer resolved validation run ${runId} for PR #${number} at ${head}; trusted=${!trustedChange}, base=${base}.`);
+      - name: Check whether trusted evidence is stale
         id: freshness
         if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.resolve.outputs.base_sha != '' && steps.resolve.outputs.blocked_reason == '' }}
         uses: ./.github/actions/reconcile-automerge
@@ -125,31 +197,31 @@ jobs:
         run: node src/cli/src/commands/ci-automerge-evidence.ts fingerprint --github-output "$GITHUB_OUTPUT"
       - name: Download exact base evidence
         id: base_download
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-base
           path: report-base
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download exact synthetic-merge evidence
         id: merge_download
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-merge
           path: report-merge
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download optional complete ancestor evidence
         id: ancestor_download
         continue-on-error: true
-        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ steps.resolve.outputs.current == 'true' && steps.resolve.outputs.trusted == 'true' && steps.freshness.outputs.status == 'current' && steps.resolve.outputs.blocked_reason == '' && steps.resolve.outputs.validation_conclusion == 'success' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: report-ancestor
           path: report-ancestor
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: provenance
         name: Verify exact evidence provenance
@@ -259,10 +331,11 @@ jobs:
           TRUSTED: ${{ steps.resolve.outputs.trusted }}
           BLOCKED: ${{ steps.resolve.outputs.blocked_reason }}
           FRESHNESS: ${{ steps.freshness.outputs.status }}
-          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_CONCLUSION: ${{ steps.resolve.outputs.validation_conclusion }}
           EVAL_GREEN: ${{ steps.evaluate.outputs.green }}
           EVAL_REASON: ${{ steps.evaluate.outputs.reason }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ inputs.validation_run_id }}
+          TARGET_URL: ${{ steps.resolve.outputs.validation_url }}
         with:
           script: |
             const fs = require('node:fs');
@@ -295,34 +368,36 @@ jobs:
               green = false;
               reason = 'infrastructure';
               summary = `### Trusted auto-merge evaluation\n\n⚠️ Validation infrastructure did not complete reliably (${blocked || workflowConclusion}).`;
-            } else if (freshness === 'revalidation-requested') {
+            } else if (freshness === 'revalidation-needed') {
               green = false;
               reason = 'stale';
-              summary = '### Trusted auto-merge evaluation\n\n🔄 `main` advanced after this evidence was produced. Fresh validation was explicitly dispatched without modifying the PR branch.';
+              summary = '### Trusted auto-merge evaluation\n\n🔄 `main` advanced after this evidence was produced. The central admission coordinator will queue fresh validation without mutating the PR branch.';
             } else if (!summary) {
               green = false;
               reason = 'infrastructure';
               summary = '### Trusted auto-merge evaluation\n\n⚠️ Expected trusted evaluation output was unavailable.';
             }
 
-            const stateModule = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'src/cli/src/commands/ci-automerge-state.ts')).href);
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
             const state = {
               pr: number,
               head: process.env.HEAD_SHA,
-              base: process.env.BASE_SHA || '0'.repeat(40),
+              base: process.env.BASE_SHA || '',
               green,
               trusted,
               reason,
               retry: Number(process.env.RETRY || 0),
               runId: Number(process.env.RUN_ID || 0),
             };
-            const stateMarker = stateModule.serializeAutoMergeState(state);
-            const marker = '<!-- automerge-pr-test-summary -->';
-            const body = `${marker}\n${stateMarker}\n${summary}`;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: number, per_page: 100 });
-            const existing = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-            if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const existing = stateModule.findBotAutoMergeSummaryComment(comments);
+            const body = stateModule.renderAutoMergeStateComment(state, summary);
+            if (existing?.id) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             else await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
 
             let status = 'failure';
@@ -345,13 +420,13 @@ jobs:
               }
             } else if (reason === 'stale') {
               status = 'pending';
-              description = 'Fresh validation requested';
+              description = 'Fresh validation awaiting admission';
             }
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: process.env.HEAD_SHA, state: status,
               context: 'automerge/trusted-validation',
               description: description.slice(0, 140),
-              target_url: context.payload.workflow_run?.html_url,
+              target_url: process.env.TARGET_URL || undefined,
             });
             core.setOutput('green', green ? 'true' : 'false');
             core.setOutput('reason', reason);
@@ -393,7 +468,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -467,7 +541,7 @@ jobs:
         with:
           name: report-merge
           path: report-merge
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.validation_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Retarget validated evidence to the identical landed tree
         if: ${{ steps.provenance.outputs.valid == 'true' }}

--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -12,6 +12,10 @@ on:
         description: "Exact PR head SHA expected by the dispatcher."
         required: true
         type: string
+      expected_base:
+        description: "Exact main SHA admitted by the trusted coordinator."
+        required: true
+        type: string
       retry:
         description: "Infrastructure retry generation (0 for normal validation)."
         required: false
@@ -55,17 +59,19 @@ jobs:
         env:
           INPUT_PR: ${{ inputs.pr_number }}
           EXPECTED_HEAD: ${{ inputs.expected_head }}
+          EXPECTED_BASE: ${{ inputs.expected_base }}
           INPUT_RETRY: ${{ inputs.retry }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const number = Number(process.env.INPUT_PR);
             const expectedHead = String(process.env.EXPECTED_HEAD || '');
+            const expectedBase = String(process.env.EXPECTED_BASE || '');
             const retry = Number(process.env.INPUT_RETRY || '0');
             const set = (key, value) => core.setOutput(key, String(value));
             set('pr_number', Number.isInteger(number) ? number : 0);
             set('head_sha', expectedHead);
-            set('base_sha', '');
+            set('base_sha', expectedBase);
             set('merge_sha', '');
             set('shard_count', 5);
             set('shard_watchdog_ms', 1500000);
@@ -75,8 +81,14 @@ jobs:
             set('should_validate', 'false');
             set('retry', Number.isInteger(retry) && retry >= 0 ? retry : 0);
 
-            if (!Number.isInteger(number) || number <= 0 || !/^[0-9a-f]{40}$/u.test(expectedHead)) {
-              core.warning('Dispatch did not provide a valid PR number and exact 40-character head SHA.');
+            if (!Number.isInteger(number) || number <= 0
+                || !/^[0-9a-f]{40}$/u.test(expectedHead)
+                || !/^[0-9a-f]{40}$/u.test(expectedBase)) {
+              core.warning('Dispatch did not provide a valid PR number and exact head/base SHAs.');
+              return;
+            }
+            if (context.sha !== expectedBase) {
+              core.warning(`Validation worker executed from ${context.sha}, not admitted main ${expectedBase}.`);
               return;
             }
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
@@ -87,8 +99,11 @@ jobs:
             }
 
             const { data: baseBranch } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
-            const baseSha = baseBranch.commit.sha;
-            set('base_sha', baseSha);
+            if (baseBranch.commit.sha !== expectedBase) {
+              core.notice(`main advanced from admitted ${expectedBase} to ${baseBranch.commit.sha}; coordinator must admit a fresh generation.`);
+              return;
+            }
+            const baseSha = expectedBase;
 
             const readJson = async (path) => {
               const { data } = await github.rest.repos.getContent({ owner, repo, path, ref: baseSha });
@@ -150,6 +165,11 @@ jobs:
               const { data: latest } = await github.rest.pulls.get({ owner, repo, pull_number: number });
               if (latest.state !== 'open' || latest.head.sha !== expectedHead) {
                 set('blocked_reason', 'not-current');
+                return;
+              }
+              const { data: currentBase } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
+              if (currentBase.commit.sha !== expectedBase) {
+                core.notice(`main advanced while resolving the synthetic merge; abandoning admitted base ${expectedBase}.`);
                 return;
               }
               const mergeableState = String(latest.mergeable_state || '').toLowerCase();

--- a/.github/workflows/automerge-reconcile.yml
+++ b/.github/workflows/automerge-reconcile.yml
@@ -4,8 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
+  # This accelerates human-dispatched workers. Bot-dispatched workers are still
+  # recovered deterministically by the periodic coordinator below.
   workflow_run:
-    workflows: ["Finalize auto-merge"]
+    workflows: ["Auto-merge PRs"]
     types: [completed]
   schedule:
     - cron: "*/5 * * * *"
@@ -19,14 +21,14 @@ concurrency:
 
 jobs:
   discover:
-    name: Admit validation and trusted merge candidates
+    name: Coordinate validation and trusted merge candidates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       matrix: ${{ steps.queue.outputs.matrix }}
@@ -50,30 +52,71 @@ jobs:
             const policy = JSON.parse(fs.readFileSync('.github/ci/automerge-policy.json', 'utf8'));
             const maxParallel = Number(policy.maxParallelValidations || 2);
             const maxRetries = Number(policy.maxInfrastructureRetries || 1);
+            const pendingTimeoutMs = Number(policy.pendingStateTimeoutMs || 900000);
             if (!Number.isInteger(maxParallel) || maxParallel < 1 || maxParallel > 10
-                || !Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10) {
+                || !Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10
+                || !Number.isInteger(pendingTimeoutMs) || pendingTimeoutMs < 60000) {
               core.setFailed('Invalid auto-merge admission policy.');
               return;
             }
-            const stateModule = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'src/cli/src/commands/ci-automerge-state.ts')).href);
+
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
+            const planner = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-plan.ts',
+            )).href);
             const { data: branch } = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
             const liveBase = branch.commit.sha;
             const pulls = await github.paginate(github.rest.pulls.list, {
               owner, repo, state: 'open', base: 'main', sort: 'created', direction: 'asc', per_page: 100,
             });
 
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner, repo, workflow_id: 'automerge-prs.yml', per_page: 100,
+            const listRecentWorkflowRuns = async (workflowId, maxPages = 5) => {
+              const runs = [];
+              for (let page = 1; page <= maxPages; page += 1) {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner, repo, workflow_id: workflowId, per_page: 100, page,
+                });
+                runs.push(...data.workflow_runs);
+                if (data.workflow_runs.length < 100) break;
+              }
+              return runs;
+            };
+            const [validationRuns, finalizerRuns] = await Promise.all([
+              listRecentWorkflowRuns('automerge-prs.yml'),
+              listRecentWorkflowRuns('automerge-finalize.yml'),
+            ]);
+            const normalizedValidationRuns = validationRuns.map((run) => {
+              const identity = stateModule.parseAutoMergeValidationRunTitle(run.display_title);
+              return identity ? { ...run, validationPr: identity.pr, validationHead: identity.head } : run;
             });
-            const active = new Map();
-            for (const run of runs.data.workflow_runs) {
-              if (!['queued', 'in_progress'].includes(run.status)) continue;
-              const match = String(run.display_title || '').match(/PR #(\d+) @ ([0-9a-f]{40})/u);
-              if (match) active.set(Number(match[1]), match[2]);
-            }
+            const normalizedFinalizerRuns = finalizerRuns.map((run) => {
+              const validationRunId = stateModule.parseAutoMergeFinalizerRunTitle(run.display_title);
+              return validationRunId ? { ...run, finalizerValidationRunId: validationRunId } : run;
+            });
+            const newestValidations = planner.selectNewestValidationRuns(normalizedValidationRuns);
+            const activeValidationCount = [...newestValidations.values()]
+              .filter((run) => run.status === 'queued' || run.status === 'in_progress').length;
+
+            const upsertState = async (pr, state, summary, knownComments = null) => {
+              const comments = knownComments || await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const existing = stateModule.findBotAutoMergeSummaryComment(comments);
+              const body = stateModule.renderAutoMergeStateComment(state, summary);
+              if (existing?.id) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+              }
+            };
 
             const eventPr = Number(process.env.EVENT_PR || 0);
             const validations = [];
+            const finalizations = [];
             const reconcile = [];
             for (const pr of pulls) {
               if (pr.draft) continue;
@@ -81,79 +124,202 @@ jobs:
                 core.notice(`PR #${pr.number} comes from an external repository; unattended validation/merge is disabled.`);
                 continue;
               }
+
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: pr.number, per_page: 100,
               });
-              const latest = stateModule.findLatestBotAutoMergeState(comments);
-              if (latest && latest.head === pr.head.sha && latest.green && latest.trusted && latest.base === liveBase) {
-                if (reconcile.length === 0) reconcile.push({ pr_number: pr.number, head_sha: pr.head.sha, base_sha: liveBase });
-                continue;
-              }
+              const latestState = stateModule.findLatestBotAutoMergeState(comments);
+              const key = `${pr.number}:${pr.head.sha}`;
+              const newestValidation = newestValidations.get(key) || null;
+              const finalizerState = newestValidation
+                ? planner.summarizeFinalizerRuns(normalizedFinalizerRuns, newestValidation.id)
+                : { active: false, failedAttempts: 0 };
+              const decision = planner.planAutoMergePr({
+                head: pr.head.sha,
+                liveBase,
+                state: latestState,
+                newestValidation,
+                finalizer: finalizerState,
+                maxInfrastructureRetries: maxRetries,
+                pendingTimeoutMs,
+                nowMs: Date.now(),
+              });
 
-              if (active.get(pr.number) === pr.head.sha) continue;
-              let retry = 0;
-              let eligible = false;
-              if (!latest || latest.head !== pr.head.sha) {
-                eligible = true;
-              } else if (['infrastructure', 'baseline-unavailable'].includes(latest.reason) && latest.retry < maxRetries) {
-                eligible = true;
-                retry = latest.retry + 1;
-              } else if (latest.reason === 'stale' || (latest.green && latest.base !== liveBase)) {
-                eligible = true;
-              } else if (latest.reason === 'pending' && latest.base !== liveBase) {
-                eligible = true;
-              }
-              if (eligible) {
-                validations.push({
+              if (decision.kind === 'finalize' && newestValidation) {
+                finalizations.push({
                   pr,
-                  retry,
+                  run: newestValidation,
+                  retry: decision.retry,
+                  comments,
                   priority: pr.number === eventPr ? 0 : 1,
                 });
+                continue;
+              }
+              if (decision.kind === 'merge') {
+                if (reconcile.length === 0) reconcile.push({
+                  pr_number: pr.number,
+                  head_sha: pr.head.sha,
+                  base_sha: liveBase,
+                });
+                continue;
+              }
+              if (decision.kind === 'blocked'
+                  && (decision.reason === 'finalizer-retry-exhausted' || decision.reason === 'pending-retry-exhausted')) {
+                try {
+                  await upsertState(pr, {
+                    pr: pr.number,
+                    head: pr.head.sha,
+                    base: latestState?.base || '',
+                    green: false,
+                    trusted: false,
+                    reason: 'infrastructure',
+                    retry: maxRetries,
+                    runId: newestValidation?.id || latestState?.runId || 0,
+                  }, `### Trusted auto-merge evaluation\n\n⚠️ ${decision.reason === 'finalizer-retry-exhausted'
+                    ? 'Trusted finalization retry budget was exhausted.'
+                    : 'An orphaned pending validation exhausted its retry budget.'}`, comments);
+                  await github.rest.repos.createCommitStatus({
+                    owner, repo, sha: pr.head.sha,
+                    state: 'failure',
+                    context: 'automerge/trusted-validation',
+                    description: 'Trusted auto-merge infrastructure retry exhausted',
+                  });
+                } catch (error) {
+                  core.warning(`Could not persist terminal infrastructure state for PR #${pr.number}: ${error.message}`);
+                }
+                continue;
+              }
+              if (decision.kind !== 'validate') continue;
+
+              const { data: changedFiles } = await github.rest.pulls.listFiles({
+                owner, repo, pull_number: pr.number, per_page: 1,
+              });
+              if (changedFiles.length === 0) {
+                core.notice(`PR #${pr.number} has no changed files yet; waiting for its first substantive synchronize event.`);
+                continue;
+              }
+              validations.push({
+                pr,
+                retry: decision.retry,
+                comments,
+                reason: decision.reason,
+                priority: pr.number === eventPr ? 0 : 1,
+              });
+            }
+
+            finalizations.sort((a, b) => a.priority - b.priority
+              || new Date(a.run.created_at || 0).getTime() - new Date(b.run.created_at || 0).getTime());
+            let finalizersDispatched = 0;
+            for (const candidate of finalizations.slice(0, maxParallel)) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'automerge-finalize.yml',
+                  ref: 'main',
+                  inputs: { validation_run_id: String(candidate.run.id) },
+                });
+                finalizersDispatched += 1;
+                core.notice(`Dispatched trusted finalizer for validation run ${candidate.run.id} (PR #${candidate.pr.number}).`);
+              } catch (error) {
+                const nextRetry = candidate.retry + 1;
+                const canRetry = nextRetry <= maxRetries;
+                try {
+                  await upsertState(candidate.pr, {
+                    pr: candidate.pr.number,
+                    head: candidate.pr.head.sha,
+                    base: liveBase,
+                    green: false,
+                    trusted: false,
+                    reason: 'infrastructure',
+                    retry: nextRetry,
+                    runId: 0,
+                  }, `### Trusted auto-merge evaluation\n\n⚠️ Finalizer dispatch failed before the finalizer started: ${error.message}`,
+                  candidate.comments);
+                  await github.rest.repos.createCommitStatus({
+                    owner, repo, sha: candidate.pr.head.sha,
+                    state: canRetry ? 'pending' : 'failure',
+                    context: 'automerge/trusted-validation',
+                    description: canRetry ? 'Finalizer dispatch failed; retry pending' : 'Finalizer dispatch retry exhausted',
+                  });
+                } catch (stateError) {
+                  core.warning(`Could not persist finalizer dispatch failure for PR #${candidate.pr.number}: ${stateError.message}`);
+                }
+                core.warning(`Could not dispatch finalizer for validation run ${candidate.run.id}: ${error.message}`);
               }
             }
 
             validations.sort((a, b) => a.priority - b.priority
               || new Date(a.pr.created_at).getTime() - new Date(b.pr.created_at).getTime());
-            const slots = Math.max(0, maxParallel - active.size);
+            const slots = Math.max(0, maxParallel - activeValidationCount);
             const admitted = validations.slice(0, slots);
-            const publishPendingState = async (pr, retry) => {
-              const marker = '<!-- automerge-pr-test-summary -->';
-              const stateMarker = stateModule.serializeAutoMergeState({
-                pr: pr.number, head: pr.head.sha, base: liveBase, green: false, trusted: false,
-                reason: 'pending', retry, runId: 0,
-              });
-              const body = `${marker}\n${stateMarker}\n### Trusted auto-merge evaluation\n\n⏳ Validation admitted for the exact current PR head and live main.`;
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: pr.number, per_page: 100,
-              });
-              const existing = comments.find((comment) =>
-                comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-              if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-              else await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
-            };
+            let validationsDispatched = 0;
             for (const candidate of admitted) {
               const pr = candidate.pr;
-              await github.rest.actions.createWorkflowDispatch({
-                owner, repo, workflow_id: 'automerge-prs.yml', ref: 'main',
-                inputs: {
-                  pr_number: String(pr.number),
-                  expected_head: pr.head.sha,
-                  retry: String(candidate.retry),
-                  reason: candidate.retry ? 'queue-infrastructure-retry' : 'admission-queue',
-                },
-              });
-              await github.rest.repos.createCommitStatus({
-                owner, repo, sha: pr.head.sha,
-                state: 'pending',
-                context: 'automerge/trusted-validation',
-                description: candidate.retry ? 'Trusted validation retry queued' : 'Trusted validation queued',
-              });
-              await publishPendingState(pr, candidate.retry);
-              core.notice(`Admitted PR #${pr.number} @ ${pr.head.sha} (retry=${candidate.retry}).`);
+              const state = {
+                pr: pr.number,
+                head: pr.head.sha,
+                base: liveBase,
+                green: false,
+                trusted: false,
+                reason: 'pending',
+                retry: candidate.retry,
+                runId: 0,
+              };
+
+              // Both prerequisite state surfaces must be writable before launching
+              // work. A failure here leaves no orphan worker and remains retryable.
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: pr.head.sha,
+                  state: 'pending',
+                  context: 'automerge/trusted-validation',
+                  description: candidate.retry ? 'Trusted validation retry queued' : 'Trusted validation queued',
+                });
+                await upsertState(pr, state,
+                  '### Trusted auto-merge evaluation\n\n⏳ Validation admitted for the exact current PR head and live main.',
+                  candidate.comments);
+              } catch (error) {
+                core.warning(`Could not establish durable pending state for PR #${pr.number}; validation was not dispatched: ${error.message}`);
+                continue;
+              }
+
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: 'automerge-prs.yml', ref: 'main',
+                  inputs: {
+                    pr_number: String(pr.number),
+                    expected_head: pr.head.sha,
+                    expected_base: liveBase,
+                    retry: String(candidate.retry),
+                    reason: candidate.reason,
+                  },
+                });
+                validationsDispatched += 1;
+                core.notice(`Admitted PR #${pr.number} @ ${pr.head.sha} against ${liveBase} (retry=${candidate.retry}, reason=${candidate.reason}).`);
+              } catch (error) {
+                const canRetry = candidate.retry < maxRetries;
+                try {
+                  await upsertState(pr, {
+                    ...state,
+                    reason: 'infrastructure',
+                  }, `### Trusted auto-merge evaluation\n\n⚠️ Validation dispatch failed before a worker started: ${error.message}`);
+                  await github.rest.repos.createCommitStatus({
+                    owner, repo, sha: pr.head.sha,
+                    state: canRetry ? 'pending' : 'failure',
+                    context: 'automerge/trusted-validation',
+                    description: canRetry ? 'Validation dispatch failed; retry pending' : 'Validation dispatch retry exhausted',
+                  });
+                } catch (stateError) {
+                  core.warning(`Could not persist validation dispatch failure for PR #${pr.number}: ${stateError.message}`);
+                }
+                core.warning(`Could not dispatch validation for PR #${pr.number}: ${error.message}`);
+              }
             }
+
             core.setOutput('matrix', JSON.stringify({ include: reconcile }));
             core.setOutput('count', String(reconcile.length));
-            core.notice(`Active validations=${active.size}; admitted=${admitted.length}; green merge candidates=${reconcile.length}.`);
+            core.notice(`Active validations=${activeValidationCount}; validation dispatches=${validationsDispatched}; finalizer dispatches=${finalizersDispatched}; green merge candidates=${reconcile.length}.`);
 
   reconcile:
     name: Reconcile trusted green PR #${{ matrix.pr_number }}
@@ -166,7 +332,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
       contents: write
       issues: write
       pull-requests: write

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -8,7 +8,7 @@ on:
       - ".github/actions/**"
       - ".github/ci/automerge-policy.json"
       - "src/cli/src/commands/ci-automerge-*.ts"
-      - "src/cli/test/ci-automerge-state.test.ts"
+      - "src/cli/test/ci-automerge-*.test.ts"
   workflow_dispatch:
 
 permissions:
@@ -52,5 +52,34 @@ jobs:
       - name: Self-test trusted auto-merge control plane
         run: |
           node src/cli/src/commands/ci-automerge-state.ts self-test
+          node src/cli/src/commands/ci-automerge-plan.ts self-test
           node src/cli/src/commands/ci-automerge-evidence.ts self-test
           node src/cli/src/commands/ci-automerge-gate.ts self-test
+      - name: Stage trusted TypeScript unit-test runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf .trusted-ci-runtime
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+          import { stripTypeScriptTypes } from 'node:module';
+
+          const files = [
+            'src/cli/src/commands/ci-automerge-state.ts',
+            'src/cli/src/commands/ci-automerge-plan.ts',
+            'src/cli/test/ci-automerge-state.test.ts',
+            'src/cli/test/ci-automerge-plan.test.ts',
+          ];
+          for (const source of files) {
+            const target = path.join('.trusted-ci-runtime', source.replace(/\.ts$/u, '.js'));
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            const transformed = stripTypeScriptTypes(fs.readFileSync(source, 'utf8'), {
+              mode: 'transform',
+              sourceMap: false,
+            });
+            fs.writeFileSync(target, `${transformed}\n`, 'utf8');
+          }
+          NODE
+      - name: Run trusted auto-merge unit tests
+        run: node --test .trusted-ci-runtime/src/cli/test/ci-automerge-state.test.js .trusted-ci-runtime/src/cli/test/ci-automerge-plan.test.js

--- a/src/cli/src/commands/ci-automerge-plan.ts
+++ b/src/cli/src/commands/ci-automerge-plan.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+export type AutoMergeStateSnapshot = Readonly<{
+    head: string;
+    base: string;
+    green: boolean;
+    trusted: boolean;
+    reason: string;
+    retry: number;
+    runId: number;
+    updatedAt: string;
+}>;
+
+/** Minimal API run shape plus coordinator-normalized identities. */
+export type AutoMergeWorkflowRun = Readonly<{
+    id: number;
+    run_attempt?: number;
+    status?: string | null;
+    conclusion?: string | null;
+    created_at?: string | null;
+    path?: string | null;
+    event?: string | null;
+    head_branch?: string | null;
+    head_sha?: string | null;
+    validationPr?: number | null;
+    validationHead?: string | null;
+    finalizerValidationRunId?: number | null;
+}>;
+
+export type FinalizerRunState = Readonly<{
+    active: boolean;
+    failedAttempts: number;
+}>;
+
+export type AutoMergePlanDecision = Readonly<{
+    kind: "validate" | "finalize" | "merge" | "wait" | "blocked";
+    retry: number;
+    reason: string;
+}>;
+
+export type AutoMergePlanInput = Readonly<{
+    head: string;
+    liveBase: string;
+    state: AutoMergeStateSnapshot | null;
+    newestValidation: AutoMergeWorkflowRun | null;
+    finalizer: FinalizerRunState;
+    maxInfrastructureRetries: number;
+    pendingTimeoutMs: number;
+    nowMs: number;
+}>;
+
+function runTimestamp(run: AutoMergeWorkflowRun): number {
+    const parsed = Date.parse(String(run.created_at || ""));
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function compareRunsNewestFirst(left: AutoMergeWorkflowRun, right: AutoMergeWorkflowRun): number {
+    const timeDifference = runTimestamp(right) - runTimestamp(left);
+    if (timeDifference !== 0) return timeDifference;
+    const idDifference = right.id - left.id;
+    if (idDifference !== 0) return idDifference;
+    return Number(right.run_attempt || 1) - Number(left.run_attempt || 1);
+}
+
+/** Return the newest validation workflow generation for every exact normalized PR/head identity. */
+export function selectNewestValidationRuns(runs: ReadonlyArray<AutoMergeWorkflowRun>): ReadonlyMap<string, AutoMergeWorkflowRun> {
+    const selected = new Map<string, AutoMergeWorkflowRun>();
+    for (const run of [...runs].sort(compareRunsNewestFirst)) {
+        const pr = Number(run.validationPr || 0);
+        const head = String(run.validationHead || "");
+        if (!Number.isInteger(pr) || pr <= 0 || !SHA_PATTERN.test(head)) continue;
+        const key = `${pr}:${head}`;
+        if (!selected.has(key)) selected.set(key, run);
+    }
+    return selected;
+}
+
+/** Summarize actual finalizer executions without counting successful no-op runs as failures. */
+export function summarizeFinalizerRuns(runs: ReadonlyArray<AutoMergeWorkflowRun>, validationRunId: number): FinalizerRunState {
+    let active = false;
+    let failedAttempts = 0;
+    for (const run of runs) {
+        if (run.finalizerValidationRunId !== validationRunId) continue;
+        if (run.status === "queued" || run.status === "in_progress") active = true;
+        else if (run.status === "completed" && run.conclusion !== "success") failedAttempts += 1;
+    }
+    return Object.freeze({ active, failedAttempts });
+}
+
+/** Verify that a completed validation worker itself executed from the exact trusted main commit it evaluated. */
+export function isTrustedValidationProducer(run: AutoMergeWorkflowRun, expectedBase: string): boolean {
+    return SHA_PATTERN.test(expectedBase)
+        && run.path === ".github/workflows/automerge-prs.yml"
+        && run.event === "workflow_dispatch"
+        && run.status === "completed"
+        && Number(run.run_attempt || 1) === 1
+        && run.head_branch === "main"
+        && run.head_sha === expectedBase;
+}
+
+/** Only a known, non-placeholder prior base may reset an infrastructure retry generation. */
+export function isKnownBaseTransition(previousBase: string, liveBase: string): boolean {
+    return SHA_PATTERN.test(previousBase)
+        && previousBase !== "0".repeat(40)
+        && SHA_PATTERN.test(liveBase)
+        && previousBase !== liveBase;
+}
+
+/** Treat an orphaned pending state as retryable after the configured bounded timeout. */
+export function isPendingStateExpired(state: AutoMergeStateSnapshot, nowMs: number, pendingTimeoutMs: number): boolean {
+    if (state.reason !== "pending" || pendingTimeoutMs <= 0) return false;
+    const updatedAt = Date.parse(state.updatedAt);
+    return Number.isFinite(updatedAt) && nowMs - updatedAt >= pendingTimeoutMs;
+}
+
+/** Plan one PR using only typed state and workflow snapshots; API mutation stays in the coordinator workflow. */
+export function planAutoMergePr(input: AutoMergePlanInput): AutoMergePlanDecision {
+    const { head, liveBase, state, newestValidation, finalizer, maxInfrastructureRetries, pendingTimeoutMs, nowMs } = input;
+    if (!SHA_PATTERN.test(head) || !SHA_PATTERN.test(liveBase)) {
+        return Object.freeze({ kind: "blocked", retry: 0, reason: "invalid-ref" });
+    }
+
+    if (newestValidation) {
+        if (newestValidation.status === "queued" || newestValidation.status === "in_progress") {
+            return Object.freeze({ kind: "wait", retry: state?.retry ?? 0, reason: "validation-active" });
+        }
+        if (newestValidation.status === "completed") {
+            const finalized = state?.head === head && state.runId === newestValidation.id;
+            if (!finalized) {
+                const handoffRetry = state?.head === head && state.reason === "infrastructure" && state.runId === 0
+                    ? state.retry
+                    : 0;
+                if (finalizer.active) return Object.freeze({ kind: "wait", retry: handoffRetry, reason: "finalizer-active" });
+                if (finalizer.failedAttempts > maxInfrastructureRetries || handoffRetry > maxInfrastructureRetries) {
+                    return Object.freeze({ kind: "blocked", retry: Math.max(finalizer.failedAttempts, handoffRetry), reason: "finalizer-retry-exhausted" });
+                }
+                return Object.freeze({ kind: "finalize", retry: handoffRetry, reason: "validation-completed" });
+            }
+        }
+    }
+
+    if (state?.head === head && state.green && state.trusted && state.base === liveBase) {
+        return Object.freeze({ kind: "merge", retry: state.retry, reason: "trusted-green" });
+    }
+
+    if (!state || state.head !== head) return Object.freeze({ kind: "validate", retry: 0, reason: "new-head" });
+
+    if ((state.reason === "infrastructure" || state.reason === "baseline-unavailable")
+        && isKnownBaseTransition(state.base, liveBase)) {
+        return Object.freeze({ kind: "validate", retry: 0, reason: "new-base-generation" });
+    }
+    if ((state.reason === "infrastructure" || state.reason === "baseline-unavailable")
+        && state.retry < maxInfrastructureRetries) {
+        return Object.freeze({ kind: "validate", retry: state.retry + 1, reason: "infrastructure-retry" });
+    }
+    if (state.reason === "stale" || (state.green && state.base !== liveBase)) {
+        return Object.freeze({ kind: "validate", retry: 0, reason: "stale-base" });
+    }
+    if (state.reason === "pending" && isKnownBaseTransition(state.base, liveBase)) {
+        return Object.freeze({ kind: "validate", retry: 0, reason: "pending-old-base" });
+    }
+    if (state.reason === "pending" && isPendingStateExpired(state, nowMs, pendingTimeoutMs)) {
+        if (state.retry < maxInfrastructureRetries) {
+            return Object.freeze({ kind: "validate", retry: state.retry + 1, reason: "orphaned-pending-retry" });
+        }
+        return Object.freeze({ kind: "blocked", retry: state.retry, reason: "pending-retry-exhausted" });
+    }
+
+    return Object.freeze({ kind: "wait", retry: state.retry, reason: state.reason });
+}
+
+function selfTest(): void {
+    const head = "a".repeat(40);
+    const base = "b".repeat(40);
+    const active: AutoMergeWorkflowRun = {
+        id: 20,
+        validationPr: 42,
+        validationHead: head,
+        status: "in_progress",
+        created_at: "2026-08-10T01:01:00Z"
+    };
+    const older: AutoMergeWorkflowRun = {
+        id: 19,
+        validationPr: 42,
+        validationHead: head,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-08-10T01:00:00Z"
+    };
+    assert.equal(selectNewestValidationRuns([older, active]).get(`42:${head}`)?.id, 20);
+    assert.equal(isKnownBaseTransition("", base), false);
+    assert.equal(isKnownBaseTransition("0".repeat(40), base), false);
+    assert.equal(isKnownBaseTransition("c".repeat(40), base), true);
+    assert.equal(isTrustedValidationProducer({
+        id: 1,
+        run_attempt: 1,
+        path: ".github/workflows/automerge-prs.yml",
+        event: "workflow_dispatch",
+        status: "completed",
+        head_branch: "main",
+        head_sha: base
+    }, base), true);
+    process.stdout.write("ci-automerge plan self-test passed\n");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url) && process.argv[2] === "self-test") selfTest();

--- a/src/cli/src/commands/ci-automerge-state.ts
+++ b/src/cli/src/commands/ci-automerge-state.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 export const AUTO_MERGE_STATE_MARKER = "automerge-state";
 export const AUTO_MERGE_STATE_SCHEMA_VERSION = 1;
+export const AUTO_MERGE_SUMMARY_COMMENT_MARKER = "<!-- automerge-pr-test-summary -->";
+export const AUTO_MERGE_FINALIZER_RUN_PREFIX = "Finalize auto-merge validation run ";
 export const AUTO_MERGE_STATE_REASONS = Object.freeze(new Set([
     "pending",
     "clean",
@@ -35,8 +38,14 @@ export type AutoMergeState = Readonly<{
     updatedAt: string;
 }>;
 
+export type AutoMergeValidationRunIdentity = Readonly<{
+    pr: number;
+    head: string;
+}>;
+
 type StateInput = Omit<AutoMergeState, "v" | "updatedAt"> & Readonly<{ updatedAt?: string }>;
-type IssueComment = Readonly<{
+export type AutoMergeIssueComment = Readonly<{
+    id?: number;
     body?: string | null;
     created_at?: string | null;
     updated_at?: string | null;
@@ -74,6 +83,12 @@ export function serializeAutoMergeState(value: StateInput | AutoMergeState): str
     return `<!-- ${AUTO_MERGE_STATE_MARKER} ${JSON.stringify(normalizeAutoMergeState(value))} -->`;
 }
 
+/** Render the canonical durable auto-merge summary comment. */
+export function renderAutoMergeStateComment(value: StateInput | AutoMergeState, summary: string): string {
+    const normalizedSummary = String(summary || "").trim();
+    return `${AUTO_MERGE_SUMMARY_COMMENT_MARKER}\n${serializeAutoMergeState(value)}\n${normalizedSummary}`;
+}
+
 /** Parse a durable auto-merge state marker from a PR comment body. */
 export function parseAutoMergeState(body: string | null | undefined): AutoMergeState | null {
     if (typeof body !== "string") return null;
@@ -89,14 +104,101 @@ export function parseAutoMergeState(body: string | null | undefined): AutoMergeS
 }
 
 /** Return the newest bot-authored comment containing valid auto-merge state. */
-export function findLatestBotAutoMergeState(comments: ReadonlyArray<IssueComment>, login = "github-actions[bot]"): AutoMergeState | null {
+export function findLatestBotAutoMergeState(comments: ReadonlyArray<AutoMergeIssueComment>, login = "github-actions[bot]"): AutoMergeState | null {
     const candidates = comments
         .filter((comment) => comment.user?.login === login)
         .map((comment) => ({ comment, state: parseAutoMergeState(comment.body) }))
-        .filter((entry): entry is { comment: IssueComment; state: AutoMergeState } => entry.state !== null)
+        .filter((entry): entry is { comment: AutoMergeIssueComment; state: AutoMergeState } => entry.state !== null)
         .sort((left, right) => new Date(right.comment.updated_at || right.comment.created_at || 0).getTime()
             - new Date(left.comment.updated_at || left.comment.created_at || 0).getTime());
     return candidates[0]?.state ?? null;
+}
+
+/** Find the single bot-owned summary comment used for durable auto-merge state. */
+export function findBotAutoMergeSummaryComment(comments: ReadonlyArray<AutoMergeIssueComment>, login = "github-actions[bot]"): AutoMergeIssueComment | null {
+    return comments.find((comment) => comment.user?.login === login
+        && comment.body?.includes(AUTO_MERGE_SUMMARY_COMMENT_MARKER)) ?? null;
+}
+
+/** Parse the exact PR/head identity encoded in a validation worker run title. */
+export function parseAutoMergeValidationRunTitle(title: string | null | undefined): AutoMergeValidationRunIdentity | null {
+    const match = String(title || "").match(/^Auto-merge PR #(\d+) @ ([0-9a-f]{40})$/u);
+    if (!match) return null;
+    const pr = Number(match[1]);
+    if (!Number.isInteger(pr) || pr <= 0) return null;
+    return Object.freeze({ pr, head: match[2] });
+}
+
+/** Parse the validation run ID encoded in a trusted finalizer run title. */
+export function parseAutoMergeFinalizerRunTitle(title: string | null | undefined): number | null {
+    const match = String(title || "").match(/^Finalize auto-merge validation run (\d+)$/u);
+    if (!match) return null;
+    const runId = Number(match[1]);
+    return Number.isInteger(runId) && runId > 0 ? runId : null;
+}
+
+function extractJobBlock(workflow: string, jobName: string, nextJobName: string | null): string {
+    const startMarker = `  ${jobName}:\n`;
+    const start = workflow.indexOf(startMarker);
+    assert.ok(start >= 0, `workflow must contain jobs.${jobName}`);
+    if (!nextJobName) return workflow.slice(start);
+    const end = workflow.indexOf(`\n  ${nextJobName}:\n`, start + startMarker.length);
+    assert.ok(end > start, `workflow must contain jobs.${nextJobName} after jobs.${jobName}`);
+    return workflow.slice(start, end);
+}
+
+/** Assert static trusted workflow invariants that actionlint cannot validate semantically. */
+export function assertAutoMergeControlPlaneContract(
+    reconcile: string,
+    finalizer: string,
+    reconcileAction: string,
+    worker: string
+): void {
+    const discoverJob = extractJobBlock(reconcile, "discover", "reconcile");
+    const analyzeJob = extractJobBlock(finalizer, "analyze", "merge");
+
+    assert.match(discoverJob, /permissions:\n(?: {6}[^\n]+\n)* {6}pull-requests: write/u,
+        "coordinator discover job must have PR-write permission");
+    assert.match(analyzeJob, /permissions:\n(?: {6}[^\n]+\n)* {6}pull-requests: write/u,
+        "finalizer analyze job must have PR-write permission");
+    assert.match(reconcile, /workflow_id: 'automerge-finalize\.yml'/u);
+    assert.match(reconcile, /expected_base: liveBase/u,
+        "coordinator must pin every validation dispatch to the exact admitted main SHA");
+    assert.match(reconcile, /has no changed files yet; waiting for its first substantive synchronize event/u);
+    assert.match(reconcile, /pendingTimeoutMs/u);
+    assert.doesNotMatch(reconcile, /core\.setFailed\(`Auto-merge control-plane dispatch failure/u,
+        "one PR's dispatch failure must not fail another PR's coordinator check");
+
+    const admissionAnchor = reconcile.indexOf("// Both prerequisite state surfaces must be writable before launching");
+    const statusAt = reconcile.indexOf("await github.rest.repos.createCommitStatus", admissionAnchor);
+    const persistedAt = reconcile.indexOf("await upsertState(pr, state", admissionAnchor);
+    const dispatchedAt = reconcile.indexOf("workflow_id: 'automerge-prs.yml'", admissionAnchor);
+    assert.ok(admissionAnchor >= 0 && statusAt > admissionAnchor && persistedAt > statusAt && dispatchedAt > persistedAt,
+        "commit status and durable pending state must both succeed before validation dispatch");
+
+    assert.match(worker, /expected_base:\n/u);
+    assert.match(worker, /EXPECTED_BASE: \$\{\{ inputs\.expected_base \}\}/u);
+    assert.match(worker, /context\.sha !== expectedBase/u,
+        "validation worker must execute from the exact admitted main commit");
+    assert.match(worker, /baseBranch\.commit\.sha !== expectedBase/u,
+        "validation worker must reject a live-main change after admission");
+    assert.match(worker, /currentBase\.commit\.sha !== expectedBase/u,
+        "validation worker must reject main movement while resolving the synthetic merge");
+
+    assert.match(finalizer, /workflow_dispatch:/u);
+    assert.doesNotMatch(finalizer, /workflows:\s*\["Auto-merge PRs"\]/u);
+    assert.match(finalizer, /run-id: \$\{\{ inputs\.validation_run_id \}\}/u);
+    assert.match(finalizer, /validationRun\.head_branch !== 'main'/u);
+    assert.match(finalizer, /validationRun\.run_attempt \|\| 1\) !== 1/u);
+    assert.match(finalizer, /validationRun\.head_sha !== base/u);
+    assert.match(finalizer, /parseAutoMergeValidationRunTitle/u);
+    assert.match(finalizer, /base: process\.env\.BASE_SHA \|\| ''/u,
+        "unknown validation bases must stay unknown rather than becoming a synthetic SHA");
+
+    assert.doesNotMatch(reconcileAction, /createWorkflowDispatch/u,
+        "only the admission coordinator may dispatch expensive validation");
+    assert.doesNotMatch(reconcileAction, /workflow_id:\s*'automerge-prs\.yml'/u);
+    assert.match(reconcileAction, /set\('revalidation-needed'\)/u);
 }
 
 function selfTest(): void {
@@ -113,6 +215,15 @@ function selfTest(): void {
     assert.equal(parseAutoMergeState(marker)?.pr, 42);
     assert.equal(parseAutoMergeState("<!-- automerge-state nope -->"), null);
     assert.equal(findLatestBotAutoMergeState([{ body: marker, updated_at: "2026-01-01", user: { login: "github-actions[bot]" } }])?.reason, "infrastructure");
+    assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${"a".repeat(40)}`), { pr: 42, head: "a".repeat(40) });
+    assert.equal(parseAutoMergeFinalizerRunTitle(`${AUTO_MERGE_FINALIZER_RUN_PREFIX}123`), 123);
+
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+    const reconcile = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-reconcile.yml"), "utf8");
+    const finalizer = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-finalize.yml"), "utf8");
+    const reconcileAction = fs.readFileSync(path.join(repoRoot, ".github/actions/reconcile-automerge/action.yml"), "utf8");
+    const worker = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-prs.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker);
     process.stdout.write("ci-automerge state self-test passed\n");
 }
 

--- a/src/cli/test/ci-automerge-plan.test.ts
+++ b/src/cli/test/ci-automerge-plan.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    isKnownBaseTransition,
+    isPendingStateExpired,
+    isTrustedValidationProducer,
+    planAutoMergePr,
+    selectNewestValidationRuns,
+    summarizeFinalizerRuns,
+    type AutoMergeWorkflowRun
+} from "../src/commands/ci-automerge-plan.js";
+import { normalizeAutoMergeState } from "../src/commands/ci-automerge-state.js";
+
+const HEAD = "a".repeat(40);
+const BASE = "b".repeat(40);
+const OLD_BASE = "c".repeat(40);
+const NOW = Date.parse("2026-08-10T02:00:00Z");
+
+function validationRun(id: number, status: string, createdAt: string, conclusion: string | null = null): AutoMergeWorkflowRun {
+    return {
+        id,
+        run_attempt: 1,
+        validationPr: 42,
+        validationHead: HEAD,
+        status,
+        conclusion,
+        created_at: createdAt,
+        path: ".github/workflows/automerge-prs.yml",
+        event: "workflow_dispatch",
+        head_branch: "main",
+        head_sha: BASE
+    };
+}
+
+void test("newest active generation suppresses an older completed validation", () => {
+    const older = validationRun(100, "completed", "2026-08-10T01:00:00Z", "success");
+    const newer = validationRun(101, "in_progress", "2026-08-10T01:01:00Z");
+    const latest = selectNewestValidationRuns([older, newer]).get(`42:${HEAD}`) ?? null;
+    assert.equal(latest?.id, 101);
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: null,
+        newestValidation: latest,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "wait", retry: 0, reason: "validation-active" });
+});
+
+void test("latest completed generation is finalized before any new validation", () => {
+    const latest = validationRun(101, "completed", "2026-08-10T01:01:00Z", "success");
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: null,
+        newestValidation: latest,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "finalize", retry: 0, reason: "validation-completed" });
+});
+
+void test("only failed finalizer executions consume the finalizer retry budget", () => {
+    const runs: ReadonlyArray<AutoMergeWorkflowRun> = [
+        { id: 1, finalizerValidationRunId: 101, status: "completed", conclusion: "success" },
+        { id: 2, finalizerValidationRunId: 101, status: "completed", conclusion: "failure" },
+        { id: 3, finalizerValidationRunId: 101, status: "in_progress", conclusion: null }
+    ];
+    assert.deepEqual(summarizeFinalizerRuns(runs, 101), { active: true, failedAttempts: 1 });
+});
+
+void test("known base changes reset retries but unknown or placeholder bases do not", () => {
+    assert.equal(isKnownBaseTransition(OLD_BASE, BASE), true);
+    assert.equal(isKnownBaseTransition("", BASE), false);
+    assert.equal(isKnownBaseTransition("0".repeat(40), BASE), false);
+});
+
+void test("orphaned pending state becomes retryable after its bounded timeout", () => {
+    const pending = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: BASE,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 0,
+        runId: 0,
+        updatedAt: "2026-08-10T01:30:00Z"
+    });
+    assert.equal(isPendingStateExpired(pending, NOW, 900000), true);
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: pending,
+        newestValidation: null,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "validate", retry: 1, reason: "orphaned-pending-retry" });
+});
+
+void test("unknown-base infrastructure failures remain bounded instead of resetting forever", () => {
+    const failed = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: "",
+        green: false,
+        trusted: false,
+        reason: "infrastructure",
+        retry: 1,
+        runId: 88
+    });
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: failed,
+        newestValidation: null,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "wait", retry: 1, reason: "infrastructure" });
+});
+
+void test("current trusted green state is the only state that reaches merge planning", () => {
+    const green = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: BASE,
+        green: true,
+        trusted: true,
+        reason: "clean",
+        retry: 0,
+        runId: 101
+    });
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: green,
+        newestValidation: validationRun(101, "completed", "2026-08-10T01:01:00Z", "success"),
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "merge", retry: 0, reason: "trusted-green" });
+});
+
+void test("trusted producer verification rejects alternate refs and rerun attempts", () => {
+    const good = validationRun(101, "completed", "2026-08-10T01:01:00Z", "success");
+    assert.equal(isTrustedValidationProducer(good, BASE), true);
+    assert.equal(isTrustedValidationProducer({ ...good, head_branch: "feature" }, BASE), false);
+    assert.equal(isTrustedValidationProducer({ ...good, head_sha: OLD_BASE }, BASE), false);
+    assert.equal(isTrustedValidationProducer({ ...good, run_attempt: 2 }, BASE), false);
+});

--- a/src/cli/test/ci-automerge-state.test.ts
+++ b/src/cli/test/ci-automerge-state.test.ts
@@ -1,15 +1,25 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
 import test from "node:test";
 
 import {
+    AUTO_MERGE_SUMMARY_COMMENT_MARKER,
+    assertAutoMergeControlPlaneContract,
+    findBotAutoMergeSummaryComment,
     findLatestBotAutoMergeState,
     normalizeAutoMergeState,
+    parseAutoMergeFinalizerRunTitle,
     parseAutoMergeState,
+    parseAutoMergeValidationRunTitle,
+    renderAutoMergeStateComment,
     serializeAutoMergeState
 } from "../src/commands/ci-automerge-state.js";
 
 const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
+const REPO_ROOT = process.cwd();
 
 void test("auto-merge state round-trips through its durable comment marker", () => {
     const marker = serializeAutoMergeState({
@@ -34,6 +44,40 @@ void test("auto-merge state round-trips through its durable comment marker", () 
         runId: 123,
         updatedAt: parseAutoMergeState(marker)?.updatedAt
     }));
+});
+
+void test("unknown base is represented explicitly rather than with a placeholder SHA", () => {
+    const state = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD_SHA,
+        base: "",
+        green: false,
+        trusted: false,
+        reason: "infrastructure",
+        retry: 1,
+        runId: 123
+    });
+    assert.equal(state.base, "");
+});
+
+void test("canonical summary rendering and lookup share one durable marker", () => {
+    const body = renderAutoMergeStateComment({
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 0,
+        runId: 0
+    }, "### Trusted auto-merge evaluation\n\nWaiting for validation.");
+
+    assert.match(body, new RegExp(AUTO_MERGE_SUMMARY_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.equal(parseAutoMergeState(body)?.reason, "pending");
+    assert.equal(findBotAutoMergeSummaryComment([
+        { id: 7, body, user: { login: "github-actions[bot]" } },
+        { id: 8, body, user: { login: "someone-else" } }
+    ])?.id, 7);
 });
 
 void test("latest trusted state only considers valid bot-authored markers", () => {
@@ -66,6 +110,24 @@ void test("latest trusted state only considers valid bot-authored markers", () =
 
     assert.equal(state?.green, true);
     assert.equal(state?.runId, 456);
+});
+
+void test("validation and finalizer run titles have strict machine-readable identities", () => {
+    assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${HEAD_SHA}`), {
+        pr: 42,
+        head: HEAD_SHA
+    });
+    assert.equal(parseAutoMergeValidationRunTitle(`prefix Auto-merge PR #42 @ ${HEAD_SHA}`), null);
+    assert.equal(parseAutoMergeFinalizerRunTitle("Finalize auto-merge validation run 123456"), 123456);
+    assert.equal(parseAutoMergeFinalizerRunTitle("Finalize auto-merge"), null);
+});
+
+void test("control-plane workflow contract checks exact privileged jobs, worker base pinning, and queue ownership", () => {
+    const reconcile = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-reconcile.yml"), "utf8");
+    const finalizer = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-finalize.yml"), "utf8");
+    const reconcileAction = fs.readFileSync(path.join(REPO_ROOT, ".github/actions/reconcile-automerge/action.yml"), "utf8");
+    const worker = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-prs.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker);
 });
 
 void test("malformed or unsupported auto-merge state is rejected", () => {


### PR DESCRIPTION
## Summary

Supersedes #10384 with the original control-plane handoff fixes plus a fresh-review hardening pass. This PR makes validation admission centrally planned, prevents stale/superseded generations from racing, proves validation workers execute from the exact trusted `main` commit they were admitted against, bounds orphaned state recovery, isolates per-PR control-plane failures, and makes the dangerous orchestration paths directly testable.

## Fresh-review issues addressed

- A validation run could be finalized without proving its workflow itself executed from the exact trusted `main` SHA recorded as the validation base.
- Dispatch and worker start could straddle a `main` update, letting the worker silently retarget to a different base generation.
- An older completed validation could be finalized while a newer retry for the same PR/head was queued or running.
- Stale-base and pre-merge races could dispatch expensive validation directly from the shared reconcile action, bypassing `maxParallelValidations`.
- A failure concerning one backlog PR could make another PR's `Reconcile auto-merge` check red.
- Static permission assertions were workflow-wide and could pass even if the exact privileged job regressed to read-only permissions.
- New state-machine unit tests were present but not actually executed by `Validate GitHub workflows`.
- Unknown/placeholder base state could reset infrastructure retry generations forever.
- Bounded workflow-history windows could strand old `pending` state permanently.
- GitHub rerun attempts reused `run_id` without an explicit support/rejection policy.
- Critical admission/retry planning remained embedded in a large untyped workflow script.

## Architecture

### Typed planner

Adds `ci-automerge-plan.ts`, a pure trusted planner for:

- newest validation generation selection by exact PR/head identity;
- active/completed generation precedence;
- finalizer failure accounting that counts only actual failed finalizer executions;
- trusted validation-producer verification;
- known-base generation transitions;
- bounded orphaned-pending recovery;
- deterministic `validate` / `finalize` / `merge` / `wait` / `blocked` decisions.

Run-title parsing remains centralized in `ci-automerge-state.ts`; the coordinator normalizes GitHub API runs before handing them to the planner. API mutation remains thin and explicit in the workflow.

### Single validation admission owner

Only `automerge-reconcile.yml` may dispatch `Auto-merge PRs`. The shared reconcile action now returns `revalidation-needed` when `main` advances or changes during the final merge check. The central coordinator then admits fresh validation only when global capacity is available.

### Exact admitted-base contract

Every validation dispatch carries an explicit `expected_base` equal to the trusted coordinator's current `main` SHA. The worker refuses to validate if:

- its own workflow execution SHA is not that exact admitted `main` SHA;
- live `main` has moved before gate resolution; or
- live `main` moves while GitHub is resolving the synthetic merge.

The worker therefore never silently retargets a validation generation after admission.

### Trusted producer provenance

The explicit finalizer independently requires that the supplied validation run:

- is `.github/workflows/automerge-prs.yml`;
- is a completed `workflow_dispatch`;
- executed from branch `main`;
- is the first workflow attempt (`run_attempt == 1`; reruns are intentionally unsupported rather than ambiguously sharing a run ID);
- has a strict machine-readable run title matching the downloaded target artifact;
- has `validationRun.head_sha` exactly equal to the artifact's recorded base SHA.

Synthetic-merge evidence SHA/parent provenance and trusted runtime fingerprint validation remain in place afterward.

### Retry / history recovery

- The coordinator reasons about the newest validation generation per exact PR/head, so a newer active retry suppresses an older completed run.
- Successful/no-op finalizer runs do not consume the finalizer failure budget.
- Unknown base remains `""`; it is never converted to an all-zero fake SHA.
- Infrastructure retry generation resets only when a real known prior base differs from live `main`.
- `pendingStateTimeoutMs` is 15 minutes, making an orphaned pending state retryable if its run falls outside bounded recent-history discovery.
- Coordinator workflow-history discovery scans up to five pages while the timeout provides deterministic recovery beyond that window.

### Failure isolation

Candidate-specific terminal-state publication, validation dispatch, finalizer dispatch, and dispatch-failure publication are all isolated to the affected PR and emitted as warnings on failure. They do not call a global `core.setFailed()` and cannot turn an unrelated PR's coordinator check red.

### Tests / static contract

- Permission invariants are scoped specifically to `jobs.discover` and `jobs.analyze`, so the test would catch the original 403 regression.
- The static contract verifies both sides of exact-base pinning: coordinator supplies `expected_base`, and worker enforces its execution SHA/live-main invariants.
- The static contract asserts the shared reconcile action cannot dispatch `Auto-merge PRs`.
- Unknown base representation is explicitly tested.
- `Validate GitHub workflows` now runs source self-tests plus the actual `ci-automerge-state.test.ts` and `ci-automerge-plan.test.ts` suites through a temporary JS runtime produced with Node's built-in TypeScript transformer.
- Planner tests cover newer-active-vs-older-completed races, finalizer failure accounting, known/unknown base transitions, orphaned pending timeout recovery, bounded unknown-base retries, green merge planning, alternate-ref rejection, and rerun-attempt rejection.

## Security

This PR changes the trusted CI/control-plane surface and is intentionally human-merge-only. It does not weaken evidence provenance or regression evaluation. External-fork unattended validation remains disabled.

## Final branch state

The implementation is squashed to one cohesive commit:

- head: `b42a52168b1465a902fbe0cf772d9453d68b3112`
- base: `b9d06c7b504225301e74af56bae2572e46b02cd1`
- ahead by 1, behind by 0
- exactly 10 intended control-plane/test files changed

The intervening `main` commit touched only product/refactor code, not the auto-merge control plane, and is included as the direct parent of the final commit.

## Validation

GitHub-hosted **Validate GitHub workflows #54** (`31351311003`) passed on the exact final squashed head. Every stage succeeded:

- workflow YAML / GitHub Actions expression validation with actionlint;
- local composite-action YAML parsing;
- trusted source self-tests for state, planner, evidence, and regression gate;
- staging of the trusted TypeScript unit-test runtime;
- actual `ci-automerge-state` and `ci-automerge-plan` unit tests.

This is the authoritative validation for the exact one-commit PR tree.

## Relationship to #10384

This PR starts from #10384's reviewed handoff/permission/idempotency changes, incorporates them into a clean one-commit branch on current `main`, and addresses every issue found in the subsequent fresh review. #10384 is superseded by this PR.