### PR TITLE
Fix auto-merge test evidence and restore tabular reports

### DIFF
--- a/.github/actions/run-automerge-validation/action.yml
+++ b/.github/actions/run-automerge-validation/action.yml
@@ -78,10 +78,40 @@ runs:
               echo "No files assigned to $SHARD" >&2
               status=2
             else
+              junit_reporter="$RUNNER_TEMP/automerge-junit-reporter-$SHARD.mjs"
+              cat > "$junit_reporter" <<'NODE_REPORTER'
+        function escapeXml(value) {
+          return String(value ?? "")
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&apos;");
+        }
+
+        export default async function* reporter(source) {
+          yield '<?xml version="1.0" encoding="utf-8"?>\n<testsuites>\n\t<testsuite name="automerge">\n';
+          for await (const event of source) {
+            if (event.type !== "test:pass" && event.type !== "test:fail") continue;
+            const data = event.data ?? {};
+            if (data.details?.type === "suite") continue;
+            const duration = Number(data.details?.duration_ms ?? 0) * 0.001;
+            const attributes = `name="${escapeXml(data.name)}" time="${duration.toFixed(6)}" classname="test" file="${escapeXml(data.file)}"`;
+            if (data.skip || data.todo) {
+              yield `\t\t<testcase ${attributes}><skipped/></testcase>\n`;
+            } else if (event.type === "test:fail") {
+              yield `\t\t<testcase ${attributes}><failure/></testcase>\n`;
+            } else {
+              yield `\t\t<testcase ${attributes}/>\n`;
+            }
+          }
+          yield '\t</testsuite>\n</testsuites>\n';
+        }
+        NODE_REPORTER
               timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" \
                 node --disable-warning=ExperimentalWarning --test-force-exit --test --test-timeout=120000 \
                 --test-reporter=dot --test-reporter-destination=stdout \
-                --test-reporter=junit --test-reporter-destination="$REPORT_DIR/tests-$SHARD.xml" \
+                --test-reporter="$junit_reporter" --test-reporter-destination="$REPORT_DIR/tests-$SHARD.xml" \
                 "${test_files[@]}"
               status=$?
             fi
@@ -91,13 +121,6 @@ runs:
             exit 2
             ;;
         esac
-        if [ "$MODE" = "test" ] && { [ "$status" -eq 0 ] || [ "$status" -eq 1 ]; }; then
-          junit_report="$REPORT_DIR/tests-$SHARD.xml"
-          if [ -f "$junit_report" ] && grep -Eq '</?undefined([[:space:]>])' "$junit_report"; then
-            echo "::warning::Malformed JUnit reporter output contains <undefined> elements; treating shard as infrastructure failure."
-            status=2
-          fi
-        fi
         set -e
         finished_ms="$(date +%s%3N)"
         duration_ms=$(( finished_ms - started_ms ))

--- a/.github/actions/run-automerge-validation/action.yml
+++ b/.github/actions/run-automerge-validation/action.yml
@@ -91,6 +91,13 @@ runs:
             exit 2
             ;;
         esac
+        if [ "$MODE" = "test" ] && { [ "$status" -eq 0 ] || [ "$status" -eq 1 ]; }; then
+          junit_report="$REPORT_DIR/tests-$SHARD.xml"
+          if [ -f "$junit_report" ] && grep -Eq '</?undefined([[:space:]>])' "$junit_report"; then
+            echo "::warning::Malformed JUnit reporter output contains <undefined> elements; treating shard as infrastructure failure."
+            status=2
+          fi
+        fi
         set -e
         finished_ms="$(date +%s%3N)"
         duration_ms=$(( finished_ms - started_ms ))

--- a/src/cli/src/commands/ci-automerge-state.ts
+++ b/src/cli/src/commands/ci-automerge-state.ts
@@ -52,8 +52,74 @@ export type AutoMergeIssueComment = Readonly<{
     user?: Readonly<{ login?: string | null }> | null;
 }>;
 
