### PR TITLE
Make auto-merge terminal handoff event-driven and durable

### DIFF
--- a/.github/ci/automerge-policy.json
+++ b/.github/ci/automerge-policy.json
@@ -2,6 +2,7 @@
   "schemaVersion": 2,
   "testShardCount": 5,
   "maxParallelValidations": 2,
+  "maxParallelFinalizers": 4,
   "maxInfrastructureRetries": 1,
   "pendingStateTimeoutMs": 900000,
   "maxRemovedTestCases": 3,

--- a/.github/workflows/automerge-prs.yml
+++ b/.github/workflows/automerge-prs.yml
@@ -737,3 +737,139 @@ jobs:
           else
             test '${{ needs.base_assemble.result }}' = success
           fi
+
+  terminal_handoff:
+    name: Persist validation run and wake trusted coordinator
+    needs: [gate, validation_complete]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Persist exact run identity and dispatch coordinator
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          EXPECTED_HEAD: ${{ inputs.expected_head }}
+          EXPECTED_BASE: ${{ inputs.expected_base }}
+          INPUT_RETRY: ${{ inputs.retry }}
+          VALIDATION_RUN_ID: ${{ github.run_id }}
+          VALIDATION_RUN_ATTEMPT: ${{ github.run_attempt }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const { owner, repo } = context.repo;
+            const number = Number(process.env.PR_NUMBER || 0);
+            const head = String(process.env.EXPECTED_HEAD || '');
+            const base = String(process.env.EXPECTED_BASE || '');
+            const retry = Number(process.env.INPUT_RETRY || 0);
+            const runId = Number(process.env.VALIDATION_RUN_ID || 0);
+            const runAttempt = Number(process.env.VALIDATION_RUN_ATTEMPT || 0);
+            if (!Number.isInteger(number) || number <= 0
+                || !/^[0-9a-f]{40}$/u.test(head)
+                || !/^[0-9a-f]{40}$/u.test(base)
+                || !Number.isInteger(retry) || retry < 0
+                || !Number.isInteger(runId) || runId <= 0
+                || runAttempt !== 1
+                || context.sha !== base) {
+              core.warning('Terminal handoff refused invalid or non-first-attempt validation identity.');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+            if (pr.state !== 'open' || pr.draft || pr.base.ref !== 'main' || pr.head.sha !== head) {
+              core.notice(`PR #${number} changed before terminal handoff; no coordinator wake-up is needed.`);
+              return;
+            }
+
+            const stateModule = await import(pathToFileURL(path.join(
+              process.env.GITHUB_WORKSPACE,
+              'src/cli/src/commands/ci-automerge-state.ts',
+            )).href);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const existing = stateModule.findBotAutoMergeSummaryComment(comments);
+            const pendingState = {
+              pr: number,
+              head,
+              base,
+              green: false,
+              trusted: false,
+              reason: 'pending',
+              retry,
+              validationRunId: runId,
+              handoffRetry: 0,
+              runId: 0,
+            };
+            const render = (state, summary) => stateModule.renderAutoMergeStateComment(state, summary);
+            const upsert = async (state, summary) => {
+              const body = render(state, summary);
+              if (existing?.id) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              else await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            };
+            const targetUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+
+            try {
+              await upsert(pendingState,
+                `### Trusted auto-merge evaluation\n\n⏳ Validation run ${runId} reached terminal handoff; trusted finalization is being coordinated.`);
+              await github.rest.repos.createCommitStatus({
+                owner, repo, sha: head,
+                state: 'pending',
+                context: 'automerge/trusted-validation',
+                description: 'Trusted finalization queued',
+                target_url: targetUrl,
+              });
+            } catch (error) {
+              // Finalization can repair the durable surface, so do not strand a completed
+              // worker solely because the pre-handoff status/comment update was transient.
+              core.warning(`Could not persist terminal handoff state for PR #${number}: ${error.message}`);
+            }
+
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'automerge-reconcile.yml',
+                ref: 'main',
+                inputs: {
+                  source_validation_run_id: String(runId),
+                  source_pr_number: String(number),
+                  source_head: head,
+                },
+              });
+              core.notice(`Dispatched trusted coordinator for terminal validation run ${runId}.`);
+            } catch (error) {
+              const policy = JSON.parse(fs.readFileSync('.github/ci/automerge-policy.json', 'utf8'));
+              const maxRetries = Number(policy.maxInfrastructureRetries || 1);
+              const handoffRetry = 1;
+              const canRetry = Number.isInteger(maxRetries) && handoffRetry <= maxRetries;
+              try {
+                await upsert({
+                  ...pendingState,
+                  reason: 'infrastructure',
+                  handoffRetry,
+                }, `### Trusted auto-merge evaluation\n\n⚠️ Terminal coordinator dispatch failed: ${error.message}`);
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: head,
+                  state: canRetry ? 'pending' : 'failure',
+                  context: 'automerge/trusted-validation',
+                  description: canRetry ? 'Finalizer handoff retry pending' : 'Finalizer handoff retry exhausted',
+                  target_url: targetUrl,
+                });
+              } catch (stateError) {
+                core.warning(`Could not persist terminal dispatch failure for PR #${number}: ${stateError.message}`);
+              }
+              core.warning(`Could not wake trusted coordinator for validation run ${runId}: ${error.message}`);
+            }

--- a/.github/workflows/automerge-reconcile.yml
+++ b/.github/workflows/automerge-reconcile.yml
@@ -4,14 +4,31 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
-  # This accelerates human-dispatched workers. Bot-dispatched workers are still
-  # recovered deterministically by the periodic coordinator below.
+  # Human-triggered workflow completions can still arrive here directly. The
+  # worker also dispatches this coordinator explicitly with its exact run ID,
+  # while the periodic trigger remains a deterministic recovery safety net.
   workflow_run:
     workflows: ["Auto-merge PRs"]
     types: [completed]
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
+    inputs:
+      source_validation_run_id:
+        description: "Exact Auto-merge PRs run that just reached its terminal handoff."
+        required: false
+        default: ""
+        type: string
+      source_pr_number:
+        description: "PR associated with source_validation_run_id."
+        required: false
+        default: ""
+        type: string
+      source_head:
+        description: "Exact PR head associated with source_validation_run_id."
+        required: false
+        default: ""
+        type: string
 
 permissions: {}
 
@@ -42,6 +59,9 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           EVENT_PR: ${{ github.event.pull_request.number }}
+          SOURCE_VALIDATION_RUN_ID: ${{ inputs.source_validation_run_id }}
+          SOURCE_PR_NUMBER: ${{ inputs.source_pr_number }}
+          SOURCE_HEAD: ${{ inputs.source_head }}
         with:
           script: |
             const fs = require('node:fs');
@@ -51,9 +71,11 @@ jobs:
             const thisRepository = `${owner}/${repo}`.toLowerCase();
             const policy = JSON.parse(fs.readFileSync('.github/ci/automerge-policy.json', 'utf8'));
             const maxParallel = Number(policy.maxParallelValidations || 2);
+            const maxParallelFinalizers = Number(policy.maxParallelFinalizers || maxParallel);
             const maxRetries = Number(policy.maxInfrastructureRetries || 1);
             const pendingTimeoutMs = Number(policy.pendingStateTimeoutMs || 900000);
             if (!Number.isInteger(maxParallel) || maxParallel < 1 || maxParallel > 10
+                || !Number.isInteger(maxParallelFinalizers) || maxParallelFinalizers < 1 || maxParallelFinalizers > 10
                 || !Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10
                 || !Number.isInteger(pendingTimeoutMs) || pendingTimeoutMs < 60000) {
               core.setFailed('Invalid auto-merge admission policy.');
@@ -74,6 +96,14 @@ jobs:
               owner, repo, state: 'open', base: 'main', sort: 'created', direction: 'asc', per_page: 100,
             });
 
+            const normalizeValidationRun = (run) => {
+              const identity = stateModule.parseAutoMergeValidationRunTitle(run.display_title);
+              return identity ? { ...run, validationPr: identity.pr, validationHead: identity.head } : run;
+            };
+            const normalizeFinalizerRun = (run) => {
+              const validationRunId = stateModule.parseAutoMergeFinalizerRunTitle(run.display_title);
+              return validationRunId ? { ...run, finalizerValidationRunId: validationRunId } : run;
+            };
             const listRecentWorkflowRuns = async (workflowId, maxPages = 5) => {
               const runs = [];
               for (let page = 1; page <= maxPages; page += 1) {
@@ -89,17 +119,44 @@ jobs:
               listRecentWorkflowRuns('automerge-prs.yml'),
               listRecentWorkflowRuns('automerge-finalize.yml'),
             ]);
-            const normalizedValidationRuns = validationRuns.map((run) => {
-              const identity = stateModule.parseAutoMergeValidationRunTitle(run.display_title);
-              return identity ? { ...run, validationPr: identity.pr, validationHead: identity.head } : run;
-            });
-            const normalizedFinalizerRuns = finalizerRuns.map((run) => {
-              const validationRunId = stateModule.parseAutoMergeFinalizerRunTitle(run.display_title);
-              return validationRunId ? { ...run, finalizerValidationRunId: validationRunId } : run;
-            });
-            const newestValidations = planner.selectNewestValidationRuns(normalizedValidationRuns);
-            const activeValidationCount = [...newestValidations.values()]
-              .filter((run) => run.status === 'queued' || run.status === 'in_progress').length;
+            const normalizedValidationRuns = validationRuns.map(normalizeValidationRun);
+            const normalizedFinalizerRuns = finalizerRuns.map(normalizeFinalizerRun);
+
+            // A terminal worker dispatches this coordinator before its own workflow can
+            // technically become completed. Poll that exact run briefly so the fast path
+            // can finalize it immediately rather than waiting for a cron/history scan.
+            const sourceRunId = Number(process.env.SOURCE_VALIDATION_RUN_ID || 0);
+            const sourcePr = Number(process.env.SOURCE_PR_NUMBER || 0);
+            const sourceHead = String(process.env.SOURCE_HEAD || '');
+            if (Number.isInteger(sourceRunId) && sourceRunId > 0) {
+              let sourceRun = null;
+              for (const delay of [0, 1000, 2000, 4000, 8000, 8000, 8000]) {
+                if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+                try {
+                  const { data } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: sourceRunId });
+                  sourceRun = normalizeValidationRun(data);
+                  if (sourceRun.status === 'completed') break;
+                } catch (error) {
+                  core.warning(`Could not resolve source validation run ${sourceRunId}: ${error.message}`);
+                  break;
+                }
+              }
+              if (sourceRun) {
+                const identityMatches = sourceRun.validationPr === sourcePr && sourceRun.validationHead === sourceHead;
+                if (identityMatches) normalizedValidationRuns.push(sourceRun);
+                else core.warning(`Source validation run ${sourceRunId} did not match dispatched PR/head identity.`);
+                if (identityMatches && sourceRun.status !== 'completed') {
+                  core.notice(`Source validation run ${sourceRunId} is still ${sourceRun.status}; durable-state recovery will pick it up later.`);
+                }
+              }
+            }
+
+            const recentNewestValidations = planner.selectNewestValidationRuns(normalizedValidationRuns);
+            const activeValidationIds = new Set(
+              [...recentNewestValidations.values()]
+                .filter((run) => run.status === 'queued' || run.status === 'in_progress')
+                .map((run) => run.id),
+            );
 
             const upsertState = async (pr, state, summary, knownComments = null) => {
               const comments = knownComments || await github.paginate(github.rest.issues.listComments, {
@@ -114,7 +171,7 @@ jobs:
               }
             };
 
-            const eventPr = Number(process.env.EVENT_PR || 0);
+            const eventPr = Number(process.env.SOURCE_PR_NUMBER || process.env.EVENT_PR || 0);
             const validations = [];
             const finalizations = [];
             const reconcile = [];
@@ -130,7 +187,32 @@ jobs:
               });
               const latestState = stateModule.findLatestBotAutoMergeState(comments);
               const key = `${pr.number}:${pr.head.sha}`;