+type AutoMergeSummaryRow = Readonly<{
+    check: string;
+    result: string;
+    details: ReadonlyArray<string>;
+}>;
+
 function isSha(value: string): boolean {
     return /^[0-9a-f]{40}$/u.test(value);
+}
+
+function escapeMarkdownTableCell(value: string): string {
+    return value.replaceAll("|", String.raw`\|`).replaceAll("\n", " ");
+}
+
+function formatAutoMergeSummaryTable(summary: string): string {
+    const lines = summary.split(/\r?\n/u).map((line) => line.trim());
+    const heading = lines[0] === "### Trusted auto-merge evaluation" ? lines.shift() ?? "" : "";
+    while (lines[0] === "") lines.shift();
+    const lead = lines.shift() ?? "";
+    while (lines[0] === "") lines.shift();
+
+    const rows: Array<AutoMergeSummaryRow> = [];
+    const notes: Array<string> = [];
+    let active: { check: string; result: string; details: Array<string> } | null = null;
+    const flushActive = (): void => {
+        if (!active) return;
+        rows.push(Object.freeze({ check: active.check, result: active.result, details: Object.freeze(active.details) }));
+        active = null;
+    };
+
+    for (const line of lines) {
+        if (!line) continue;
+        const section = line.match(/^\*\*(.+)\*\*$/u);
+        if (section?.[1]) {
+            flushActive();
+            active = { check: section[1], result: "❌", details: [] };
+            continue;
+        }
+        if (line.startsWith("- ")) {
+            const detail = line.slice(2).trim();
+            if (active) {
+                active.details.push(detail);
+                continue;
+            }
+            const separator = detail.indexOf(":");
+            const check = separator >= 0 ? detail.slice(0, separator).trim() : detail;
+            const value = separator >= 0 ? detail.slice(separator + 1).trim() : "";
+            const result = detail.includes("(informational;") ? "ℹ️" : (lead.startsWith("✅") ? "✅" : "❌");
+            rows.push(Object.freeze({ check, result, details: Object.freeze(value ? [value] : []) }));
+            continue;
+        }
+        flushActive();
+        notes.push(line);
+    }
+    flushActive();
+
+    if (rows.length === 0) return summary.trim();
+    const table = [
+        "| Check | Result | Details |",
+        "| --- | :---: | --- |",
+        ...rows.map((row) => {
+            const details = row.details.map(escapeMarkdownTableCell).join("<br>");
+            return `| ${escapeMarkdownTableCell(row.check)} | ${row.result} | ${details} |`;
+        })
+    ];
+    const output = [heading, "", lead, "", ...table];
+    if (notes.length > 0) output.push("", ...notes);
+    return output.join("\n").trim();
 }
 
 /** Normalize and validate the durable machine-readable auto-merge state. */
@@ -85,7 +151,7 @@ export function serializeAutoMergeState(value: StateInput | AutoMergeState): str
 
 /** Render the canonical durable auto-merge summary comment. */
 export function renderAutoMergeStateComment(value: StateInput | AutoMergeState, summary: string): string {
-    const normalizedSummary = String(summary || "").trim();
+    const normalizedSummary = formatAutoMergeSummaryTable(String(summary || "").trim());
     return `${AUTO_MERGE_SUMMARY_COMMENT_MARKER}\n${serializeAutoMergeState(value)}\n${normalizedSummary}`;
 }
 
@@ -152,7 +218,8 @@ export function assertAutoMergeControlPlaneContract(
     reconcile: string,
     finalizer: string,
     reconcileAction: string,
-    worker: string
+    worker: string,
+    validationAction: string
 ): void {
     const discoverJob = extractJobBlock(reconcile, "discover", "reconcile");
     const analyzeJob = extractJobBlock(finalizer, "analyze", "merge");
@@ -184,6 +251,8 @@ export function assertAutoMergeControlPlaneContract(
         "validation worker must reject a live-main change after admission");
     assert.match(worker, /currentBase\.commit\.sha !== expectedBase/u,
         "validation worker must reject main movement while resolving the synthetic merge");
+    assert.ok(validationAction.includes("grep -Eq '</?undefined([[:space:]>])'"),
+        "validation action must reject malformed Node JUnit <undefined> elements before evidence is trusted");
 
     assert.match(finalizer, /workflow_dispatch:/u);
     assert.doesNotMatch(finalizer, /workflows:\s*\["Auto-merge PRs"\]/u);
@@ -218,12 +287,57 @@ function selfTest(): void {
     assert.deepEqual(parseAutoMergeValidationRunTitle(`Auto-merge PR #42 @ ${"a".repeat(40)}`), { pr: 42, head: "a".repeat(40) });
     assert.equal(parseAutoMergeFinalizerRunTitle(`${AUTO_MERGE_FINALIZER_RUN_PREFIX}123`), 123);
 
+    const summaryComment = renderAutoMergeStateComment({
+        pr: 42,
+        head: "a".repeat(40),
+        base: "b".repeat(40),
+        green: true,
+        trusted: true,
+        reason: "clean",
+        retry: 0,
+        runId: 123
+    }, [
+        "### Trusted auto-merge evaluation",
+        "",
+        "✅ No new regressions were introduced.",
+        "",
+        "- Lint findings: 12 baseline → 12 merged; **0 new/upgraded**.",
+        "- Test cases: 100 baseline → 100 merged; **net reduction 0/3 allowed**.",
+        "- Canonical test files removed: **0** (informational; case-count budget is authoritative).",
+        "- Newly failing / newly skipped test cases: **0 / 0**."
+    ].join("\n"));
+    assert.match(summaryComment, /\| Check \| Result \| Details \|/u);
+    assert.match(summaryComment, /\| Lint findings \| ✅ \|/u);
+    assert.match(summaryComment, /\| Canonical test files removed \| ℹ️ \|/u);
+
+    const regressionComment = renderAutoMergeStateComment({
+        pr: 42,
+        head: "a".repeat(40),
+        base: "b".repeat(40),
+        green: false,
+        trusted: true,
+        reason: "quality-regression",
+        retry: 0,
+        runId: 123
+    }, [
+        "### Trusted auto-merge evaluation",
+        "",
+        "❌ The exact synthetic merge weakens the trusted quality baseline.",
+        "",
+        "**Net test-case reduction exceeds policy (37 removed; maximum 3)**",
+        "- Test cases: 7652 baseline → 7615 merged.",
+        "- src/runtime-wrapper/dist/test/index.test.js :: applyPatch handles closure patches"
+    ].join("\n"));
+    assert.match(regressionComment, /\| Net test-case reduction exceeds policy \(37 removed; maximum 3\) \| ❌ \|/u);
+    assert.match(regressionComment, /7652 baseline → 7615 merged\.<br>src\/runtime-wrapper/u);
+
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
     const reconcile = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-reconcile.yml"), "utf8");
     const finalizer = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-finalize.yml"), "utf8");
     const reconcileAction = fs.readFileSync(path.join(repoRoot, ".github/actions/reconcile-automerge/action.yml"), "utf8");
     const worker = fs.readFileSync(path.join(repoRoot, ".github/workflows/automerge-prs.yml"), "utf8");
-    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker);
+    const validationAction = fs.readFileSync(path.join(repoRoot, ".github/actions/run-automerge-validation/action.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker, validationAction);
     process.stdout.write("ci-automerge state self-test passed\n");
 }
 

--- a/src/cli/src/commands/ci-automerge-state.ts
+++ b/src/cli/src/commands/ci-automerge-state.ts
@@ -251,8 +251,10 @@ export function assertAutoMergeControlPlaneContract(
         "validation worker must reject a live-main change after admission");
     assert.match(worker, /currentBase\.commit\.sha !== expectedBase/u,
         "validation worker must reject main movement while resolving the synthetic merge");
-    assert.ok(validationAction.includes("grep -Eq '</?undefined([[:space:]>])'"),
-        "validation action must reject malformed Node JUnit <undefined> elements before evidence is trusted");
+    assert.ok(validationAction.includes('--test-reporter="$junit_reporter"'),
+        "validation action must use the trusted TestsStream reporter for comparable test evidence");
+    assert.ok(validationAction.includes('if (data.details?.type === "suite") continue;'),
+        "trusted test reporter must exclude suite summary events from case evidence");
 
     assert.match(finalizer, /workflow_dispatch:/u);
     assert.doesNotMatch(finalizer, /workflows:\s*\["Auto-merge PRs"\]/u);

--- a/src/cli/test/ci-automerge-state.test.ts
+++ b/src/cli/test/ci-automerge-state.test.ts
@@ -127,7 +127,8 @@ void test("control-plane workflow contract checks exact privileged jobs, worker 
     const finalizer = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-finalize.yml"), "utf8");
     const reconcileAction = fs.readFileSync(path.join(REPO_ROOT, ".github/actions/reconcile-automerge/action.yml"), "utf8");
     const worker = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/automerge-prs.yml"), "utf8");
-    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker);
+    const validationAction = fs.readFileSync(path.join(REPO_ROOT, ".github/actions/run-automerge-validation/action.yml"), "utf8");
+    assertAutoMergeControlPlaneContract(reconcile, finalizer, reconcileAction, worker, validationAction);
 });
 
 void test("malformed or unsupported auto-merge state is rejected", () => {


### PR DESCRIPTION
## Summary

Fix the trusted auto-merge regression exposed by #10405 and restore a Quality Report-style table for the durable merge evaluation comment.

## Root cause

The validation run for #10405 used identical 793-file test manifests for base and synthetic merge, and the staged compiled artifacts differed only in the four files actually changed by the PR. Despite that, Node's built-in JUnit reporter emitted different malformed `<undefined>` wrapper elements between the two runs. The evidence parser counted only `<testcase>` elements, so valid tests hidden/replaced by those malformed reporter sections appeared to have been removed (including runtime-wrapper tests whose compiled file was identical).

## Changes

- Replace the built-in JUnit formatter used for trusted evidence with a deterministic custom reporter over Node test-runner events.
  - emits one JUnit `<testcase>` for each actual test event
  - excludes suite summary events
  - preserves pass/fail/skip/todo state and source file attribution
  - keeps the existing dot reporter for human-readable progress
- Render the durable trusted auto-merge evaluation as a Markdown table (`Check | Result | Details`) for both clean and regression reports, while leaving non-comparable/infrastructure status summaries as prose.
- Extend the auto-merge control-plane self-test and unit test so the trusted reporter contract and tabular rendering are locked in.

## Validation

- Reproduced #10405 from its exact `report-base` / `report-merge` workflow artifacts: 7652 vs 7615 parsed cases despite identical manifests and an unchanged runtime-wrapper compiled test file.
- Confirmed the malformed JUnit sections (`<undefined ...>`) differ between base and merge and explain the false removed-test report.
- Replayed #10405's exact 158-file shard-2 manifest with the replacement reporter against both staged compiled trees: both produced 477 test cases total and 107 runtime-wrapper test cases, eliminating the false 57-case runtime-wrapper drop.
- Exercised the replacement reporter with pass, skipped, and suite events; it emits exactly one testcase per actual test and excludes suites.
- Exercised clean and regression merge-summary inputs through the table formatter shape; both render as Markdown tables with the expected status rows.
- `Validate GitHub workflows` passes on the final PR head, including YAML/action parsing, trusted auto-merge self-tests, and trusted TypeScript unit tests.

Refs #10405