-              const newestValidation = newestValidations.get(key) || null;
+              let newestValidation = recentNewestValidations.get(key) || null;
+
+              // Once a worker reaches terminal handoff, its exact run ID is durable state.
+              // Resolve that run directly instead of depending on the global history window.
+              if (latestState?.head === pr.head.sha && latestState.validationRunId > 0
+                  && newestValidation?.id !== latestState.validationRunId) {
+                try {
+                  const { data } = await github.rest.actions.getWorkflowRun({
+                    owner, repo, run_id: latestState.validationRunId,
+                  });
+                  const exactRun = normalizeValidationRun(data);
+                  if (exactRun.validationPr === pr.number && exactRun.validationHead === pr.head.sha) {
+                    newestValidation = planner.selectNewestValidationRuns(
+                      newestValidation ? [newestValidation, exactRun] : [exactRun],
+                    ).get(key) || newestValidation;
+                    if (exactRun.status === 'queued' || exactRun.status === 'in_progress') {
+                      activeValidationIds.add(exactRun.id);
+                    }
+                  } else {
+                    core.warning(`Durable validation run ${latestState.validationRunId} no longer matches PR #${pr.number} @ ${pr.head.sha}.`);
+                  }
+                } catch (error) {
+                  core.warning(`Could not resolve durable validation run ${latestState.validationRunId} for PR #${pr.number}: ${error.message}`);
+                }
+              }
+
               const finalizerState = newestValidation
                 ? planner.summarizeFinalizerRuns(normalizedFinalizerRuns, newestValidation.id)
                 : { active: false, failedAttempts: 0 };
@@ -149,7 +231,8 @@ jobs:
                 finalizations.push({
                   pr,
                   run: newestValidation,
-                  retry: decision.retry,
+                  handoffRetry: decision.retry,
+                  validationRetry: latestState?.retry || 0,
                   comments,
                   priority: pr.number === eventPr ? 0 : 1,
                 });
@@ -173,8 +256,12 @@ jobs:
                     green: false,
                     trusted: false,
                     reason: 'infrastructure',
-                    retry: maxRetries,
-                    runId: newestValidation?.id || latestState?.runId || 0,
+                    retry: latestState?.retry || 0,
+                    validationRunId: newestValidation?.id || latestState?.validationRunId || 0,
+                    handoffRetry: decision.reason === 'finalizer-retry-exhausted'
+                      ? decision.retry
+                      : latestState?.handoffRetry || 0,
+                    runId: latestState?.runId || 0,
                   }, `### Trusted auto-merge evaluation\n\n⚠️ ${decision.reason === 'finalizer-retry-exhausted'
                     ? 'Trusted finalization retry budget was exhausted.'
                     : 'An orphaned pending validation exhausted its retry budget.'}`, comments);
@@ -210,7 +297,34 @@ jobs:
             finalizations.sort((a, b) => a.priority - b.priority
               || new Date(a.run.created_at || 0).getTime() - new Date(b.run.created_at || 0).getTime());
             let finalizersDispatched = 0;
-            for (const candidate of finalizations.slice(0, maxParallel)) {
+            for (const candidate of finalizations.slice(0, maxParallelFinalizers)) {
+              const pendingHandoffState = {
+                pr: candidate.pr.number,
+                head: candidate.pr.head.sha,
+                base: liveBase,
+                green: false,
+                trusted: false,
+                reason: 'pending',
+                retry: candidate.validationRetry,
+                validationRunId: candidate.run.id,
+                handoffRetry: candidate.handoffRetry,
+                runId: 0,
+              };
+              try {
+                await upsertState(candidate.pr, pendingHandoffState,
+                  `### Trusted auto-merge evaluation\n\n⏳ Validation run ${candidate.run.id} completed; trusted finalization is queued.`,
+                  candidate.comments);
+                await github.rest.repos.createCommitStatus({
+                  owner, repo, sha: candidate.pr.head.sha,
+                  state: 'pending',
+                  context: 'automerge/trusted-validation',
+                  description: 'Trusted finalization queued',
+                  target_url: candidate.run.html_url || undefined,
+                });
+              } catch (stateError) {
+                core.warning(`Could not refresh finalizer handoff state for PR #${candidate.pr.number}: ${stateError.message}`);
+              }
+
               try {
                 await github.rest.actions.createWorkflowDispatch({
                   owner,
@@ -222,20 +336,14 @@ jobs:
                 finalizersDispatched += 1;
                 core.notice(`Dispatched trusted finalizer for validation run ${candidate.run.id} (PR #${candidate.pr.number}).`);
               } catch (error) {
-                const nextRetry = candidate.retry + 1;
-                const canRetry = nextRetry <= maxRetries;
+                const nextHandoffRetry = candidate.handoffRetry + 1;
+                const canRetry = nextHandoffRetry <= maxRetries;
                 try {
                   await upsertState(candidate.pr, {
-                    pr: candidate.pr.number,
-                    head: candidate.pr.head.sha,
-                    base: liveBase,
-                    green: false,
-                    trusted: false,
+                    ...pendingHandoffState,
                     reason: 'infrastructure',
-                    retry: nextRetry,
-                    runId: 0,
-                  }, `### Trusted auto-merge evaluation\n\n⚠️ Finalizer dispatch failed before the finalizer started: ${error.message}`,
-                  candidate.comments);
+                    handoffRetry: nextHandoffRetry,
+                  }, `### Trusted auto-merge evaluation\n\n⚠️ Finalizer dispatch failed before the finalizer started: ${error.message}`);
                   await github.rest.repos.createCommitStatus({
                     owner, repo, sha: candidate.pr.head.sha,
                     state: canRetry ? 'pending' : 'failure',
@@ -251,6 +359,7 @@ jobs:
 
             validations.sort((a, b) => a.priority - b.priority
               || new Date(a.pr.created_at).getTime() - new Date(b.pr.created_at).getTime());
+            const activeValidationCount = activeValidationIds.size;
             const slots = Math.max(0, maxParallel - activeValidationCount);
             const admitted = validations.slice(0, slots);
             let validationsDispatched = 0;
@@ -264,6 +373,8 @@ jobs:
                 trusted: false,
                 reason: 'pending',
                 retry: candidate.retry,
+                validationRunId: 0,
+                handoffRetry: 0,
                 runId: 0,
               };
 

--- a/src/cli/src/commands/ci-automerge-gate.ts
+++ b/src/cli/src/commands/ci-automerge-gate.ts
@@ -209,6 +209,26 @@ function formatSamples(items: ReadonlyArray<ComparisonItem>, limit = 8): Array<s
     return items.slice(0, limit).map((item) => `- ${item.sample.file} :: ${item.sample.name}`);
 }
 
+function formatQualityTable(lint: ReturnType<typeof compareLint>, tests: TestComparison, maxRemovedTestCases: number): Array<string> {
+    const grossRemovedCases = tests.removedCases.reduce((total, item) => total + item.count, 0);
+    const newFailureCount = tests.newFailures.reduce((total, item) => total + item.count, 0);
+    const newSkipCount = tests.newSkips.reduce((total, item) => total + item.count, 0);
+    const removalWithinPolicy = tests.netRemovedCaseCount <= maxRemovedTestCases;
+    const rows = [
+        "| Check | Baseline | Merged | Delta / policy |",
+        "| --- | ---: | ---: | --- |",
+        `| Lint findings | ${lint.baseCount} | ${lint.targetCount} | ${lint.added.length === 0 ? "✅ **0 new/upgraded**" : `❌ **${lint.added.length} new/upgraded**`} |`,
+        `| Test cases | ${tests.baseCaseCount} | ${tests.targetCaseCount} | ${removalWithinPolicy ? "✅" : "❌"} **net reduction ${tests.netRemovedCaseCount} / ${maxRemovedTestCases} allowed** |`,
+        `| Canonical test files removed | — | — | ℹ️ **${tests.removedFiles.length} removed**; informational, case-count budget is authoritative |`,
+        `| Newly failing test cases | — | — | ${newFailureCount === 0 ? "✅ **0 introduced**" : `❌ **${newFailureCount} introduced**`} |`,
+        `| Newly skipped test cases | — | — | ${newSkipCount === 0 ? "✅ **0 introduced**" : `❌ **${newSkipCount} introduced**`} |`
+    ];
+    if (grossRemovedCases > 0) {
+        rows.push(`| Gross removed/renamed test identities | — | — | ℹ️ **${grossRemovedCases}**; new passing cases offset these for net reduction |`);
+    }
+    return rows;
+}
+
 function commandEvaluate(args: ParsedArgs): number {
     const baseDirectory = requireOption(args, "base");
     const mergeDirectory = requireOption(args, "merge");
@@ -251,6 +271,7 @@ function commandEvaluate(args: ParsedArgs): number {
             const exceedsRemovalBudget = tests.netRemovedCaseCount > maxRemovedTestCases;
             const hasRegression = lint.added.length > 0 || exceedsRemovalBudget
                 || tests.newFailures.length > 0 || tests.newSkips.length > 0;
+            const qualityTable = formatQualityTable(lint, tests, maxRemovedTestCases);
             if (!hasRegression) {
                 green = true;
                 reason = baseKind === "build-failure" ? "recovery" : "clean";
@@ -258,25 +279,14 @@ function commandEvaluate(args: ParsedArgs): number {
                     "",
                     "✅ No new lint warnings/errors, newly failing tests, or newly skipped tests were introduced, and net test removal stays within policy.",
                     "",
-                    `- Lint findings: ${lint.baseCount} baseline → ${lint.targetCount} merged; **0 new/upgraded**.`,
-                    `- Test cases: ${tests.baseCaseCount} baseline → ${tests.targetCaseCount} merged; **net reduction ${tests.netRemovedCaseCount}/${maxRemovedTestCases} allowed**.`,
-                    `- Canonical test files removed: **${tests.removedFiles.length}** (informational; case-count budget is authoritative).`,
-                    "- Newly failing / newly skipped test cases: **0 / 0**."
+                    ...qualityTable
                 );
-                if (tests.removedCases.length > 0) {
-                    const grossRemovedCases = tests.removedCases.reduce((total, item) => total + item.count, 0);
-                    lines.push("", `ℹ️ Gross removed/renamed test-case identities: **${grossRemovedCases}**; new passing cases offset these when calculating net reduction.`);
-                }
             } else {
                 reason = "quality-regression";
-                lines.push("", "❌ The exact synthetic merge weakens the trusted quality baseline.");
+                lines.push("", "❌ The exact synthetic merge weakens the trusted quality baseline.", "", ...qualityTable);
                 if (lint.added.length > 0) lines.push("", `**New/upgraded lint findings (${lint.added.length})**`, ...lint.added.slice(0, 8).map((item) => `- ${item.file}: ${item.ruleId || "eslint"}: ${item.message}`));
                 if (exceedsRemovalBudget) {
-                    lines.push(
-                        "",
-                        `**Net test-case reduction exceeds policy (${tests.netRemovedCaseCount} removed; maximum ${maxRemovedTestCases})**`,
-                        `- Test cases: ${tests.baseCaseCount} baseline → ${tests.targetCaseCount} merged.`
-                    );
+                    lines.push("", `**Net test-case reduction exceeds policy (${tests.netRemovedCaseCount} removed; maximum ${maxRemovedTestCases})**`);
                     if (tests.removedFiles.length > 0) lines.push(`- Removed canonical test files: ${tests.removedFiles.length}.`);
                     if (tests.removedCases.length > 0) lines.push(...formatSamples(tests.removedCases));
                 }
@@ -337,6 +347,11 @@ function selfTest(): void {
     assert.equal(deduplicatedWithReplacement.netRemovedCaseCount, 1);
     assert.equal(deduplicatedWithReplacement.newFailures.length, 0);
     assert.equal(deduplicatedWithReplacement.newSkips.length, 0);
+
+    const table = formatQualityTable(compareLint(baselineLint, movedLint), deduplicatedWithReplacement, 3).join("\n");
+    assert.match(table, /\| Check \| Baseline \| Merged \| Delta \/ policy \|/u);
+    assert.match(table, /\| Test cases \| 5 \| 4 \| ✅ \*\*net reduction 1 \/ 3 allowed\*\* \|/u);
+    assert.match(table, /Gross removed\/renamed test identities/u);
 
     process.stdout.write("ci-automerge gate self-test passed\n");
 }

--- a/src/cli/src/commands/ci-automerge-plan.ts
+++ b/src/cli/src/commands/ci-automerge-plan.ts
@@ -12,6 +12,8 @@ export type AutoMergeStateSnapshot = Readonly<{
     trusted: boolean;
     reason: string;
     retry: number;
+    validationRunId: number;
+    handoffRetry: number;
     runId: number;
     updatedAt: string;
 }>;
@@ -39,6 +41,7 @@ export type FinalizerRunState = Readonly<{
 
 export type AutoMergePlanDecision = Readonly<{
     kind: "validate" | "finalize" | "merge" | "wait" | "blocked";
+    /** Operation-specific retry generation: validation for validate, handoff for finalize. */
     retry: number;
     reason: string;
 }>;
@@ -111,7 +114,7 @@ export function isKnownBaseTransition(previousBase: string, liveBase: string): b
         && previousBase !== liveBase;
 }
 
-/** Treat an orphaned pending state as retryable after the configured bounded timeout. */
+/** Treat a pending state as expired after the configured bounded timeout. */
 export function isPendingStateExpired(state: AutoMergeStateSnapshot, nowMs: number, pendingTimeoutMs: number): boolean {
     if (state.reason !== "pending" || pendingTimeoutMs <= 0) return false;
     const updatedAt = Date.parse(state.updatedAt);
@@ -132,12 +135,27 @@ export function planAutoMergePr(input: AutoMergePlanInput): AutoMergePlanDecisio
         if (newestValidation.status === "completed") {
             const finalized = state?.head === head && state.runId === newestValidation.id;
             if (!finalized) {
-                const handoffRetry = state?.head === head && state.reason === "infrastructure" && state.runId === 0
-                    ? state.retry
-                    : 0;
-                if (finalizer.active) return Object.freeze({ kind: "wait", retry: handoffRetry, reason: "finalizer-active" });
+                // There is no value finalizing evidence that is already stale. Re-admit the
+                // same PR head against current main immediately and save a finalizer slot.
+                if (SHA_PATTERN.test(String(newestValidation.head_sha || ""))
+                    && newestValidation.head_sha !== liveBase) {
+                    return Object.freeze({ kind: "validate", retry: 0, reason: "stale-completed-validation" });
+                }
+
+                const exactHandoff = state?.head === head && state.validationRunId === newestValidation.id;
+                const handoffRetry = exactHandoff ? state.handoffRetry : 0;
+                if (finalizer.active) {
+                    return Object.freeze({ kind: "wait", retry: handoffRetry, reason: "finalizer-active" });
+                }
+                // terminal_handoff wakes the coordinator, not the finalizer. Once the exact
+                // worker is completed, coordinator recovery must finalize it immediately;
+                // waiting here would recreate the pending-status stall this handoff fixes.
                 if (finalizer.failedAttempts > maxInfrastructureRetries || handoffRetry > maxInfrastructureRetries) {
-                    return Object.freeze({ kind: "blocked", retry: Math.max(finalizer.failedAttempts, handoffRetry), reason: "finalizer-retry-exhausted" });
+                    return Object.freeze({
+                        kind: "blocked",
+                        retry: Math.max(finalizer.failedAttempts, handoffRetry),
+                        reason: "finalizer-retry-exhausted"
+                    });
                 }
                 return Object.freeze({ kind: "finalize", retry: handoffRetry, reason: "validation-completed" });
             }
@@ -165,6 +183,14 @@ export function planAutoMergePr(input: AutoMergePlanInput): AutoMergePlanDecisio
         return Object.freeze({ kind: "validate", retry: 0, reason: "pending-old-base" });
     }
     if (state.reason === "pending" && isPendingStateExpired(state, nowMs, pendingTimeoutMs)) {
+        if (state.validationRunId > 0) {
+            // A durable run ID means validation already existed. If the coordinator cannot
+            // resolve it, retrying validation is safer than leaving a permanent pending check.
+            if (state.retry < maxInfrastructureRetries) {
+                return Object.freeze({ kind: "validate", retry: state.retry + 1, reason: "orphaned-run-retry" });
+            }
+            return Object.freeze({ kind: "blocked", retry: state.retry, reason: "pending-retry-exhausted" });
+        }
         if (state.retry < maxInfrastructureRetries) {
             return Object.freeze({ kind: "validate", retry: state.retry + 1, reason: "orphaned-pending-retry" });
         }

--- a/src/cli/src/commands/ci-automerge-state.ts
+++ b/src/cli/src/commands/ci-automerge-state.ts
@@ -34,6 +34,11 @@ export type AutoMergeState = Readonly<{
     trusted: boolean;
     reason: string;
     retry: number;
+    /** Exact validation worker run observed for this head, even before finalization. */
+    validationRunId: number;
+    /** Failed coordinator/finalizer handoff dispatch attempts, independent from validation retries. */
+    handoffRetry: number;
+    /** Validation run whose trusted finalizer has already published this state. */
     runId: number;
     updatedAt: string;
 }>;
@@ -43,7 +48,8 @@ export type AutoMergeValidationRunIdentity = Readonly<{
     head: string;
 }>;
 
-type StateInput = Omit<AutoMergeState, "v" | "updatedAt"> & Readonly<{ updatedAt?: string }>;
+type StateInput = Omit<AutoMergeState, "v" | "updatedAt" | "validationRunId" | "handoffRetry">
+    & Readonly<{ validationRunId?: number; handoffRetry?: number; updatedAt?: string }>;
 export type AutoMergeIssueComment = Readonly<{
     id?: number;
     body?: string | null;
@@ -67,6 +73,8 @@ export function normalizeAutoMergeState(value: StateInput | AutoMergeState): Aut
         trusted: value.trusted === true,
         reason: String(value.reason || ""),
         retry: Number(value.retry || 0),
+        validationRunId: Number(value.validationRunId || 0),
+        handoffRetry: Number(value.handoffRetry || 0),
         runId: Number(value.runId || 0),
         updatedAt: String(value.updatedAt || new Date().toISOString())
     });
@@ -74,7 +82,9 @@ export function normalizeAutoMergeState(value: StateInput | AutoMergeState): Aut
     if (!isSha(state.head) || (state.base !== "" && !isSha(state.base))) throw new Error("Invalid head/base SHA in auto-merge state.");
     if (!AUTO_MERGE_STATE_REASONS.has(state.reason)) throw new Error(`Unsupported auto-merge reason: ${state.reason}`);
     if (!Number.isInteger(state.retry) || state.retry < 0 || state.retry > 10) throw new Error("Invalid retry count in auto-merge state.");
-    if (!Number.isInteger(state.runId) || state.runId < 0) throw new Error("Invalid workflow run ID in auto-merge state.");
+    if (!Number.isInteger(state.validationRunId) || state.validationRunId < 0) throw new Error("Invalid validation workflow run ID in auto-merge state.");
+    if (!Number.isInteger(state.handoffRetry) || state.handoffRetry < 0 || state.handoffRetry > 10) throw new Error("Invalid finalizer handoff retry count in auto-merge state.");
+    if (!Number.isInteger(state.runId) || state.runId < 0) throw new Error("Invalid finalized workflow run ID in auto-merge state.");
     return state;
 }
 
@@ -156,14 +166,44 @@ export function assertAutoMergeControlPlaneContract(
 ): void {
     const discoverJob = extractJobBlock(reconcile, "discover", "reconcile");
     const analyzeJob = extractJobBlock(finalizer, "analyze", "merge");
+    const handoffJob = extractJobBlock(worker, "terminal_handoff", null);
 
     assert.match(discoverJob, /permissions:\n(?: {6}[^\n]+\n)* {6}pull-requests: write/u,
         "coordinator discover job must have PR-write permission");
     assert.match(analyzeJob, /permissions:\n(?: {6}[^\n]+\n)* {6}pull-requests: write/u,
         "finalizer analyze job must have PR-write permission");
+    assert.match(handoffJob, /permissions:\n(?: {6}[^\n]+\n)* {6}actions: write/u,
+        "terminal validation handoff must be allowed to wake the trusted coordinator");
+    assert.match(handoffJob, /permissions:\n(?: {6}[^\n]+\n)* {6}pull-requests: write/u,
+        "terminal validation handoff must persist durable PR state");
+    assert.match(handoffJob, /permissions:\n(?: {6}[^\n]+\n)* {6}statuses: write/u,
+        "terminal validation handoff must update the trusted-validation status");
+    assert.match(handoffJob, /ref: \$\{\{ github\.sha \}\}/u,
+        "terminal handoff helper code must come from the exact workflow commit");
+    assert.match(handoffJob, /context\.sha !== base/u,
+        "terminal handoff must refuse a run whose workflow commit differs from the admitted base");
+    assert.match(handoffJob, /validationRunId: runId/u,
+        "terminal handoff must durably correlate the exact validation run");
+    assert.match(handoffJob, /workflow_id: 'automerge-reconcile\.yml'/u);
+    assert.match(handoffJob, /source_validation_run_id: String\(runId\)/u,
+        "terminal worker must explicitly wake the coordinator with its own run ID");
+    assert.doesNotMatch(handoffJob, /workflow_id: 'automerge-finalize\.yml'/u,
+        "a worker must not race its own completion by dispatching the finalizer directly");
+
+    assert.match(reconcile, /source_validation_run_id:/u,
+        "coordinator must accept an exact terminal worker run ID");
+    assert.match(reconcile, /SOURCE_VALIDATION_RUN_ID: \$\{\{ inputs\.source_validation_run_id \}\}/u);
     assert.match(reconcile, /workflow_id: 'automerge-finalize\.yml'/u);
     assert.match(reconcile, /expected_base: liveBase/u,
         "coordinator must pin every validation dispatch to the exact admitted main SHA");
+    assert.match(reconcile, /latestState\.validationRunId/u,
+        "coordinator must use durable validation-run identity instead of relying only on global history");
+    assert.match(reconcile, /getWorkflowRun\(\{\s*owner, repo, run_id: latestState\.validationRunId,?\s*\}\)/u,
+        "coordinator must resolve durable validation runs directly by ID");
+    assert.match(reconcile, /sourceRun\.status === 'completed'/u,
+        "terminal fast path must wait until GitHub marks the source worker completed");
+    assert.match(reconcile, /maxParallelFinalizers/u,
+        "finalizer recovery concurrency must be independent from expensive validation concurrency");
     assert.match(reconcile, /has no changed files yet; waiting for its first substantive synchronize event/u);
     assert.match(reconcile, /pendingTimeoutMs/u);
     assert.doesNotMatch(reconcile, /core\.setFailed\(`Auto-merge control-plane dispatch failure/u,
@@ -210,9 +250,13 @@ function selfTest(): void {
         trusted: true,
         reason: "infrastructure",
         retry: 0,
-        runId: 123
+        validationRunId: 123,
+        handoffRetry: 1,
+        runId: 0
     });
     assert.equal(parseAutoMergeState(marker)?.pr, 42);
+    assert.equal(parseAutoMergeState(marker)?.validationRunId, 123);
+    assert.equal(parseAutoMergeState(marker)?.handoffRetry, 1);
     assert.equal(parseAutoMergeState("<!-- automerge-state nope -->"), null);
     assert.equal(findLatestBotAutoMergeState([{ body: marker, updated_at: "2026-01-01", user: { login: "github-actions[bot]" } }])?.reason, "infrastructure");
     assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${"a".repeat(40)}`), { pr: 42, head: "a".repeat(40) });

--- a/src/cli/test/ci-automerge-plan.test.ts
+++ b/src/cli/test/ci-automerge-plan.test.ts
@@ -17,7 +17,13 @@ const BASE = "b".repeat(40);
 const OLD_BASE = "c".repeat(40);
 const NOW = Date.parse("2026-08-10T02:00:00Z");
 
-function validationRun(id: number, status: string, createdAt: string, conclusion: string | null = null): AutoMergeWorkflowRun {
+function validationRun(
+    id: number,
+    status: string,
+    createdAt: string,
+    conclusion: string | null = null,
+    base = BASE
+): AutoMergeWorkflowRun {
     return {
         id,
         run_attempt: 1,
@@ -29,7 +35,7 @@ function validationRun(id: number, status: string, createdAt: string, conclusion
         path: ".github/workflows/automerge-prs.yml",
         event: "workflow_dispatch",
         head_branch: "main",
-        head_sha: BASE
+        head_sha: base
     };
 }
 
@@ -64,13 +70,117 @@ void test("latest completed generation is finalized before any new validation", 
     }), { kind: "finalize", retry: 0, reason: "validation-completed" });
 });
 
-void test("only failed finalizer executions consume the finalizer retry budget", () => {
+void test("exact terminal handoff finalizes immediately instead of waiting on pending timeout", () => {
+    const latest = validationRun(101, "completed", "2026-08-10T01:59:00Z", "success");
+    const pending = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: BASE,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 1,
+        validationRunId: 101,
+        handoffRetry: 0,
+        runId: 0,
+        updatedAt: "2026-08-10T01:59:59Z"
+    });
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: pending,
+        newestValidation: latest,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "finalize", retry: 0, reason: "validation-completed" });
+});
+
+void test("completed exact-run recovery finalizes without re-running validation", () => {
+    const latest = validationRun(101, "completed", "2026-08-10T01:00:00Z", "success");
+    const pending = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: BASE,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 1,
+        validationRunId: 101,
+        handoffRetry: 1,
+        runId: 0,
+        updatedAt: "2026-08-10T01:30:00Z"
+    });
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: pending,
+        newestValidation: latest,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "finalize", retry: 1, reason: "validation-completed" });
+});
+
+void test("completed evidence from an older main generation is revalidated without wasting a finalizer slot", () => {
+    const stale = validationRun(101, "completed", "2026-08-10T01:00:00Z", "success", OLD_BASE);
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: normalizeAutoMergeState({
+            pr: 42,
+            head: HEAD,
+            base: OLD_BASE,
+            green: false,
+            trusted: false,
+            reason: "pending",
+            retry: 0,
+            validationRunId: 101,
+            runId: 0
+        }),
+        newestValidation: stale,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "validate", retry: 0, reason: "stale-completed-validation" });
+});
+
+void test("only failed finalizer executions consume the finalizer execution retry budget", () => {
     const runs: ReadonlyArray<AutoMergeWorkflowRun> = [
         { id: 1, finalizerValidationRunId: 101, status: "completed", conclusion: "success" },
         { id: 2, finalizerValidationRunId: 101, status: "completed", conclusion: "failure" },
         { id: 3, finalizerValidationRunId: 101, status: "in_progress", conclusion: null }
     ];
     assert.deepEqual(summarizeFinalizerRuns(runs, 101), { active: true, failedAttempts: 1 });
+});
+
+void test("validation and finalizer-dispatch retry budgets remain independent", () => {
+    const latest = validationRun(101, "completed", "2026-08-10T01:00:00Z", "success");
+    const failedHandoff = normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD,
+        base: BASE,
+        green: false,
+        trusted: false,
+        reason: "infrastructure",
+        retry: 1,
+        validationRunId: 101,
+        handoffRetry: 1,
+        runId: 0
+    });
+    assert.deepEqual(planAutoMergePr({
+        head: HEAD,
+        liveBase: BASE,
+        state: failedHandoff,
+        newestValidation: latest,
+        finalizer: { active: false, failedAttempts: 0 },
+        maxInfrastructureRetries: 1,
+        pendingTimeoutMs: 900000,
+        nowMs: NOW
+    }), { kind: "finalize", retry: 1, reason: "validation-completed" });
 });
 
 void test("known base changes reset retries but unknown or placeholder bases do not", () => {
@@ -136,6 +246,7 @@ void test("current trusted green state is the only state that reaches merge plan
         trusted: true,
         reason: "clean",
         retry: 0,
+        validationRunId: 101,
         runId: 101
     });
     assert.deepEqual(planAutoMergePr({

--- a/src/cli/test/ci-automerge-state.test.ts
+++ b/src/cli/test/ci-automerge-state.test.ts
@@ -21,7 +21,7 @@ const HEAD_SHA = "a".repeat(40);
 const BASE_SHA = "b".repeat(40);
 const REPO_ROOT = process.cwd();
 
-void test("auto-merge state round-trips through its durable comment marker", () => {
+void test("auto-merge state round-trips durable validation and finalizer identities", () => {
     const marker = serializeAutoMergeState({
         pr: 42,
         head: HEAD_SHA,
@@ -30,6 +30,8 @@ void test("auto-merge state round-trips through its durable comment marker", () 
         trusted: true,
         reason: "clean",
         retry: 0,
+        validationRunId: 123,
+        handoffRetry: 1,
         runId: 123
     });
 
@@ -41,9 +43,29 @@ void test("auto-merge state round-trips through its durable comment marker", () 
         trusted: true,
         reason: "clean",
         retry: 0,
+        validationRunId: 123,
+        handoffRetry: 1,
         runId: 123,
         updatedAt: parseAutoMergeState(marker)?.updatedAt
     }));
+});
+
+void test("legacy schema-v1 state defaults new handoff fields without becoming unreadable", () => {
+    const legacy = `<!-- automerge-state ${JSON.stringify({
+        v: 1,
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: false,
+        trusted: false,
+        reason: "pending",
+        retry: 0,
+        runId: 0,
+        updatedAt: "2026-08-10T01:00:00Z"
+    })} -->`;
+    const parsed = parseAutoMergeState(legacy);
+    assert.equal(parsed?.validationRunId, 0);
+    assert.equal(parsed?.handoffRetry, 0);
 });
 
 void test("unknown base is represented explicitly rather than with a placeholder SHA", () => {
@@ -69,11 +91,13 @@ void test("canonical summary rendering and lookup share one durable marker", () 
         trusted: false,
         reason: "pending",
         retry: 0,
+        validationRunId: 456,
         runId: 0
     }, "### Trusted auto-merge evaluation\n\nWaiting for validation.");
 
     assert.match(body, new RegExp(AUTO_MERGE_SUMMARY_COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
     assert.equal(parseAutoMergeState(body)?.reason, "pending");
+    assert.equal(parseAutoMergeState(body)?.validationRunId, 456);
     assert.equal(findBotAutoMergeSummaryComment([
         { id: 7, body, user: { login: "github-actions[bot]" } },
         { id: 8, body, user: { login: "someone-else" } }
@@ -89,6 +113,7 @@ void test("latest trusted state only considers valid bot-authored markers", () =
         trusted: false,
         reason: "pending",
         retry: 0,
+        validationRunId: 111,
         runId: 0
     });
     const newer = serializeAutoMergeState({
@@ -99,6 +124,7 @@ void test("latest trusted state only considers valid bot-authored markers", () =
         trusted: true,
         reason: "clean",
         retry: 0,
+        validationRunId: 456,
         runId: 456
     });
 
@@ -109,6 +135,7 @@ void test("latest trusted state only considers valid bot-authored markers", () =
     ]);
 
     assert.equal(state?.green, true);
+    assert.equal(state?.validationRunId, 456);
     assert.equal(state?.runId, 456);
 });
 
@@ -122,7 +149,7 @@ void test("validation and finalizer run titles have strict machine-readable iden
     assert.equal(parseAutoMergeFinalizerRunTitle("Finalize auto-merge"), null);
 });
 
-void test("control-plane workflow contract checks exact privileged jobs, worker base pinning, and queue ownership", () => {
+void test("control-plane workflow contract checks exact privileged jobs, terminal handoff, base pinning, and queue ownership", () => {
     const reconcile = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-reconcile.yml"), "utf8");
     const finalizer = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-finalize.yml"), "utf8");
     const reconcileAction = fs.readFileSync(path.join(REPO_ROOT, ".github/actions/reconcile-automerge/action.yml"), "utf8");
@@ -141,5 +168,17 @@ void test("malformed or unsupported auto-merge state is rejected", () => {
         reason: "infrastructure",
         retry: 0,
         runId: 1
+    }));
+    assert.throws(() => normalizeAutoMergeState({
+        pr: 42,
+        head: HEAD_SHA,
+        base: BASE_SHA,
+        green: false,
+        trusted: true,
+        reason: "infrastructure",
+        retry: 0,
+        validationRunId: 1,
+        handoffRetry: 11,
+        runId: 0
     }));
 });


### PR DESCRIPTION
## Summary

Fix the auto-merge stall exposed by PR #10364, where validation completed successfully but `automerge/trusted-validation` remained pending because trusted finalization depended on delayed/global workflow-history scanning and shared validation/finalizer queue capacity.

Also restore the human-facing auto-merge evaluation to a compact **Quality Report-style Markdown table** instead of a block of raw prose.

## What changed

- **Event-driven terminal handoff:** every validation worker ends with a small trusted terminal job that records its exact `github.run_id` and wakes the trusted coordinator.
- **No worker/finalizer race:** the worker wakes the coordinator rather than dispatching the finalizer directly; the coordinator polls the exact source run until GitHub reports it completed, then applies the normal trusted finalization path.
- **Durable exact-run recovery:** PR state now distinguishes `validationRunId`, validation `retry`, finalizer/coordinator `handoffRetry`, and finalized `runId`. The coordinator resolves durable validation runs directly with `getWorkflowRun`, so correctness no longer depends on the latest 500 global workflow runs.
- **History/cron are fallback only:** workflow-history scanning and the five-minute schedule remain recovery paths for missed dispatches or GitHub infrastructure failures rather than the primary handoff mechanism.
- **No finalizer starvation:** terminal source PRs are prioritized, and fallback finalizer concurrency is independently configurable with `maxParallelFinalizers` instead of reusing expensive validation concurrency.
- **Avoid useless finalization:** if completed evidence was produced from an older `main`, the planner skips finalization and immediately re-admits the same PR head against current `main`.
- **Independent retry budgets:** a finalizer/coordinator handoff failure cannot consume or reset the validation retry generation.
- **Backward-compatible durable state:** existing schema-v1 comments without the new fields remain readable and default new counters/IDs to zero.
- **Failure isolation retained:** one PR's handoff/dispatch failure does not fail unrelated PR coordinator checks.

## Quality-report presentation

Successful and failing trusted evaluations now use the same compact table structure:

| Check | Baseline | Merged | Delta / policy |
| --- | ---: | ---: | --- |
| Lint findings | baseline count | merged count | new/upgraded findings |
| Test cases | baseline count | merged count | net reduction / configured allowance |
| Canonical test files removed | — | — | informational removed-file count |
| Newly failing test cases | — | — | introduced failures |
| Newly skipped test cases | — | — | introduced skips |

The short overall verdict remains above the table. Specific lint/test identities are shown **below the table only when there is an actual regression**, keeping normal green comments compact while preserving actionable failure detail.

## Regression coverage

The trusted planner/state/gate tests cover:
- exact terminal handoff finalizes promptly rather than waiting for pending-state timeout;
- direct exact-run recovery after a run falls outside normal history discovery;
- newer active generations suppress older completed runs;
- stale completed evidence is revalidated without consuming a finalizer slot;
- validation and handoff retry budgets remain independent;
- legacy durable state remains readable;
- job-scoped write permissions, exact-run handoff, worker base pinning, and coordinator-only validation dispatch are statically asserted;
- the human-facing quality summary renders the expected Markdown table and net-removal policy row.

## Validation

Final squashed head: `402a24f304c4fd6b7b93034a75362d9c262e5ba8`, exactly **one commit** on `main` `90bba011f9f7172979929e93681080b513a829b5`, changing exactly the intended eight control-plane/test files.

`Validate GitHub workflows` **#75 / run 31490047742** passed on that exact head. It passed workflow YAML/expression validation, composite-action parsing, trusted control-plane source self-tests, TypeScript staging, and the real planner/state unit tests.

This changes trusted CI/control-plane code and is intentionally **human-merge-only**.